### PR TITLE
zloop changes for consideration

### DIFF
--- a/include/zloop.h
+++ b/include/zloop.h
@@ -36,7 +36,7 @@ typedef struct _zloop_t zloop_t;
 
 //  @interface
 //  Callback function for reactor events
-typedef int (zloop_fn) (zloop_t *loop, void *socket, void *arg);
+typedef int (zloop_fn) (zloop_t *loop, const zmq_pollitem_t *pi, void *arg);
 
 //  Create a new zloop reactor
 zloop_t *
@@ -48,11 +48,19 @@ void
 
 //  Register a socket reader, on one socket
 int
-    zloop_reader (zloop_t *self, void *socket, zloop_fn handler, void *arg);
+    zloop_reader (zloop_t *self, const zmq_pollitem_t *pi, zloop_fn handler, void *arg);
 
 //  Cancel the reader on the specified socket, if any
 void
-    zloop_cancel (zloop_t *self, void *socket);
+    zloop_cancel_socket (zloop_t *self, void *socket);
+
+//  Cancel the reader on the specified fd, if any
+void
+    zloop_cancel_fd (zloop_t *self, int fd);
+
+//  Cancel a timer with the specified delay, if any
+void
+zloop_cancel_timer (zloop_t *self, size_t delay);
 
 //  Register a timer that will go off after 'delay' msecs, and will
 //  repeat 'times' times, unless 'times' is zero, meaning repeat forever.
@@ -67,6 +75,10 @@ void
 //  received SIGINT or SIGTERM.
 int
     zloop_start (zloop_t *self);
+
+//  returns zsocket_type_str() for sockets and 'FD' for file descriptors
+const char *
+    zpollitem_type_str(const zmq_pollitem_t *pi);
 
 //  Self test of this class
 int


### PR DESCRIPTION
Modified zmq socket-based functions to take a zmq_pollitem_t.
Adjusted some function names to reflect the types they now handle.
Added a timer cancel function using delay as the 'id'.

Notes:
1) Not extensively tested :-)
2) As the code almost supports POLLOUT perhaps the "reader" functions should be renamed 'event' or something more general otherwise the whole lot will need to be duplicated for writers...
3) In a couple of logging places I changed from %p to 0x%lx to handle two different types of object (ptr and file descriptor). I'm not sure how interchangeable long int and pointers are across platforms (it was a pragmatic choice to avoid creating two separate log messages for now).
4) zloop.c line 347,8. I left out the updated assert because it is no-longer a reliable test (fd can be genuinely zero or just left unset at zero so the assert fails to catch a range of potentially errors with incorrect socket)

5) I've written some other code (not quite complete or published) which factors out timers to a separate set of functions so that they can be used with a normal zmq_poll (or even poll). I think this might be a more generally applicable solution. I'll consider porting it to czmq given sufficient interest.
