### PR TITLE
AIX, HP-UX, and SunOS needs to use rand() rather than random()

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -304,7 +304,7 @@
 #   include <sys/file.h>
 #   include <sys/wait.h>
 #   include <netinet/in.h>              //  Must come before arpa/inet.h
-#   if (!defined (__UTYPE_ANDROID))
+#   if (!defined (__UTYPE_ANDROID)) && (!defined (__UTYPE_IBMAIX)) && (!defined (__UTYPE_HPUX)) && (!defined (__UTYPE_SUNOS))
 #       include <ifaddrs.h>
 #   endif
 #   if (!defined (__UTYPE_BEOS))
@@ -402,7 +402,7 @@ typedef unsigned int    qbyte;          //  Quad byte = 32 bits
 #define tblsize(x)      (sizeof (x) / sizeof ((x) [0]))
 #define tbllast(x)      (x [tblsize (x) - 1])
 //  Provide random number from 0..(num-1)
-#if (defined (__WINDOWS__))
+#if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS))
 #   define randof(num)  (int) ((float) (num) * rand () / (RAND_MAX + 1.0))
 #else
 #   define randof(num)  (int) ((float) (num) * random () / (RAND_MAX + 1.0))


### PR DESCRIPTION
 This fixes up the selftest run on AIX, HP-UX, and SunOS (Solaris 10, Sparc-based).  It may also need to be adjusted for the other systems, such as those that show up as __UTYPE_SOLARIS, but I haven't hit one of those systems yet.
