### PR TITLE
Reverted logic to avoid port reuse since it wasn't a full guarantee

### DIFF
--- a/src/zctx.c
+++ b/src/zctx.c
@@ -29,7 +29,7 @@
     The zctx class wraps 0MQ contexts. It manages open sockets in the context
     and automatically closes these before terminating the context. It provides
     a simple way to set the linger timeout on sockets, and configure contexts
-    for number of I/O threads. Sets-up signal (interrrupt) handling for the
+    for number of I/O threads. Sets-up signal (interrupt) handling for the
     process.
 
     The zctx class has these main features:


### PR DESCRIPTION
Removed code that avoided reusing ports since this will not work in a multi-process scenario, and thus gives clients no gurantees. The case of old peers connecting to reused ports has to be solved at the higher protocol level.
