### PR TITLE
Fix build on Win64 and cleanup poll_size.

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -234,8 +234,8 @@
 #           define FD_SETSIZE 1024      //  Max. filehandles/sockets
 #       endif
 #       include <direct.h>
+#	include <winsock2.h>
 #       include <windows.h>
-#       include <winsock.h>
 #       include <process.h>
 #   endif
 #   include <malloc.h>

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -458,7 +458,7 @@ zframe_test (Bool verbose)
     assert (frame == NULL);
 
     // Test zero copy
-    char *buffer = malloc (1024);
+    char *buffer = (char *) malloc (1024);
     int i;
     for (i = 0; i < 1024; i++)
         buffer [i] = 'A';

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -50,7 +50,7 @@ typedef struct _s_timer_t s_timer_t;
 struct _zloop_t {
     zlist_t *pollers;           //  List of poll items
     zlist_t *timers;            //  List of timers
-    int poll_size;              //  Size of poll set
+    size_t poll_size;           //  Size of poll set
     zmq_pollitem_t *pollset;    //  zmq_poll set
     s_poller_t *pollact;        //  Pollers for this poll set
     Bool dirty;                 //  True if pollset needs rebuilding
@@ -358,7 +358,7 @@ zloop_start (zloop_t *self)
             if (rc)
                 break;
         }
-        rc = zmq_poll (self->pollset, self->poll_size,
+        rc = zmq_poll (self->pollset, (int) self->poll_size,
                        s_tickless_timer (self) * ZMQ_POLL_MSEC);
         if (rc == -1 || zctx_interrupted) {
             if (self->verbose)
@@ -385,7 +385,7 @@ zloop_start (zloop_t *self)
             timer = (s_timer_t *) zlist_next (self->timers);
         }
         //  Handle any pollers that are ready
-        uint item_nbr;
+        size_t item_nbr;
         for (item_nbr = 0; item_nbr < self->poll_size; item_nbr++) {
             s_poller_t *poller = &self->pollact [item_nbr];
             assert (self->pollset [item_nbr].socket == poller->item.socket);

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -193,7 +193,7 @@ zframe_t *
 zmsg_pop (zmsg_t *self)
 {
     assert (self);
-    zframe_t *frame = zlist_pop (self->frames);
+    zframe_t *frame = (zframe_t *) zlist_pop (self->frames);
     if (frame)
         self->content_size -= zframe_size (frame);
     return frame;
@@ -506,7 +506,7 @@ zmsg_encode (zmsg_t *self, byte **buffer)
             buffer_size += frame_size + 5;
         frame = zmsg_next (self);
     }
-    *buffer = malloc (buffer_size);
+    *buffer = (byte *) malloc (buffer_size);
 
     //  Encode message now
     byte *dest = *buffer;
@@ -775,7 +775,7 @@ zmsg_test (Bool verbose)
     //  Test encoding/decoding
     msg = zmsg_new ();
     assert (msg);
-    byte *blank = zmalloc (100000);
+    byte *blank = (byte *) zmalloc (100000);
     assert (blank);
     rc = zmsg_addmem (msg, blank, 0);
     assert (rc == 0);

--- a/src/zsockopt.c
+++ b/src/zsockopt.c
@@ -135,7 +135,7 @@ char *
 zsocket_identity (void *socket)
 {
     size_t option_len = 255;
-    char *identity = zmalloc (option_len);
+    char *identity = (char *) zmalloc (option_len);
     zmq_getsockopt (socket, ZMQ_IDENTITY, &identity, &option_len);
     return (char *) identity;
 }

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -53,7 +53,7 @@ zstr_recv (void *socket)
     if (zmq_recvmsg (socket, &message, 0) < 0)
         return NULL;
 
-    int size = zmq_msg_size (&message);
+    size_t size = zmq_msg_size (&message);
     char *string = (char *) malloc (size + 1);
     memcpy (string, zmq_msg_data (&message), size);
     zmq_msg_close (&message);
@@ -77,7 +77,7 @@ zstr_recv_nowait (void *socket)
     if (zmq_recvmsg (socket, &message, ZMQ_DONTWAIT) < 0)
         return NULL;
 
-    int size = zmq_msg_size (&message);
+    size_t size = zmq_msg_size (&message);
     char *string = (char *) malloc (size + 1);
     memcpy (string, zmq_msg_data (&message), size);
     zmq_msg_close (&message);


### PR DESCRIPTION
Fix build error with SDK 7.0a and order of WinSock header.
Fix C++ incompatibilities with casting void.
Convert poll_size to size_t as more appropriate for usage.
