### PR TITLE
Correct configure option for specifying libzmq install path in readme

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -95,7 +95,7 @@ CZMQ uses autotools for packaging. To build from git (all example commands are f
 
 You will need the libtool and autotools packages. On FreeBSD, you may need to specify the default directories for configure:
 
-    ./configure --with-zeromq=/usr/local
+    ./configure --with-libzmq=/usr/local
 
 After building, you can run the CZMQ selftests:
 


### PR DESCRIPTION
Minor change.
