### PR TITLE
Fixed issue #20

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,15 +4,20 @@ CZMQ version 1.2.0 (stable), released on 2011/10/xx
 Changes
 -------
 
+* zsockopt_ functions renamed to zsocket_, for clarity. Old names are
+  still provided for compatibility.
+
 * SUB sockets are no longer subscribed to everything.
 
-* Fixed issue CZMQ-7, wrong name used for czmq man page.
+* Fixed issue CZMQ-7, wrong name used for CZMQ man page.
 
 * Changed zsocket_connect() to return 0 or -1, since zmq_connect() now
   checks endpoints properly (issue LIBZMQ-207).
 
 * All classes handle memory exhaustion correctly by returning an error
   instead of asserting.
+
+* zsocket_identity implemented correctly.
 
 
 CZMQ version 1.1.0 (stable), released on 2011/08/30

--- a/doc/zframe.txt
+++ b/doc/zframe.txt
@@ -11,6 +11,9 @@ SYNOPSIS
 #define ZFRAME_MORE     1
 #define ZFRAME_REUSE    2
 
+//  Callback function for zframe_free_fn method
+typedef void (zframe_free_fn) (void *data, void *arg);
+
 //  Create a new frame with optional size, and optional data
 zframe_t *
     zframe_new (const void *data, size_t size);
@@ -100,36 +103,12 @@ frame is part of an unfinished multipart message. The zframe_send method
 normally destroys the frame, but with the ZFRAME_REUSE flag, you can send
 the same frame many times. Frames are binary, and this class has no
 special support for text data.
-zframe_new_zero_copy() can be used to create zero-copy frames. The caller
-must provide contents, size and free function for the frame to be initialised
-as zero-copy. Caller is responsible for making sure that the frame contents
-are valid until the free_fn is called.
 
 
 EXAMPLE
 -------
 .From zframe_test method
 ----
-static void
-s_test_free_cb (void *data, void *arg)
-{
-    char cmp_buf [1024];
-
-    int i;
-    for (i = 0; i < 1024; i++)
-        cmp_buf [i] = 'A';
-
-    assert (memcmp (data, cmp_buf, 1024) == 0);
-    free (data);
-}
-
-int
-zframe_test (Bool verbose)
-{
-    printf (" * zframe: ");
-    int rc;
-
-    //  @selftest
     zctx_t *ctx = zctx_new ();
     assert (ctx);
 
@@ -207,10 +186,6 @@ zframe_test (Bool verbose)
     zframe_destroy (&frame_copy);
 
     zctx_destroy (&ctx);
-    //  @end
-    printf ("OK\n");
-    return 0;
-}
 ----
 
 SEE ALSO

--- a/doc/zsockopt.txt
+++ b/doc/zsockopt.txt
@@ -10,78 +10,78 @@ SYNOPSIS
 ----
 #if (ZMQ_VERSION_MAJOR == 2)
 //  Get socket options
-int  zsockopt_hwm (void *socket);
-int  zsockopt_swap (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_recovery_ivl_msec (void *socket);
-int  zsockopt_mcast_loop (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
+int  zsocket_hwm (void *socket);
+int  zsocket_swap (void *socket);
+int  zsocket_affinity (void *socket);
+int  zsocket_rate (void *socket);
+int  zsocket_recovery_ivl (void *socket);
+int  zsocket_recovery_ivl_msec (void *socket);
+int  zsocket_mcast_loop (void *socket);
+int  zsocket_sndbuf (void *socket);
+int  zsocket_rcvbuf (void *socket);
+int  zsocket_linger (void *socket);
+int  zsocket_reconnect_ivl (void *socket);
+int  zsocket_reconnect_ivl_max (void *socket);
+int  zsocket_backlog (void *socket);
+int  zsocket_type (void *socket);
+int  zsocket_rcvmore (void *socket);
+int  zsocket_fd (void *socket);
+int  zsocket_events (void *socket);
 
 //  Set socket options
-void zsockopt_set_hwm (void *socket, int hwm);
-void zsockopt_set_swap (void *socket, int swap);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_identity (void *socket, char * identity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec);
-void zsockopt_set_mcast_loop (void *socket, int mcast_loop);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_hwm (void *socket, int hwm);
+void zsocket_set_swap (void *socket, int swap);
+void zsocket_set_affinity (void *socket, int affinity);
+void zsocket_set_identity (void *socket, char * identity);
+void zsocket_set_rate (void *socket, int rate);
+void zsocket_set_recovery_ivl (void *socket, int recovery_ivl);
+void zsocket_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec);
+void zsocket_set_mcast_loop (void *socket, int mcast_loop);
+void zsocket_set_sndbuf (void *socket, int sndbuf);
+void zsocket_set_rcvbuf (void *socket, int rcvbuf);
+void zsocket_set_linger (void *socket, int linger);
+void zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl);
+void zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
+void zsocket_set_backlog (void *socket, int backlog);
+void zsocket_set_subscribe (void *socket, char * subscribe);
+void zsocket_set_unsubscribe (void *socket, char * unsubscribe);
 #endif
 
 #if (ZMQ_VERSION_MAJOR == 3)
 //  Get socket options
