### PR TITLE
Fix dllexport declspec for static/DLL usage on Windows

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -467,7 +467,7 @@ static inline void *
 #   if defined DLL_EXPORT
 #       define CZMQ_EXPORT __declspec(dllexport)
 #   else
-#       define CZMQ_EXPORT __declspec(dllimport)
+#       define CZMQ_EXPORT
 #   endif
 #else
 #   define CZMQ_EXPORT


### PR DESCRIPTION
I don't think the dllimport is intended here. It causes external programs using the header to try and link the symbols only from a DLL, breaking static linking. Programs that dynamically link against czmq DLL should define DLL_EXPORT and will be fine.
