### PR TITLE
Make zctx_interrupted volatile

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This is the class interface:
     
     //  Global signal indicator, TRUE when user presses Ctrl-C or the process
     //  gets a SIGTERM signal.
-    extern int zctx_interrupted;
+    extern volatile int zctx_interrupted;
 
 
 <A name="toc4-127" title="zsocket - working with ØMQ sockets" />

--- a/doc/zctx.txt
+++ b/doc/zctx.txt
@@ -38,7 +38,7 @@ int
 
 //  Global signal indicator, TRUE when user presses Ctrl-C or the process
 //  gets a SIGTERM signal.
-extern int zctx_interrupted;
+extern volatile int zctx_interrupted;
 ----
 
 DESCRIPTION

--- a/include/zctx.h
+++ b/include/zctx.h
@@ -78,7 +78,7 @@ int
 
 //  Global signal indicator, TRUE when user presses Ctrl-C or the process
 //  gets a SIGTERM signal.
-extern int zctx_interrupted;
+extern volatile int zctx_interrupted;
 //  @end
 
 //  Create socket within this context, for czmq use only

--- a/src/zctx.c
+++ b/src/zctx.c
@@ -79,7 +79,7 @@ struct _zctx_t {
 //
 
 //  This is a global variable accessible to CZMQ application code
-int zctx_interrupted = 0;
+volatile int zctx_interrupted = 0;
 #if defined (__UNIX__)
 static void s_signal_handler (int signal_value)
 {


### PR DESCRIPTION
To be absolutely safe, in the presence of signals a flag variable
should use the volatile keyword. If the compiler was capable of
inter-library optimization, then it would be possible for it to
assume that since the interrupted flag is never changed by code
in the normal path that it was always true.