-int  zsockopt_sndhwm (void *socket);
-int  zsockopt_rcvhwm (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_maxmsgsize (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
+int  zsocket_sndhwm (void *socket);
+int  zsocket_rcvhwm (void *socket);
+int  zsocket_affinity (void *socket);
+int  zsocket_rate (void *socket);
+int  zsocket_recovery_ivl (void *socket);
+int  zsocket_sndbuf (void *socket);
+int  zsocket_rcvbuf (void *socket);
+int  zsocket_linger (void *socket);
+int  zsocket_reconnect_ivl (void *socket);
+int  zsocket_reconnect_ivl_max (void *socket);
+int  zsocket_backlog (void *socket);
+int  zsocket_maxmsgsize (void *socket);
+int  zsocket_type (void *socket);
+int  zsocket_rcvmore (void *socket);
+int  zsocket_fd (void *socket);
+int  zsocket_events (void *socket);
 
 //  Set socket options
-void zsockopt_set_sndhwm (void *socket, int sndhwm);
-void zsockopt_set_rcvhwm (void *socket, int rcvhwm);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_identity (void *socket, char * identity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_maxmsgsize (void *socket, int maxmsgsize);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_sndhwm (void *socket, int sndhwm);
+void zsocket_set_rcvhwm (void *socket, int rcvhwm);
+void zsocket_set_affinity (void *socket, int affinity);
+void zsocket_set_identity (void *socket, char * identity);
+void zsocket_set_rate (void *socket, int rate);
+void zsocket_set_recovery_ivl (void *socket, int recovery_ivl);
+void zsocket_set_sndbuf (void *socket, int sndbuf);
+void zsocket_set_rcvbuf (void *socket, int rcvbuf);
+void zsocket_set_linger (void *socket, int linger);
+void zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl);
+void zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
+void zsocket_set_backlog (void *socket, int backlog);
+void zsocket_set_maxmsgsize (void *socket, int maxmsgsize);
+void zsocket_set_subscribe (void *socket, char * subscribe);
+void zsocket_set_unsubscribe (void *socket, char * unsubscribe);
 
 //  Emulation of widely-used 2.x socket options
 void zsockopt_set_hwm (void *socket, int hwm);
@@ -89,38 +89,38 @@ void zsockopt_set_hwm (void *socket, int hwm);
 
 #if (ZMQ_VERSION_MAJOR == 4)
 //  Get socket options
-int  zsockopt_sndhwm (void *socket);
-int  zsockopt_rcvhwm (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_maxmsgsize (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
+int  zsocket_sndhwm (void *socket);
+int  zsocket_rcvhwm (void *socket);
+int  zsocket_affinity (void *socket);
+int  zsocket_rate (void *socket);
+int  zsocket_recovery_ivl (void *socket);
+int  zsocket_sndbuf (void *socket);
+int  zsocket_rcvbuf (void *socket);
+int  zsocket_linger (void *socket);
+int  zsocket_reconnect_ivl (void *socket);
+int  zsocket_reconnect_ivl_max (void *socket);
+int  zsocket_backlog (void *socket);
+int  zsocket_maxmsgsize (void *socket);
+int  zsocket_type (void *socket);
+int  zsocket_rcvmore (void *socket);
+int  zsocket_fd (void *socket);
+int  zsocket_events (void *socket);
 
 //  Set socket options
-void zsockopt_set_sndhwm (void *socket, int sndhwm);
-void zsockopt_set_rcvhwm (void *socket, int rcvhwm);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_maxmsgsize (void *socket, int maxmsgsize);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_sndhwm (void *socket, int sndhwm);
+void zsocket_set_rcvhwm (void *socket, int rcvhwm);
+void zsocket_set_affinity (void *socket, int affinity);
+void zsocket_set_rate (void *socket, int rate);
+void zsocket_set_recovery_ivl (void *socket, int recovery_ivl);
+void zsocket_set_sndbuf (void *socket, int sndbuf);
+void zsocket_set_rcvbuf (void *socket, int rcvbuf);
+void zsocket_set_linger (void *socket, int linger);
+void zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl);
+void zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
+void zsocket_set_backlog (void *socket, int backlog);
+void zsocket_set_maxmsgsize (void *socket, int maxmsgsize);
+void zsocket_set_subscribe (void *socket, char * subscribe);
+void zsocket_set_unsubscribe (void *socket, char * unsubscribe);
 
 //  Emulation of widely-used 2.x socket options
 void zsockopt_set_hwm (void *socket, int hwm);

--- a/include/zsockopt.h
+++ b/include/zsockopt.h
@@ -3,7 +3,7 @@
 
     GENERATED SOURCE CODE, DO NOT EDIT
     -------------------------------------------------------------------------
-    Copyright (c) 1991-2011 iMatix Corporation <www.imatix.com>
+    Copyright (c) 1991-2012 iMatix Corporation <www.imatix.com>
     Copyright other contributors as noted in the AUTHORS file.
 
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -35,117 +35,93 @@ extern "C" {
 //  @interface
 #if (ZMQ_VERSION_MAJOR == 2)
 //  Get socket options
-int  zsockopt_hwm (void *socket);
-int  zsockopt_swap (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_recovery_ivl_msec (void *socket);
-int  zsockopt_mcast_loop (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
+int  zsocket_hwm (void *socket);
+int  zsocket_swap (void *socket);
+int  zsocket_affinity (void *socket);
+//  Returns freshly allocated string, free when done
+char *zsocket_identity (void *socket);
+int  zsocket_rate (void *socket);
+int  zsocket_recovery_ivl (void *socket);
+int  zsocket_recovery_ivl_msec (void *socket);
+int  zsocket_mcast_loop (void *socket);
+int  zsocket_sndbuf (void *socket);
+int  zsocket_rcvbuf (void *socket);
+int  zsocket_linger (void *socket);
+int  zsocket_reconnect_ivl (void *socket);
+int  zsocket_reconnect_ivl_max (void *socket);
+int  zsocket_backlog (void *socket);
+int  zsocket_type (void *socket);
+int  zsocket_rcvmore (void *socket);
+int  zsocket_fd (void *socket);
+int  zsocket_events (void *socket);
 
 //  Set socket options
-void zsockopt_set_hwm (void *socket, int hwm);
-void zsockopt_set_swap (void *socket, int swap);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_identity (void *socket, char * identity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec);
-void zsockopt_set_mcast_loop (void *socket, int mcast_loop);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_hwm (void *socket, int hwm);
+void zsocket_set_swap (void *socket, int swap);
+void zsocket_set_affinity (void *socket, int affinity);
+void zsocket_set_identity (void *socket, char * identity);
+void zsocket_set_rate (void *socket, int rate);
+void zsocket_set_recovery_ivl (void *socket, int recovery_ivl);
+void zsocket_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec);
+void zsocket_set_mcast_loop (void *socket, int mcast_loop);
+void zsocket_set_sndbuf (void *socket, int sndbuf);
+void zsocket_set_rcvbuf (void *socket, int rcvbuf);
+void zsocket_set_linger (void *socket, int linger);
+void zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl);
+void zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
+void zsocket_set_backlog (void *socket, int backlog);
+void zsocket_set_subscribe (void *socket, char * subscribe);
+void zsocket_set_unsubscribe (void *socket, char * unsubscribe);
 #endif
 
 #if (ZMQ_VERSION_MAJOR == 3)
 //  Get socket options
-int  zsockopt_sndhwm (void *socket);
-int  zsockopt_rcvhwm (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_maxmsgsize (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
+int  zsocket_type (void *socket);
+int  zsocket_sndhwm (void *socket);
+int  zsocket_rcvhwm (void *socket);
+int  zsocket_affinity (void *socket);
+//  Returns freshly allocated string, free when done
+char *zsocket_identity (void *socket);
+int  zsocket_rate (void *socket);
+int  zsocket_recovery_ivl (void *socket);
+int  zsocket_sndbuf (void *socket);
+int  zsocket_rcvbuf (void *socket);
+int  zsocket_linger (void *socket);
+int  zsocket_reconnect_ivl (void *socket);
+int  zsocket_reconnect_ivl_max (void *socket);
+int  zsocket_backlog (void *socket);
+int  zsocket_maxmsgsize (void *socket);
+int  zsocket_multicast_hops (void *socket);
+int  zsocket_rcvtimeo (void *socket);
+int  zsocket_sndtimeo (void *socket);
+int  zsocket_ipv4only (void *socket);
+int  zsocket_rcvmore (void *socket);
+int  zsocket_fd (void *socket);
+int  zsocket_events (void *socket);
+//  Returns freshly allocated string, free when done
+char *zsocket_last_endpoint (void *socket);
 
 //  Set socket options
-void zsockopt_set_sndhwm (void *socket, int sndhwm);
-void zsockopt_set_rcvhwm (void *socket, int rcvhwm);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_identity (void *socket, char * identity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_maxmsgsize (void *socket, int maxmsgsize);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
-
-//  Emulation of widely-used 2.x socket options
-void zsockopt_set_hwm (void *socket, int hwm);
-#endif
-
-#if (ZMQ_VERSION_MAJOR == 4)
-//  Get socket options
-int  zsockopt_sndhwm (void *socket);
-int  zsockopt_rcvhwm (void *socket);
-int  zsockopt_affinity (void *socket);
-int  zsockopt_rate (void *socket);
-int  zsockopt_recovery_ivl (void *socket);
-int  zsockopt_sndbuf (void *socket);
-int  zsockopt_rcvbuf (void *socket);
-int  zsockopt_linger (void *socket);
-int  zsockopt_reconnect_ivl (void *socket);
-int  zsockopt_reconnect_ivl_max (void *socket);
-int  zsockopt_backlog (void *socket);
-int  zsockopt_maxmsgsize (void *socket);
-int  zsockopt_type (void *socket);
-int  zsockopt_rcvmore (void *socket);
-int  zsockopt_fd (void *socket);
-int  zsockopt_events (void *socket);
-
-//  Set socket options
-void zsockopt_set_sndhwm (void *socket, int sndhwm);
-void zsockopt_set_rcvhwm (void *socket, int rcvhwm);
-void zsockopt_set_affinity (void *socket, int affinity);
-void zsockopt_set_rate (void *socket, int rate);
-void zsockopt_set_recovery_ivl (void *socket, int recovery_ivl);
-void zsockopt_set_sndbuf (void *socket, int sndbuf);
-void zsockopt_set_rcvbuf (void *socket, int rcvbuf);
-void zsockopt_set_linger (void *socket, int linger);
-void zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl);
-void zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
-void zsockopt_set_backlog (void *socket, int backlog);
-void zsockopt_set_maxmsgsize (void *socket, int maxmsgsize);
-void zsockopt_set_subscribe (void *socket, char * subscribe);
-void zsockopt_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_sndhwm (void *socket, int sndhwm);
+void zsocket_set_rcvhwm (void *socket, int rcvhwm);
+void zsocket_set_affinity (void *socket, int affinity);
+void zsocket_set_subscribe (void *socket, char * subscribe);
+void zsocket_set_unsubscribe (void *socket, char * unsubscribe);
+void zsocket_set_identity (void *socket, char * identity);
+void zsocket_set_rate (void *socket, int rate);
+void zsocket_set_recovery_ivl (void *socket, int recovery_ivl);
+void zsocket_set_sndbuf (void *socket, int sndbuf);
+void zsocket_set_rcvbuf (void *socket, int rcvbuf);
+void zsocket_set_linger (void *socket, int linger);
+void zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl);
+void zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max);
+void zsocket_set_backlog (void *socket, int backlog);
+void zsocket_set_maxmsgsize (void *socket, int maxmsgsize);
+void zsocket_set_multicast_hops (void *socket, int multicast_hops);
+void zsocket_set_rcvtimeo (void *socket, int rcvtimeo);
+void zsocket_set_sndtimeo (void *socket, int sndtimeo);
+void zsocket_set_ipv4only (void *socket, int ipv4only);
+void zsocket_set_fail_unroutable (void *socket, int fail_unroutable);
 
 //  Emulation of widely-used 2.x socket options
 void zsockopt_set_hwm (void *socket, int hwm);
@@ -154,6 +130,91 @@ void zsockopt_set_hwm (void *socket, int hwm);
 //  Self test of this class
 int zsockopt_test (Bool verbose);
 //  @end
+
+//  Deprecated function names
+#if (ZMQ_VERSION_MAJOR == 2)
+#define zsockopt_hwm zsocket_hwm
+#define zsockopt_set_hwm zsocket_set_hwm
+#define zsockopt_swap zsocket_swap
+#define zsockopt_set_swap zsocket_set_swap
+#define zsockopt_affinity zsocket_affinity
+#define zsockopt_set_affinity zsocket_set_affinity
+#define zsockopt_identity zsocket_identity
+#define zsockopt_set_identity zsocket_set_identity
+#define zsockopt_rate zsocket_rate
+#define zsockopt_set_rate zsocket_set_rate
+#define zsockopt_recovery_ivl zsocket_recovery_ivl
+#define zsockopt_set_recovery_ivl zsocket_set_recovery_ivl
+#define zsockopt_recovery_ivl_msec zsocket_recovery_ivl_msec
+#define zsockopt_set_recovery_ivl_msec zsocket_set_recovery_ivl_msec
+#define zsockopt_mcast_loop zsocket_mcast_loop
+#define zsockopt_set_mcast_loop zsocket_set_mcast_loop
+#define zsockopt_sndbuf zsocket_sndbuf
+#define zsockopt_set_sndbuf zsocket_set_sndbuf
+#define zsockopt_rcvbuf zsocket_rcvbuf
+#define zsockopt_set_rcvbuf zsocket_set_rcvbuf
+#define zsockopt_linger zsocket_linger
+#define zsockopt_set_linger zsocket_set_linger
+#define zsockopt_reconnect_ivl zsocket_reconnect_ivl
+#define zsockopt_set_reconnect_ivl zsocket_set_reconnect_ivl
+#define zsockopt_reconnect_ivl_max zsocket_reconnect_ivl_max
+#define zsockopt_set_reconnect_ivl_max zsocket_set_reconnect_ivl_max
+#define zsockopt_backlog zsocket_backlog
+#define zsockopt_set_backlog zsocket_set_backlog
+#define zsockopt_set_subscribe zsocket_set_subscribe
+#define zsockopt_set_unsubscribe zsocket_set_unsubscribe
+#define zsockopt_type zsocket_type
+#define zsockopt_rcvmore zsocket_rcvmore
+#define zsockopt_fd zsocket_fd
+#define zsockopt_events zsocket_events
+#endif
+
+//  Deprecated function names
+#if (ZMQ_VERSION_MAJOR == 3)
+#define zsockopt_type zsocket_type
+#define zsockopt_sndhwm zsocket_sndhwm
+#define zsockopt_set_sndhwm zsocket_set_sndhwm
+#define zsockopt_rcvhwm zsocket_rcvhwm
+#define zsockopt_set_rcvhwm zsocket_set_rcvhwm
+#define zsockopt_affinity zsocket_affinity
+#define zsockopt_set_affinity zsocket_set_affinity
+#define zsockopt_set_subscribe zsocket_set_subscribe
+#define zsockopt_set_unsubscribe zsocket_set_unsubscribe
+#define zsockopt_identity zsocket_identity
+#define zsockopt_set_identity zsocket_set_identity
+#define zsockopt_rate zsocket_rate
+#define zsockopt_set_rate zsocket_set_rate
+#define zsockopt_recovery_ivl zsocket_recovery_ivl
+#define zsockopt_set_recovery_ivl zsocket_set_recovery_ivl
+#define zsockopt_sndbuf zsocket_sndbuf
+#define zsockopt_set_sndbuf zsocket_set_sndbuf
+#define zsockopt_rcvbuf zsocket_rcvbuf
+#define zsockopt_set_rcvbuf zsocket_set_rcvbuf
+#define zsockopt_linger zsocket_linger
+#define zsockopt_set_linger zsocket_set_linger
+#define zsockopt_reconnect_ivl zsocket_reconnect_ivl
+#define zsockopt_set_reconnect_ivl zsocket_set_reconnect_ivl
+#define zsockopt_reconnect_ivl_max zsocket_reconnect_ivl_max
+#define zsockopt_set_reconnect_ivl_max zsocket_set_reconnect_ivl_max
+#define zsockopt_backlog zsocket_backlog
+#define zsockopt_set_backlog zsocket_set_backlog
+#define zsockopt_maxmsgsize zsocket_maxmsgsize
+#define zsockopt_set_maxmsgsize zsocket_set_maxmsgsize
+#define zsockopt_multicast_hops zsocket_multicast_hops
+#define zsockopt_set_multicast_hops zsocket_set_multicast_hops
+#define zsockopt_rcvtimeo zsocket_rcvtimeo
+#define zsockopt_set_rcvtimeo zsocket_set_rcvtimeo
+#define zsockopt_sndtimeo zsocket_sndtimeo
+#define zsockopt_set_sndtimeo zsocket_set_sndtimeo
+#define zsockopt_ipv4only zsocket_ipv4only
+#define zsockopt_set_ipv4only zsocket_set_ipv4only
+#define zsockopt_set_fail_unroutable zsocket_set_fail_unroutable
+#define zsockopt_rcvmore zsocket_rcvmore
+#define zsockopt_fd zsocket_fd
+#define zsockopt_events zsocket_events
+#define zsockopt_last_endpoint zsocket_last_endpoint
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/sockopts.gsl
+++ b/sockopts.gsl
@@ -5,7 +5,6 @@
 .           option.ctype = "int"
 .       elsif type = "blob"
 .           option.ctype = "char *"     #   Enforce C strings
-.           mode = "w"                  #   and read-only
 .       else
 .           echo "E: unknown type: $(type)"
 .       endif
@@ -16,7 +15,7 @@
 
     GENERATED SOURCE CODE, DO NOT EDIT
     -------------------------------------------------------------------------
-    Copyright (c) 1991-2011 iMatix Corporation <www.imatix.com>
+    Copyright (c) 1991-2012 iMatix Corporation <www.imatix.com>
     Copyright other contributors as noted in the AUTHORS file.
 
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -51,15 +50,17 @@ extern "C" {
 //  Get socket options
 .   for option
 .       if mode = "rw" | mode = "r"
-$(ctype)\
-     zsockopt_$(name) (void *socket);
+.           if type = "blob"
+//  Returns freshly allocated string, free when done
+.           endif
+$(ctype) zsocket_$(name) (void *socket);
 .       endif
 .   endfor
 
 //  Set socket options
 .   for option
 .       if mode = "rw" | mode = "w"
-void zsockopt_set_$(name) (void *socket, $(ctype) $(name));
+void zsocket_set_$(name) (void *socket, $(ctype) $(name));
 .       endif
 .   endfor
 .   for header
@@ -73,6 +74,21 @@ $(string.trim(.):)
 int zsockopt_test (Bool verbose);
 //  @end
 
+.for version
+//  Deprecated function names
+#if (ZMQ_VERSION_MAJOR == $(major))
+.   for option
+.       if mode = "rw" | mode = "r"
+#define zsockopt_$(name) zsocket_$(name)
+.       endif
+.       if mode = "rw" | mode = "w"
+#define zsockopt_set_$(name) zsocket_set_$(name)
+.       endif
+.   endfor
+#endif
+
+.endfor
+
 #ifdef __cplusplus
 }
 #endif
@@ -84,7 +100,7 @@ int zsockopt_test (Bool verbose);
 
     GENERATED SOURCE CODE, DO NOT EDIT
     -------------------------------------------------------------------------
-    Copyright (c) 1991-2011 iMatix Corporation <www.imatix.com>
+    Copyright (c) 1991-2012 iMatix Corporation <www.imatix.com>
     Copyright other contributors as noted in the AUTHORS file.
 
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -130,7 +146,7 @@ int zsockopt_test (Bool verbose);
 //  Set socket ZMQ_$(NAME) value
 
 void
-zsockopt_set_$(name) (void *socket, $(ctype) $(name))
+zsocket_set_$(name) (void *socket, $(ctype) $(name))
 {
 .           if ctype = "int"
 .               if type = "uint64"
@@ -158,22 +174,25 @@ zsockopt_set_$(name) (void *socket, $(ctype) $(name))
 //  Return socket ZMQ_$(NAME) value
 
 $(ctype)
-zsockopt_$(name) (void *socket)
+zsocket_$(name) (void *socket)
 {
 .           if type = "uint64"
     uint64_t $(name);
-    size_t type_size = sizeof (uint64_t);
+    size_t option_len = sizeof (uint64_t);
 .           elsif type = "int64"
     int64_t $(name);
-    size_t type_size = sizeof (int64_t);
+    size_t option_len = sizeof (int64_t);
 .           elsif type = "uint32"
     uint32_t $(name);
-    size_t type_size = sizeof (uint32_t);
+    size_t option_len = sizeof (uint32_t);
 .           elsif type = "int"
     int $(name);
-    size_t type_size = sizeof (int);
+    size_t option_len = sizeof (int);
+.           elsif type = "blob"
+    size_t option_len = 255;
+    char *$(name) = zmalloc (option_len);
 .           endif
-    zmq_getsockopt (socket, ZMQ_$(NAME), &$(name), &type_size);
+    zmq_getsockopt (socket, ZMQ_$(NAME), &$(name), &option_len);
 .           if type = "int"
     return $(name);
 .           else
@@ -210,16 +229,16 @@ zsockopt_test (Bool verbose)
     assert (socket);
 .       if mode = "rw" | mode = "w"
 .           if ctype = "int"
-    zsockopt_set_$(name) (socket, 1);
+    zsocket_set_$(name) (socket, 1);
 .               if mode = "rw"
-    assert (zsockopt_$(name) (socket) == 1);
+    assert (zsocket_$(name) (socket) == 1);
 .               endif
 .           else
-    zsockopt_set_$(name) (socket, "test");
+    zsocket_set_$(name) (socket, "test"); //a
 .           endif
 .       endif
 .       if mode = "rw" | mode = "r"
-    zsockopt_$(name) (socket);
+    zsocket_$(name) (socket);
 .       endif
     zsocket_destroy (ctx, socket);
 .   endfor

--- a/sockopts.xml
+++ b/sockopts.xml
@@ -28,9 +28,12 @@
     </version>
 
     <version major = "3">
+        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
         <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />
         <option name = "rcvhwm"            type = "int"    mode = "rw" test = "SUB" />
         <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "subscribe"         type = "blob"   mode = "w"  test = "SUB" />
+        <option name = "unsubscribe"       type = "blob"   mode = "w"  test = "SUB" />
         <option name = "identity"          type = "blob"   mode = "rw" test = "SUB" />
         <option name = "rate"              type = "int"    mode = "rw" test = "SUB" />
         <option name = "recovery_ivl"      type = "int"    mode = "rw" test = "SUB" />
@@ -41,52 +44,15 @@
         <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
         <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
         <option name = "maxmsgsize"        type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "blob"   mode = "w"  test = "SUB" />
-        <option name = "unsubscribe"       type = "blob"   mode = "w"  test = "SUB" />
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
+        <option name = "multicast_hops"    type = "int"    mode = "rw" test = "SUB" />
+        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "fail_unroutable"   type = "int"    mode = "w"  test = "ROUTER" />
         <option name = "rcvmore"           type = "int"    mode = "r"  test = "SUB" />
         <option name = "fd"                type = "int"    mode = "r"  test = "SUB" />
         <option name = "events"            type = "int"    mode = "r"  test = "SUB" />
-        <header>
-//  Emulation of widely-used 2.x socket options
-void zsockopt_set_hwm (void *socket, int hwm);
-        </header>
-        <source>
-//  --------------------------------------------------------------------------
-//  Set socket high-water mark, emulating 2.x API
-
-void
-zsockopt_set_hwm (void *socket, int hwm)
-{
-    zsockopt_set_sndhwm (socket, hwm);
-    zsockopt_set_rcvhwm (socket, hwm);
-}
-        </source>
-        <selftest>
-    zsockopt_set_hwm (socket, 1);
-        </selftest>
-    </version>
-
-   <!-- Copy of V3, since libzmq master has started 4.0...-->
-    <version major = "4">
-        <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />
-        <option name = "rcvhwm"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "rate"              type = "int"    mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int"    mode = "rw" test = "SUB" />
-        <option name = "sndbuf"            type = "int"    mode = "rw" test = "PUB" />
-        <option name = "rcvbuf"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
-        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "maxmsgsize"        type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "blob"   mode = "w"  test = "SUB" />
-        <option name = "unsubscribe"       type = "blob"   mode = "w"  test = "SUB" />
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
-        <option name = "rcvmore"           type = "int"    mode = "r"  test = "SUB" />
-        <option name = "fd"                type = "int"    mode = "r"  test = "SUB" />
-        <option name = "events"            type = "int"    mode = "r"  test = "SUB" />
+        <option name = "last_endpoint"     type = "blob"   mode = "r"  test = "SUB" />
         <header>
 //  Emulation of widely-used 2.x socket options
 void zsockopt_set_hwm (void *socket, int hwm);

--- a/src/zctx.c
+++ b/src/zctx.c
@@ -226,7 +226,7 @@ zctx__socket_destroy (zctx_t *self, void *socket)
 {
     assert (self);
     assert (socket);
-    zsockopt_set_linger (socket, self->linger);
+    zsocket_set_linger (socket, self->linger);
     zmq_close (socket);
     zlist_remove (self->sockets, socket);
 }

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -137,7 +137,7 @@ zframe_recv (void *socket)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsockopt_rcvmore (socket);
+        self->more = zsocket_rcvmore (socket);
     }
     return self;
 }
@@ -157,7 +157,7 @@ zframe_recv_nowait (void *socket)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsockopt_rcvmore (socket);
+        self->more = zsocket_rcvmore (socket);
     }
     return self;
 }

--- a/src/zsockopt.c
+++ b/src/zsockopt.c
@@ -3,7 +3,7 @@
 
     GENERATED SOURCE CODE, DO NOT EDIT
     -------------------------------------------------------------------------
-    Copyright (c) 1991-2011 iMatix Corporation <www.imatix.com>
+    Copyright (c) 1991-2012 iMatix Corporation <www.imatix.com>
     Copyright other contributors as noted in the AUTHORS file.
 
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -46,7 +46,7 @@
 //  Set socket ZMQ_HWM value
 
 void
-zsockopt_set_hwm (void *socket, int hwm)
+zsocket_set_hwm (void *socket, int hwm)
 {
     uint64_t value = hwm;
     int rc = zmq_setsockopt (socket, ZMQ_HWM, &value, sizeof (uint64_t));
@@ -58,11 +58,11 @@ zsockopt_set_hwm (void *socket, int hwm)
 //  Return socket ZMQ_HWM value
 
 int
-zsockopt_hwm (void *socket)
+zsocket_hwm (void *socket)
 {
     uint64_t hwm;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_HWM, &hwm, &type_size);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (socket, ZMQ_HWM, &hwm, &option_len);
     return (int) hwm;
 }
 
@@ -71,7 +71,7 @@ zsockopt_hwm (void *socket)
 //  Set socket ZMQ_SWAP value
 
 void
-zsockopt_set_swap (void *socket, int swap)
+zsocket_set_swap (void *socket, int swap)
 {
     int64_t value = swap;
     int rc = zmq_setsockopt (socket, ZMQ_SWAP, &value, sizeof (int64_t));
@@ -83,11 +83,11 @@ zsockopt_set_swap (void *socket, int swap)
 //  Return socket ZMQ_SWAP value
 
 int
-zsockopt_swap (void *socket)
+zsocket_swap (void *socket)
 {
     int64_t swap;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_SWAP, &swap, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_SWAP, &swap, &option_len);
     return (int) swap;
 }
 
@@ -96,7 +96,7 @@ zsockopt_swap (void *socket)
 //  Set socket ZMQ_AFFINITY value
 
 void
-zsockopt_set_affinity (void *socket, int affinity)
+zsocket_set_affinity (void *socket, int affinity)
 {
     uint64_t value = affinity;
     int rc = zmq_setsockopt (socket, ZMQ_AFFINITY, &value, sizeof (uint64_t));
@@ -108,11 +108,11 @@ zsockopt_set_affinity (void *socket, int affinity)
 //  Return socket ZMQ_AFFINITY value
 
 int
-zsockopt_affinity (void *socket)
+zsocket_affinity (void *socket)
 {
     uint64_t affinity;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_AFFINITY, &affinity, &type_size);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (socket, ZMQ_AFFINITY, &affinity, &option_len);
     return (int) affinity;
 }
 
@@ -121,7 +121,7 @@ zsockopt_affinity (void *socket)
 //  Set socket ZMQ_IDENTITY value
 
 void
-zsockopt_set_identity (void *socket, char * identity)
+zsocket_set_identity (void *socket, char * identity)
 {
     int rc = zmq_setsockopt (socket, ZMQ_IDENTITY, identity, strlen (identity));
     assert (rc == 0 || errno == ETERM);
@@ -129,10 +129,23 @@ zsockopt_set_identity (void *socket, char * identity)
 
 
 //  --------------------------------------------------------------------------
+//  Return socket ZMQ_IDENTITY value
+
+char *
+zsocket_identity (void *socket)
+{
+    size_t option_len = 255;
+    char *identity = zmalloc (option_len);
+    zmq_getsockopt (socket, ZMQ_IDENTITY, &identity, &option_len);
+    return (char *) identity;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_RATE value
 
 void
-zsockopt_set_rate (void *socket, int rate)
+zsocket_set_rate (void *socket, int rate)
 {
     int64_t value = rate;
     int rc = zmq_setsockopt (socket, ZMQ_RATE, &value, sizeof (int64_t));
@@ -144,11 +157,11 @@ zsockopt_set_rate (void *socket, int rate)
 //  Return socket ZMQ_RATE value
 
 int
-zsockopt_rate (void *socket)
+zsocket_rate (void *socket)
 {
     int64_t rate;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_RATE, &rate, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_RATE, &rate, &option_len);
     return (int) rate;
 }
 
@@ -157,7 +170,7 @@ zsockopt_rate (void *socket)
 //  Set socket ZMQ_RECOVERY_IVL value
 
 void
-zsockopt_set_recovery_ivl (void *socket, int recovery_ivl)
+zsocket_set_recovery_ivl (void *socket, int recovery_ivl)
 {
     int64_t value = recovery_ivl;
     int rc = zmq_setsockopt (socket, ZMQ_RECOVERY_IVL, &value, sizeof (int64_t));
@@ -169,11 +182,11 @@ zsockopt_set_recovery_ivl (void *socket, int recovery_ivl)
 //  Return socket ZMQ_RECOVERY_IVL value
 
 int
-zsockopt_recovery_ivl (void *socket)
+zsocket_recovery_ivl (void *socket)
 {
     int64_t recovery_ivl;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
     return (int) recovery_ivl;
 }
 
@@ -182,7 +195,7 @@ zsockopt_recovery_ivl (void *socket)
 //  Set socket ZMQ_RECOVERY_IVL_MSEC value
 
 void
-zsockopt_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec)
+zsocket_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec)
 {
     int64_t value = recovery_ivl_msec;
     int rc = zmq_setsockopt (socket, ZMQ_RECOVERY_IVL_MSEC, &value, sizeof (int64_t));
@@ -194,11 +207,11 @@ zsockopt_set_recovery_ivl_msec (void *socket, int recovery_ivl_msec)
 //  Return socket ZMQ_RECOVERY_IVL_MSEC value
 
 int
-zsockopt_recovery_ivl_msec (void *socket)
+zsocket_recovery_ivl_msec (void *socket)
 {
     int64_t recovery_ivl_msec;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL_MSEC, &recovery_ivl_msec, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL_MSEC, &recovery_ivl_msec, &option_len);
     return (int) recovery_ivl_msec;
 }
 
@@ -207,7 +220,7 @@ zsockopt_recovery_ivl_msec (void *socket)
 //  Set socket ZMQ_MCAST_LOOP value
 
 void
-zsockopt_set_mcast_loop (void *socket, int mcast_loop)
+zsocket_set_mcast_loop (void *socket, int mcast_loop)
 {
     int64_t value = mcast_loop;
     int rc = zmq_setsockopt (socket, ZMQ_MCAST_LOOP, &value, sizeof (int64_t));
@@ -219,11 +232,11 @@ zsockopt_set_mcast_loop (void *socket, int mcast_loop)
 //  Return socket ZMQ_MCAST_LOOP value
 
 int
-zsockopt_mcast_loop (void *socket)
+zsocket_mcast_loop (void *socket)
 {
     int64_t mcast_loop;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_MCAST_LOOP, &mcast_loop, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_MCAST_LOOP, &mcast_loop, &option_len);
     return (int) mcast_loop;
 }
 
@@ -232,7 +245,7 @@ zsockopt_mcast_loop (void *socket)
 //  Set socket ZMQ_SNDBUF value
 
 void
-zsockopt_set_sndbuf (void *socket, int sndbuf)
+zsocket_set_sndbuf (void *socket, int sndbuf)
 {
     uint64_t value = sndbuf;
     int rc = zmq_setsockopt (socket, ZMQ_SNDBUF, &value, sizeof (uint64_t));
@@ -244,11 +257,11 @@ zsockopt_set_sndbuf (void *socket, int sndbuf)
 //  Return socket ZMQ_SNDBUF value
 
 int
-zsockopt_sndbuf (void *socket)
+zsocket_sndbuf (void *socket)
 {
     uint64_t sndbuf;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_SNDBUF, &sndbuf, &type_size);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (socket, ZMQ_SNDBUF, &sndbuf, &option_len);
     return (int) sndbuf;
 }
 
@@ -257,7 +270,7 @@ zsockopt_sndbuf (void *socket)
 //  Set socket ZMQ_RCVBUF value
 
 void
-zsockopt_set_rcvbuf (void *socket, int rcvbuf)
+zsocket_set_rcvbuf (void *socket, int rcvbuf)
 {
     uint64_t value = rcvbuf;
     int rc = zmq_setsockopt (socket, ZMQ_RCVBUF, &value, sizeof (uint64_t));
@@ -269,11 +282,11 @@ zsockopt_set_rcvbuf (void *socket, int rcvbuf)
 //  Return socket ZMQ_RCVBUF value
 
 int
-zsockopt_rcvbuf (void *socket)
+zsocket_rcvbuf (void *socket)
 {
     uint64_t rcvbuf;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_RCVBUF, &rcvbuf, &type_size);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (socket, ZMQ_RCVBUF, &rcvbuf, &option_len);
     return (int) rcvbuf;
 }
 
@@ -282,7 +295,7 @@ zsockopt_rcvbuf (void *socket)
 //  Set socket ZMQ_LINGER value
 
 void
-zsockopt_set_linger (void *socket, int linger)
+zsocket_set_linger (void *socket, int linger)
 {
     int rc = zmq_setsockopt (socket, ZMQ_LINGER, &linger, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -293,11 +306,11 @@ zsockopt_set_linger (void *socket, int linger)
 //  Return socket ZMQ_LINGER value
 
 int
-zsockopt_linger (void *socket)
+zsocket_linger (void *socket)
 {
     int linger;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_LINGER, &linger, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_LINGER, &linger, &option_len);
     return linger;
 }
 
@@ -306,7 +319,7 @@ zsockopt_linger (void *socket)
 //  Set socket ZMQ_RECONNECT_IVL value
 
 void
-zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl)
+zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -317,11 +330,11 @@ zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl)
 //  Return socket ZMQ_RECONNECT_IVL value
 
 int
-zsockopt_reconnect_ivl (void *socket)
+zsocket_reconnect_ivl (void *socket)
 {
     int reconnect_ivl;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
     return reconnect_ivl;
 }
 
@@ -330,7 +343,7 @@ zsockopt_reconnect_ivl (void *socket)
 //  Set socket ZMQ_RECONNECT_IVL_MAX value
 
 void
-zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
+zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -341,11 +354,11 @@ zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
 //  Return socket ZMQ_RECONNECT_IVL_MAX value
 
 int
-zsockopt_reconnect_ivl_max (void *socket)
+zsocket_reconnect_ivl_max (void *socket)
 {
     int reconnect_ivl_max;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
     return reconnect_ivl_max;
 }
 
@@ -354,7 +367,7 @@ zsockopt_reconnect_ivl_max (void *socket)
 //  Set socket ZMQ_BACKLOG value
 
 void
-zsockopt_set_backlog (void *socket, int backlog)
+zsocket_set_backlog (void *socket, int backlog)
 {
     int rc = zmq_setsockopt (socket, ZMQ_BACKLOG, &backlog, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -365,11 +378,11 @@ zsockopt_set_backlog (void *socket, int backlog)
 //  Return socket ZMQ_BACKLOG value
 
 int
-zsockopt_backlog (void *socket)
+zsocket_backlog (void *socket)
 {
     int backlog;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_BACKLOG, &backlog, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_BACKLOG, &backlog, &option_len);
     return backlog;
 }
 
@@ -378,7 +391,7 @@ zsockopt_backlog (void *socket)
 //  Set socket ZMQ_SUBSCRIBE value
 
 void
-zsockopt_set_subscribe (void *socket, char * subscribe)
+zsocket_set_subscribe (void *socket, char * subscribe)
 {
     int rc = zmq_setsockopt (socket, ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
     assert (rc == 0 || errno == ETERM);
@@ -389,7 +402,7 @@ zsockopt_set_subscribe (void *socket, char * subscribe)
 //  Set socket ZMQ_UNSUBSCRIBE value
 
 void
-zsockopt_set_unsubscribe (void *socket, char * unsubscribe)
+zsocket_set_unsubscribe (void *socket, char * unsubscribe)
 {
     int rc = zmq_setsockopt (socket, ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
     assert (rc == 0 || errno == ETERM);
@@ -400,11 +413,11 @@ zsockopt_set_unsubscribe (void *socket, char * unsubscribe)
 //  Return socket ZMQ_TYPE value
 
 int
-zsockopt_type (void *socket)
+zsocket_type (void *socket)
 {
     int type;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_TYPE, &type, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_TYPE, &type, &option_len);
     return type;
 }
 
@@ -413,11 +426,11 @@ zsockopt_type (void *socket)
 //  Return socket ZMQ_RCVMORE value
 
 int
-zsockopt_rcvmore (void *socket)
+zsocket_rcvmore (void *socket)
 {
     int64_t rcvmore;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_RCVMORE, &rcvmore, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_RCVMORE, &rcvmore, &option_len);
     return (int) rcvmore;
 }
 
@@ -426,11 +439,11 @@ zsockopt_rcvmore (void *socket)
 //  Return socket ZMQ_FD value
 
 int
-zsockopt_fd (void *socket)
+zsocket_fd (void *socket)
 {
     int fd;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_FD, &fd, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_FD, &fd, &option_len);
     return fd;
 }
 
@@ -439,11 +452,11 @@ zsockopt_fd (void *socket)
 //  Return socket ZMQ_EVENTS value
 
 int
-zsockopt_events (void *socket)
+zsocket_events (void *socket)
 {
     uint32_t events;
-    size_t type_size = sizeof (uint32_t);
-    zmq_getsockopt (socket, ZMQ_EVENTS, &events, &type_size);
+    size_t option_len = sizeof (uint32_t);
+    zmq_getsockopt (socket, ZMQ_EVENTS, &events, &option_len);
     return (int) events;
 }
 
@@ -452,10 +465,23 @@ zsockopt_events (void *socket)
 
 #if (ZMQ_VERSION_MAJOR == 3)
 //  --------------------------------------------------------------------------
+//  Return socket ZMQ_TYPE value
+
+int
+zsocket_type (void *socket)
+{
+    int type;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_TYPE, &type, &option_len);
+    return type;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_SNDHWM value
 
 void
-zsockopt_set_sndhwm (void *socket, int sndhwm)
+zsocket_set_sndhwm (void *socket, int sndhwm)
 {
     int rc = zmq_setsockopt (socket, ZMQ_SNDHWM, &sndhwm, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -466,11 +492,11 @@ zsockopt_set_sndhwm (void *socket, int sndhwm)
 //  Return socket ZMQ_SNDHWM value
 
 int
-zsockopt_sndhwm (void *socket)
+zsocket_sndhwm (void *socket)
 {
     int sndhwm;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_SNDHWM, &sndhwm, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_SNDHWM, &sndhwm, &option_len);
     return sndhwm;
 }
 
@@ -479,7 +505,7 @@ zsockopt_sndhwm (void *socket)
 //  Set socket ZMQ_RCVHWM value
 
 void
-zsockopt_set_rcvhwm (void *socket, int rcvhwm)
+zsocket_set_rcvhwm (void *socket, int rcvhwm)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RCVHWM, &rcvhwm, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -490,11 +516,11 @@ zsockopt_set_rcvhwm (void *socket, int rcvhwm)
 //  Return socket ZMQ_RCVHWM value
 
 int
-zsockopt_rcvhwm (void *socket)
+zsocket_rcvhwm (void *socket)
 {
     int rcvhwm;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVHWM, &rcvhwm, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RCVHWM, &rcvhwm, &option_len);
     return rcvhwm;
 }
 
@@ -503,7 +529,7 @@ zsockopt_rcvhwm (void *socket)
 //  Set socket ZMQ_AFFINITY value
 
 void
-zsockopt_set_affinity (void *socket, int affinity)
+zsocket_set_affinity (void *socket, int affinity)
 {
     uint64_t value = affinity;
     int rc = zmq_setsockopt (socket, ZMQ_AFFINITY, &value, sizeof (uint64_t));
@@ -515,12 +541,34 @@ zsockopt_set_affinity (void *socket, int affinity)
 //  Return socket ZMQ_AFFINITY value
 
 int
-zsockopt_affinity (void *socket)
+zsocket_affinity (void *socket)
 {
     uint64_t affinity;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_AFFINITY, &affinity, &type_size);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (socket, ZMQ_AFFINITY, &affinity, &option_len);
     return (int) affinity;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_SUBSCRIBE value
+
+void
+zsocket_set_subscribe (void *socket, char * subscribe)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
+    assert (rc == 0 || errno == ETERM);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_UNSUBSCRIBE value
+
+void
+zsocket_set_unsubscribe (void *socket, char * unsubscribe)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
+    assert (rc == 0 || errno == ETERM);
 }
 
 
@@ -528,7 +576,7 @@ zsockopt_affinity (void *socket)
 //  Set socket ZMQ_IDENTITY value
 
 void
-zsockopt_set_identity (void *socket, char * identity)
+zsocket_set_identity (void *socket, char * identity)
 {
     int rc = zmq_setsockopt (socket, ZMQ_IDENTITY, identity, strlen (identity));
     assert (rc == 0 || errno == ETERM);
@@ -536,10 +584,23 @@ zsockopt_set_identity (void *socket, char * identity)
 
 
 //  --------------------------------------------------------------------------
+//  Return socket ZMQ_IDENTITY value
+
+char *
+zsocket_identity (void *socket)
+{
+    size_t option_len = 255;
+    char *identity = zmalloc (option_len);
+    zmq_getsockopt (socket, ZMQ_IDENTITY, &identity, &option_len);
+    return (char *) identity;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_RATE value
 
 void
-zsockopt_set_rate (void *socket, int rate)
+zsocket_set_rate (void *socket, int rate)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RATE, &rate, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -550,11 +611,11 @@ zsockopt_set_rate (void *socket, int rate)
 //  Return socket ZMQ_RATE value
 
 int
-zsockopt_rate (void *socket)
+zsocket_rate (void *socket)
 {
     int rate;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RATE, &rate, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RATE, &rate, &option_len);
     return rate;
 }
 
@@ -563,7 +624,7 @@ zsockopt_rate (void *socket)
 //  Set socket ZMQ_RECOVERY_IVL value
 
 void
-zsockopt_set_recovery_ivl (void *socket, int recovery_ivl)
+zsocket_set_recovery_ivl (void *socket, int recovery_ivl)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -574,11 +635,11 @@ zsockopt_set_recovery_ivl (void *socket, int recovery_ivl)
 //  Return socket ZMQ_RECOVERY_IVL value
 
 int
-zsockopt_recovery_ivl (void *socket)
+zsocket_recovery_ivl (void *socket)
 {
     int recovery_ivl;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
     return recovery_ivl;
 }
 
@@ -587,7 +648,7 @@ zsockopt_recovery_ivl (void *socket)
 //  Set socket ZMQ_SNDBUF value
 
 void
-zsockopt_set_sndbuf (void *socket, int sndbuf)
+zsocket_set_sndbuf (void *socket, int sndbuf)
 {
     int rc = zmq_setsockopt (socket, ZMQ_SNDBUF, &sndbuf, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -598,11 +659,11 @@ zsockopt_set_sndbuf (void *socket, int sndbuf)
 //  Return socket ZMQ_SNDBUF value
 
 int
-zsockopt_sndbuf (void *socket)
+zsocket_sndbuf (void *socket)
 {
     int sndbuf;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_SNDBUF, &sndbuf, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_SNDBUF, &sndbuf, &option_len);
     return sndbuf;
 }
 
@@ -611,7 +672,7 @@ zsockopt_sndbuf (void *socket)
 //  Set socket ZMQ_RCVBUF value
 
 void
-zsockopt_set_rcvbuf (void *socket, int rcvbuf)
+zsocket_set_rcvbuf (void *socket, int rcvbuf)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RCVBUF, &rcvbuf, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -622,11 +683,11 @@ zsockopt_set_rcvbuf (void *socket, int rcvbuf)
 //  Return socket ZMQ_RCVBUF value
 
 int
-zsockopt_rcvbuf (void *socket)
+zsocket_rcvbuf (void *socket)
 {
     int rcvbuf;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVBUF, &rcvbuf, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RCVBUF, &rcvbuf, &option_len);
     return rcvbuf;
 }
 
@@ -635,7 +696,7 @@ zsockopt_rcvbuf (void *socket)
 //  Set socket ZMQ_LINGER value
 
 void
-zsockopt_set_linger (void *socket, int linger)
+zsocket_set_linger (void *socket, int linger)
 {
     int rc = zmq_setsockopt (socket, ZMQ_LINGER, &linger, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -646,11 +707,11 @@ zsockopt_set_linger (void *socket, int linger)
 //  Return socket ZMQ_LINGER value
 
 int
-zsockopt_linger (void *socket)
+zsocket_linger (void *socket)
 {
     int linger;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_LINGER, &linger, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_LINGER, &linger, &option_len);
     return linger;
 }
 
@@ -659,7 +720,7 @@ zsockopt_linger (void *socket)
 //  Set socket ZMQ_RECONNECT_IVL value
 
 void
-zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl)
+zsocket_set_reconnect_ivl (void *socket, int reconnect_ivl)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -670,11 +731,11 @@ zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl)
 //  Return socket ZMQ_RECONNECT_IVL value
 
 int
-zsockopt_reconnect_ivl (void *socket)
+zsocket_reconnect_ivl (void *socket)
 {
     int reconnect_ivl;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
     return reconnect_ivl;
 }
 
@@ -683,7 +744,7 @@ zsockopt_reconnect_ivl (void *socket)
 //  Set socket ZMQ_RECONNECT_IVL_MAX value
 
 void
-zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
+zsocket_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
 {
     int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -694,11 +755,11 @@ zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
 //  Return socket ZMQ_RECONNECT_IVL_MAX value
 
 int
-zsockopt_reconnect_ivl_max (void *socket)
+zsocket_reconnect_ivl_max (void *socket)
 {
     int reconnect_ivl_max;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
     return reconnect_ivl_max;
 }
 
@@ -707,7 +768,7 @@ zsockopt_reconnect_ivl_max (void *socket)
 //  Set socket ZMQ_BACKLOG value
 
 void
-zsockopt_set_backlog (void *socket, int backlog)
+zsocket_set_backlog (void *socket, int backlog)
 {
     int rc = zmq_setsockopt (socket, ZMQ_BACKLOG, &backlog, sizeof (int));
     assert (rc == 0 || errno == ETERM);
@@ -718,11 +779,11 @@ zsockopt_set_backlog (void *socket, int backlog)
 //  Return socket ZMQ_BACKLOG value
 
 int
-zsockopt_backlog (void *socket)
+zsocket_backlog (void *socket)
 {
     int backlog;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_BACKLOG, &backlog, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_BACKLOG, &backlog, &option_len);
     return backlog;
 }
 
@@ -731,7 +792,7 @@ zsockopt_backlog (void *socket)
 //  Set socket ZMQ_MAXMSGSIZE value
 
 void
-zsockopt_set_maxmsgsize (void *socket, int maxmsgsize)
+zsocket_set_maxmsgsize (void *socket, int maxmsgsize)
 {
     int64_t value = maxmsgsize;
     int rc = zmq_setsockopt (socket, ZMQ_MAXMSGSIZE, &value, sizeof (int64_t));
@@ -743,47 +804,119 @@ zsockopt_set_maxmsgsize (void *socket, int maxmsgsize)
 //  Return socket ZMQ_MAXMSGSIZE value
 
 int
-zsockopt_maxmsgsize (void *socket)
+zsocket_maxmsgsize (void *socket)
 {
     int64_t maxmsgsize;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_MAXMSGSIZE, &maxmsgsize, &type_size);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (socket, ZMQ_MAXMSGSIZE, &maxmsgsize, &option_len);
     return (int) maxmsgsize;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Set socket ZMQ_SUBSCRIBE value
+//  Set socket ZMQ_MULTICAST_HOPS value
 
 void
-zsockopt_set_subscribe (void *socket, char * subscribe)
+zsocket_set_multicast_hops (void *socket, int multicast_hops)
 {
-    int rc = zmq_setsockopt (socket, ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
+    int rc = zmq_setsockopt (socket, ZMQ_MULTICAST_HOPS, &multicast_hops, sizeof (int));
     assert (rc == 0 || errno == ETERM);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Set socket ZMQ_UNSUBSCRIBE value
-
-void
-zsockopt_set_unsubscribe (void *socket, char * unsubscribe)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TYPE value
+//  Return socket ZMQ_MULTICAST_HOPS value
 
 int
-zsockopt_type (void *socket)
+zsocket_multicast_hops (void *socket)
 {
-    int type;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_TYPE, &type, &type_size);
-    return type;
+    int multicast_hops;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_MULTICAST_HOPS, &multicast_hops, &option_len);
+    return multicast_hops;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_RCVTIMEO value
+
+void
+zsocket_set_rcvtimeo (void *socket, int rcvtimeo)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
+    assert (rc == 0 || errno == ETERM);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_RCVTIMEO value
+
+int
+zsocket_rcvtimeo (void *socket)
+{
+    int rcvtimeo;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RCVTIMEO, &rcvtimeo, &option_len);
+    return rcvtimeo;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_SNDTIMEO value
+
+void
+zsocket_set_sndtimeo (void *socket, int sndtimeo)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
+    assert (rc == 0 || errno == ETERM);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_SNDTIMEO value
+
+int
+zsocket_sndtimeo (void *socket)
+{
+    int sndtimeo;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_SNDTIMEO, &sndtimeo, &option_len);
+    return sndtimeo;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_IPV4ONLY value
+
+void
+zsocket_set_ipv4only (void *socket, int ipv4only)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_IPV4ONLY, &ipv4only, sizeof (int));
+    assert (rc == 0 || errno == ETERM);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_IPV4ONLY value
+
+int
+zsocket_ipv4only (void *socket)
+{
+    int ipv4only;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_IPV4ONLY, &ipv4only, &option_len);
+    return ipv4only;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_FAIL_UNROUTABLE value
+
+void
+zsocket_set_fail_unroutable (void *socket, int fail_unroutable)
+{
+    int rc = zmq_setsockopt (socket, ZMQ_FAIL_UNROUTABLE, &fail_unroutable, sizeof (int));
+    assert (rc == 0 || errno == ETERM);
 }
 
 
@@ -791,11 +924,11 @@ zsockopt_type (void *socket)
 //  Return socket ZMQ_RCVMORE value
 
 int
-zsockopt_rcvmore (void *socket)
+zsocket_rcvmore (void *socket)
 {
     int rcvmore;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVMORE, &rcvmore, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_RCVMORE, &rcvmore, &option_len);
     return rcvmore;
 }
 
@@ -804,11 +937,11 @@ zsockopt_rcvmore (void *socket)
 //  Return socket ZMQ_FD value
 
 int
-zsockopt_fd (void *socket)
+zsocket_fd (void *socket)
 {
     int fd;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_FD, &fd, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_FD, &fd, &option_len);
     return fd;
 }
 
@@ -817,389 +950,25 @@ zsockopt_fd (void *socket)
 //  Return socket ZMQ_EVENTS value
 
 int
-zsockopt_events (void *socket)
+zsocket_events (void *socket)
 {
     int events;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_EVENTS, &events, &type_size);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (socket, ZMQ_EVENTS, &events, &option_len);
     return events;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Set socket high-water mark, emulating 2.x API
+//  Return socket ZMQ_LAST_ENDPOINT value
 
-void
-zsockopt_set_hwm (void *socket, int hwm)
+char *
+zsocket_last_endpoint (void *socket)
 {
-    zsockopt_set_sndhwm (socket, hwm);
-    zsockopt_set_rcvhwm (socket, hwm);
-}
-
-#endif
-
-#if (ZMQ_VERSION_MAJOR == 4)
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDHWM value
-
-void
-zsockopt_set_sndhwm (void *socket, int sndhwm)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_SNDHWM, &sndhwm, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDHWM value
-
-int
-zsockopt_sndhwm (void *socket)
-{
-    int sndhwm;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_SNDHWM, &sndhwm, &type_size);
-    return sndhwm;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVHWM value
-
-void
-zsockopt_set_rcvhwm (void *socket, int rcvhwm)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RCVHWM, &rcvhwm, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVHWM value
-
-int
-zsockopt_rcvhwm (void *socket)
-{
-    int rcvhwm;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVHWM, &rcvhwm, &type_size);
-    return rcvhwm;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_AFFINITY value
-
-void
-zsockopt_set_affinity (void *socket, int affinity)
-{
-    uint64_t value = affinity;
-    int rc = zmq_setsockopt (socket, ZMQ_AFFINITY, &value, sizeof (uint64_t));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_AFFINITY value
-
-int
-zsockopt_affinity (void *socket)
-{
-    uint64_t affinity;
-    size_t type_size = sizeof (uint64_t);
-    zmq_getsockopt (socket, ZMQ_AFFINITY, &affinity, &type_size);
-    return (int) affinity;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RATE value
-
-void
-zsockopt_set_rate (void *socket, int rate)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RATE, &rate, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RATE value
-
-int
-zsockopt_rate (void *socket)
-{
-    int rate;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RATE, &rate, &type_size);
-    return rate;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECOVERY_IVL value
-
-void
-zsockopt_set_recovery_ivl (void *socket, int recovery_ivl)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECOVERY_IVL value
-
-int
-zsockopt_recovery_ivl (void *socket)
-{
-    int recovery_ivl;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECOVERY_IVL, &recovery_ivl, &type_size);
-    return recovery_ivl;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDBUF value
-
-void
-zsockopt_set_sndbuf (void *socket, int sndbuf)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_SNDBUF, &sndbuf, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDBUF value
-
-int
-zsockopt_sndbuf (void *socket)
-{
-    int sndbuf;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_SNDBUF, &sndbuf, &type_size);
-    return sndbuf;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVBUF value
-
-void
-zsockopt_set_rcvbuf (void *socket, int rcvbuf)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RCVBUF, &rcvbuf, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVBUF value
-
-int
-zsockopt_rcvbuf (void *socket)
-{
-    int rcvbuf;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVBUF, &rcvbuf, &type_size);
-    return rcvbuf;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_LINGER value
-
-void
-zsockopt_set_linger (void *socket, int linger)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_LINGER, &linger, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_LINGER value
-
-int
-zsockopt_linger (void *socket)
-{
-    int linger;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_LINGER, &linger, &type_size);
-    return linger;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL value
-
-void
-zsockopt_set_reconnect_ivl (void *socket, int reconnect_ivl)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL value
-
-int
-zsockopt_reconnect_ivl (void *socket)
-{
-    int reconnect_ivl;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL, &reconnect_ivl, &type_size);
-    return reconnect_ivl;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL_MAX value
-
-void
-zsockopt_set_reconnect_ivl_max (void *socket, int reconnect_ivl_max)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL_MAX value
-
-int
-zsockopt_reconnect_ivl_max (void *socket)
-{
-    int reconnect_ivl_max;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &type_size);
-    return reconnect_ivl_max;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_BACKLOG value
-
-void
-zsockopt_set_backlog (void *socket, int backlog)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_BACKLOG, &backlog, sizeof (int));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_BACKLOG value
-
-int
-zsockopt_backlog (void *socket)
-{
-    int backlog;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_BACKLOG, &backlog, &type_size);
-    return backlog;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_MAXMSGSIZE value
-
-void
-zsockopt_set_maxmsgsize (void *socket, int maxmsgsize)
-{
-    int64_t value = maxmsgsize;
-    int rc = zmq_setsockopt (socket, ZMQ_MAXMSGSIZE, &value, sizeof (int64_t));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_MAXMSGSIZE value
-
-int
-zsockopt_maxmsgsize (void *socket)
-{
-    int64_t maxmsgsize;
-    size_t type_size = sizeof (int64_t);
-    zmq_getsockopt (socket, ZMQ_MAXMSGSIZE, &maxmsgsize, &type_size);
-    return (int) maxmsgsize;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SUBSCRIBE value
-
-void
-zsockopt_set_subscribe (void *socket, char * subscribe)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_UNSUBSCRIBE value
-
-void
-zsockopt_set_unsubscribe (void *socket, char * unsubscribe)
-{
-    int rc = zmq_setsockopt (socket, ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
-    assert (rc == 0 || errno == ETERM);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TYPE value
-
-int
-zsockopt_type (void *socket)
-{
-    int type;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_TYPE, &type, &type_size);
-    return type;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVMORE value
-
-int
-zsockopt_rcvmore (void *socket)
-{
-    int rcvmore;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_RCVMORE, &rcvmore, &type_size);
-    return rcvmore;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_FD value
-
-int
-zsockopt_fd (void *socket)
-{
-    int fd;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_FD, &fd, &type_size);
-    return fd;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_EVENTS value
-
-int
-zsockopt_events (void *socket)
-{
-    int events;
-    size_t type_size = sizeof (int);
-    zmq_getsockopt (socket, ZMQ_EVENTS, &events, &type_size);
-    return events;
+    size_t option_len = 255;
+    char *last_endpoint = zmalloc (option_len);
+    zmq_getsockopt (socket, ZMQ_LAST_ENDPOINT, &last_endpoint, &option_len);
+    return (char *) last_endpoint;
 }
 
 
@@ -1230,313 +999,246 @@ zsockopt_test (Bool verbose)
 #if (ZMQ_VERSION_MAJOR == 2)
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_hwm (socket, 1);
-    assert (zsockopt_hwm (socket) == 1);
-    zsockopt_hwm (socket);
+    zsocket_set_hwm (socket, 1);
+    assert (zsocket_hwm (socket) == 1);
+    zsocket_hwm (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_swap (socket, 1);
-    assert (zsockopt_swap (socket) == 1);
-    zsockopt_swap (socket);
+    zsocket_set_swap (socket, 1);
+    assert (zsocket_swap (socket) == 1);
+    zsocket_swap (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_affinity (socket, 1);
-    assert (zsockopt_affinity (socket) == 1);
-    zsockopt_affinity (socket);
+    zsocket_set_affinity (socket, 1);
+    assert (zsocket_affinity (socket) == 1);
+    zsocket_affinity (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_identity (socket, "test");
+    zsocket_set_identity (socket, "test"); //a
+    zsocket_identity (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_rate (socket, 1);
-    assert (zsockopt_rate (socket) == 1);
-    zsockopt_rate (socket);
+    zsocket_set_rate (socket, 1);
+    assert (zsocket_rate (socket) == 1);
+    zsocket_rate (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_recovery_ivl (socket, 1);
-    assert (zsockopt_recovery_ivl (socket) == 1);
-    zsockopt_recovery_ivl (socket);
+    zsocket_set_recovery_ivl (socket, 1);
+    assert (zsocket_recovery_ivl (socket) == 1);
+    zsocket_recovery_ivl (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_recovery_ivl_msec (socket, 1);
-    assert (zsockopt_recovery_ivl_msec (socket) == 1);
-    zsockopt_recovery_ivl_msec (socket);
+    zsocket_set_recovery_ivl_msec (socket, 1);
+    assert (zsocket_recovery_ivl_msec (socket) == 1);
+    zsocket_recovery_ivl_msec (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_mcast_loop (socket, 1);
-    assert (zsockopt_mcast_loop (socket) == 1);
-    zsockopt_mcast_loop (socket);
+    zsocket_set_mcast_loop (socket, 1);
+    assert (zsocket_mcast_loop (socket) == 1);
+    zsocket_mcast_loop (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_sndbuf (socket, 1);
-    assert (zsockopt_sndbuf (socket) == 1);
-    zsockopt_sndbuf (socket);
+    zsocket_set_sndbuf (socket, 1);
+    assert (zsocket_sndbuf (socket) == 1);
+    zsocket_sndbuf (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_rcvbuf (socket, 1);
-    assert (zsockopt_rcvbuf (socket) == 1);
-    zsockopt_rcvbuf (socket);
+    zsocket_set_rcvbuf (socket, 1);
+    assert (zsocket_rcvbuf (socket) == 1);
+    zsocket_rcvbuf (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_linger (socket, 1);
-    assert (zsockopt_linger (socket) == 1);
-    zsockopt_linger (socket);
+    zsocket_set_linger (socket, 1);
+    assert (zsocket_linger (socket) == 1);
+    zsocket_linger (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl (socket, 1);
-    assert (zsockopt_reconnect_ivl (socket) == 1);
-    zsockopt_reconnect_ivl (socket);
+    zsocket_set_reconnect_ivl (socket, 1);
+    assert (zsocket_reconnect_ivl (socket) == 1);
+    zsocket_reconnect_ivl (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl_max (socket, 1);
-    assert (zsockopt_reconnect_ivl_max (socket) == 1);
-    zsockopt_reconnect_ivl_max (socket);
+    zsocket_set_reconnect_ivl_max (socket, 1);
+    assert (zsocket_reconnect_ivl_max (socket) == 1);
+    zsocket_reconnect_ivl_max (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_backlog (socket, 1);
-    assert (zsockopt_backlog (socket) == 1);
-    zsockopt_backlog (socket);
+    zsocket_set_backlog (socket, 1);
+    assert (zsocket_backlog (socket) == 1);
+    zsocket_backlog (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_subscribe (socket, "test");
+    zsocket_set_subscribe (socket, "test"); //a
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_unsubscribe (socket, "test");
+    zsocket_set_unsubscribe (socket, "test"); //a
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_type (socket);
+    zsocket_type (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_rcvmore (socket);
+    zsocket_rcvmore (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_fd (socket);
+    zsocket_fd (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_events (socket);
+    zsocket_events (socket);
     zsocket_destroy (ctx, socket);
 #endif
 
 #if (ZMQ_VERSION_MAJOR == 3)
-    socket = zsocket_new (ctx, ZMQ_PUB);
-    assert (socket);
-    zsockopt_set_sndhwm (socket, 1);
-    assert (zsockopt_sndhwm (socket) == 1);
-    zsockopt_sndhwm (socket);
-    zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_rcvhwm (socket, 1);
-    assert (zsockopt_rcvhwm (socket) == 1);
-    zsockopt_rcvhwm (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_affinity (socket, 1);
-    assert (zsockopt_affinity (socket) == 1);
-    zsockopt_affinity (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_identity (socket, "test");
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_rate (socket, 1);
-    assert (zsockopt_rate (socket) == 1);
-    zsockopt_rate (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_recovery_ivl (socket, 1);
-    assert (zsockopt_recovery_ivl (socket) == 1);
-    zsockopt_recovery_ivl (socket);
+    zsocket_type (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_PUB);
     assert (socket);
-    zsockopt_set_sndbuf (socket, 1);
-    assert (zsockopt_sndbuf (socket) == 1);
-    zsockopt_sndbuf (socket);
+    zsocket_set_sndhwm (socket, 1);
+    assert (zsocket_sndhwm (socket) == 1);
+    zsocket_sndhwm (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_rcvbuf (socket, 1);
-    assert (zsockopt_rcvbuf (socket) == 1);
-    zsockopt_rcvbuf (socket);
+    zsocket_set_rcvhwm (socket, 1);
+    assert (zsocket_rcvhwm (socket) == 1);
+    zsocket_rcvhwm (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_linger (socket, 1);
-    assert (zsockopt_linger (socket) == 1);
-    zsockopt_linger (socket);
+    zsocket_set_affinity (socket, 1);
+    assert (zsocket_affinity (socket) == 1);
+    zsocket_affinity (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl (socket, 1);
-    assert (zsockopt_reconnect_ivl (socket) == 1);
-    zsockopt_reconnect_ivl (socket);
+    zsocket_set_subscribe (socket, "test"); //a
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl_max (socket, 1);
-    assert (zsockopt_reconnect_ivl_max (socket) == 1);
-    zsockopt_reconnect_ivl_max (socket);
+    zsocket_set_unsubscribe (socket, "test"); //a
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_backlog (socket, 1);
-    assert (zsockopt_backlog (socket) == 1);
-    zsockopt_backlog (socket);
+    zsocket_set_identity (socket, "test"); //a
+    zsocket_identity (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_maxmsgsize (socket, 1);
-    assert (zsockopt_maxmsgsize (socket) == 1);
-    zsockopt_maxmsgsize (socket);
+    zsocket_set_rate (socket, 1);
+    assert (zsocket_rate (socket) == 1);
+    zsocket_rate (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_subscribe (socket, "test");
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_unsubscribe (socket, "test");
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_type (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_rcvmore (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_fd (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_events (socket);
-    zsocket_destroy (ctx, socket);
-
-    zsockopt_set_hwm (socket, 1);
-#endif
-
-#if (ZMQ_VERSION_MAJOR == 4)
-    socket = zsocket_new (ctx, ZMQ_PUB);
-    assert (socket);
-    zsockopt_set_sndhwm (socket, 1);
-    assert (zsockopt_sndhwm (socket) == 1);
-    zsockopt_sndhwm (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_rcvhwm (socket, 1);
-    assert (zsockopt_rcvhwm (socket) == 1);
-    zsockopt_rcvhwm (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_affinity (socket, 1);
-    assert (zsockopt_affinity (socket) == 1);
-    zsockopt_affinity (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_rate (socket, 1);
-    assert (zsockopt_rate (socket) == 1);
-    zsockopt_rate (socket);
-    zsocket_destroy (ctx, socket);
-    socket = zsocket_new (ctx, ZMQ_SUB);
-    assert (socket);
-    zsockopt_set_recovery_ivl (socket, 1);
-    assert (zsockopt_recovery_ivl (socket) == 1);
-    zsockopt_recovery_ivl (socket);
+    zsocket_set_recovery_ivl (socket, 1);
+    assert (zsocket_recovery_ivl (socket) == 1);
+    zsocket_recovery_ivl (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_PUB);
     assert (socket);
-    zsockopt_set_sndbuf (socket, 1);
-    assert (zsockopt_sndbuf (socket) == 1);
-    zsockopt_sndbuf (socket);
+    zsocket_set_sndbuf (socket, 1);
+    assert (zsocket_sndbuf (socket) == 1);
+    zsocket_sndbuf (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_rcvbuf (socket, 1);
-    assert (zsockopt_rcvbuf (socket) == 1);
-    zsockopt_rcvbuf (socket);
+    zsocket_set_rcvbuf (socket, 1);
+    assert (zsocket_rcvbuf (socket) == 1);
+    zsocket_rcvbuf (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_linger (socket, 1);
-    assert (zsockopt_linger (socket) == 1);
-    zsockopt_linger (socket);
+    zsocket_set_linger (socket, 1);
+    assert (zsocket_linger (socket) == 1);
+    zsocket_linger (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl (socket, 1);
-    assert (zsockopt_reconnect_ivl (socket) == 1);
-    zsockopt_reconnect_ivl (socket);
+    zsocket_set_reconnect_ivl (socket, 1);
+    assert (zsocket_reconnect_ivl (socket) == 1);
+    zsocket_reconnect_ivl (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_reconnect_ivl_max (socket, 1);
-    assert (zsockopt_reconnect_ivl_max (socket) == 1);
-    zsockopt_reconnect_ivl_max (socket);
+    zsocket_set_reconnect_ivl_max (socket, 1);
+    assert (zsocket_reconnect_ivl_max (socket) == 1);
+    zsocket_reconnect_ivl_max (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_backlog (socket, 1);
-    assert (zsockopt_backlog (socket) == 1);
-    zsockopt_backlog (socket);
+    zsocket_set_backlog (socket, 1);
+    assert (zsocket_backlog (socket) == 1);
+    zsocket_backlog (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_maxmsgsize (socket, 1);
-    assert (zsockopt_maxmsgsize (socket) == 1);
-    zsockopt_maxmsgsize (socket);
+    zsocket_set_maxmsgsize (socket, 1);
+    assert (zsocket_maxmsgsize (socket) == 1);
+    zsocket_maxmsgsize (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_subscribe (socket, "test");
+    zsocket_set_multicast_hops (socket, 1);
+    assert (zsocket_multicast_hops (socket) == 1);
+    zsocket_multicast_hops (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_set_unsubscribe (socket, "test");
+    zsocket_set_rcvtimeo (socket, 1);
+    assert (zsocket_rcvtimeo (socket) == 1);
+    zsocket_rcvtimeo (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_type (socket);
+    zsocket_set_sndtimeo (socket, 1);
+    assert (zsocket_sndtimeo (socket) == 1);
+    zsocket_sndtimeo (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_rcvmore (socket);
+    zsocket_set_ipv4only (socket, 1);
+    assert (zsocket_ipv4only (socket) == 1);
+    zsocket_ipv4only (socket);
+    zsocket_destroy (ctx, socket);
+    socket = zsocket_new (ctx, ZMQ_ROUTER);
+    assert (socket);
+    zsocket_set_fail_unroutable (socket, 1);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_fd (socket);
+    zsocket_rcvmore (socket);
     zsocket_destroy (ctx, socket);
     socket = zsocket_new (ctx, ZMQ_SUB);
     assert (socket);
-    zsockopt_events (socket);
+    zsocket_fd (socket);
+    zsocket_destroy (ctx, socket);
+    socket = zsocket_new (ctx, ZMQ_SUB);
+    assert (socket);
+    zsocket_events (socket);
+    zsocket_destroy (ctx, socket);
+    socket = zsocket_new (ctx, ZMQ_SUB);
+    assert (socket);
+    zsocket_last_endpoint (socket);
     zsocket_destroy (ctx, socket);
 
     zsockopt_set_hwm (socket, 1);

--- a/src/zthread.c
+++ b/src/zthread.c
@@ -180,7 +180,7 @@ zthread_fork (zctx_t *ctx, zthread_attached_fn *thread_fn, void *args)
     //  Pipe has HWM of 1 at both sides to block runaway writers
     void *pipe = zsocket_new (ctx, ZMQ_PAIR);
     if (pipe) {
-        zsockopt_set_hwm (pipe, 1);
+        zsocket_set_hwm (pipe, 1);
         zsocket_bind (pipe, "inproc://zctx-pipe-%p", pipe);
     }
     else
@@ -202,7 +202,7 @@ zthread_fork (zctx_t *ctx, zthread_attached_fn *thread_fn, void *args)
     shim->pipe = zsocket_new (shim->ctx, ZMQ_PAIR);
     if (!shim->pipe)
         return NULL;
-    zsockopt_set_hwm (shim->pipe, 1);
+    zsocket_set_hwm (shim->pipe, 1);
     zsocket_connect (shim->pipe, "inproc://zctx-pipe-%p", pipe);
     
     s_thread_start (shim);


### PR DESCRIPTION
- Renamed to zsocket_get_xxx and zsocket_xxx for clarity
- Old function names provided for backwards compatibility
- Added missing socket properties for 0MQ/3.1
- Added proper read/write for blob properties

https://github.com/zeromq/czmq/issues/20
