### PR TITLE
Adjust selftest script to properly compile the czmq_selftest and allow alternate locations of the zmq library. 

### DIFF
--- a/src/selftest
+++ b/src/selftest
@@ -1,7 +1,7 @@
 #  Run selftests and check memory
 echo "Rebuilding czmq..."
-gcc -g -o czmq_selftest z*.c -lzmq
+gcc -g -o czmq_selftest czmq_selftest.c z*.c ${CFLAGS} ${LDFLAGS} -lzmq
 if [ $? -eq 0 ]; then
     echo "Starting Valgrind memcheck..."
-    valgrind --tool=memcheck --leak-check=full --suppressions=valgrind.supp czmq_selftest
+    valgrind --tool=memcheck --leak-check=full --suppressions=valgrind.supp ./czmq_selftest
 fi


### PR DESCRIPTION
Add czmq_selftest.c to the compile line.  Add CFLAGS and LDFLAGS vars
to the compile line.

Add relative path './' to valgrind call out to czmq_selftest.

Can now specify alternate zmq location from the CLI as follows:
LD_LIBRARY_PATH=${zmq_lib_path} LDFLAGS=-L${zmq_lib_path} \
  CFLAGS=-I${zmq_include_path} ./selftest

Signed-off-by: AJ Lewis aj.lewis@quantum.com
