### PR TITLE
Fix for vsnprintf usage to ensure all data is sent

### DIFF
--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -275,12 +275,14 @@ zmsg_pushstr (zmsg_t *self, const char *format, ...)
             va_end (argptr);
             return -1;
         }
-        vsnprintf (string, size, format, argptr);
+        size = vsnprintf (string, size, format, argptr);
+    } else {
+      size = required;
     }
     va_end (argptr);
 
-    self->content_size += strlen (string);
-    zlist_push (self->frames, zframe_new (string, strlen (string)));
+    self->content_size += size;
+    zlist_push (self->frames, zframe_new (string, size));
     free (string);
     return 0;
 }
@@ -311,12 +313,14 @@ zmsg_addstr (zmsg_t *self, const char *format, ...)
             va_end (argptr);
             return -1;
         }
-        vsnprintf (string, size, format, argptr);
+        size = vsnprintf (string, size, format, argptr);
+    } else {
+      size = required;
     }
     va_end (argptr);
 
-    self->content_size += strlen (string);
-    zlist_append (self->frames, zframe_new (string, strlen (string)));
+    self->content_size += size;
+    zlist_append (self->frames, zframe_new (string, size));
     free (string);
     return 0;
 }


### PR DESCRIPTION
In the case where vsnprintf outputs a char array containing null bytes, then strlen would fail as it's expecting a string terminated with a null byte. By contrast, using the value returned by vsnprintf will always provide the real length of the output string.
