### PR TITLE
Fix tests and change zlist_remove behaviour

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -242,11 +242,6 @@ zlist_remove (zlist_t *self, void *item)
 {
     node_t *node, *prev = NULL;
 
-    //  First off, we need to find the list node
-    //  Cheap optimization for case where we've been looking through list
-    if (self->cursor && self->cursor->item == item)
-        node = self->cursor;
-    else
     for (node = self->head; node != NULL; node = node->next) {
         if (node->item == item)
             break;
@@ -397,6 +392,10 @@ zlist_test (int verbose)
 
     zlist_remove (list, bread);
     assert (zlist_size (list) == 0);
+    assert (zlist_last(list) == NULL);
+    assert (list->head == NULL);
+    assert (list->tail == NULL);
+    assert (list->cursor == NULL);
 
     zlist_append (list, cheese);
     zlist_append (list, bread);


### PR DESCRIPTION
Fix `zlist_remove` behavior when cursor points to the element that we want to remove because we always need to get `*prev` and the optimization was skipping this step.
