### PR TITLE
Enable callbacks on zframe_destroy

### DIFF
--- a/include/zframe.h
+++ b/include/zframe.h
@@ -116,6 +116,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zframe_reset (zframe_t *self, const void *data, size_t size);
 
+//  Set the free callback for frame
+CZMQ_EXPORT void
+    zframe_freefn(zframe_t *self, zframe_free_fn *free_fn, void *arg);
+
 //  Self test of this class
 CZMQ_EXPORT int
     zframe_test (bool verbose);


### PR DESCRIPTION
This patch is the same as one previously proposed by @methodmissing.

It can be seen in action here: https://github.com/methodmissing/rbczmq/commit/65b0db8e96235a2a81b3ae337c7f2bffbc00cf71
