### PR TITLE
Fixed issue #113

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -382,7 +382,7 @@ zloop_start (zloop_t *self)
         }
         //  Handle any pollers that are ready
         size_t item_nbr;
-        for (item_nbr = 0; item_nbr < self->poll_size && rc == 0; item_nbr++) {
+        for (item_nbr = 0; item_nbr < self->poll_size && rc >= 0; item_nbr++) {
             s_poller_t *poller = &self->pollact [item_nbr];
             assert (self->pollset [item_nbr].socket == poller->item.socket);
             


### PR DESCRIPTION
zmq_poll() returns rc > 0 when there are events signaled, which need to be processed in the corresponding poller for loop. If a timer returns rc == -1 the loop is still skipped. 
