### PR TITLE
fix zhash_foreach behavior

### DIFF
--- a/src/zhash.c
+++ b/src/zhash.c
@@ -446,7 +446,7 @@ zhash_foreach (zhash_t *self, zhash_foreach_fn *callback, void *argument)
             item_t *next = item->next;
             rc = callback (item->key, item->value, argument);
             if (rc)
-                break;          //  End if non-zero return code
+                return rc;      //  End if non-zero return code
             item = next;
         }
     }


### PR DESCRIPTION
Currently, zhash_foreach won't stop on non-zero return from zhash_foreach_fn. This is cause by having it only break from internal while loop (items with keys that produce the same hash index), while outer foreach continues. One option could be to add another if statement into the foreach loop, but that seemed slow. Feedback welcome.
