### PR TITLE
Add zero-copy version of zmsg_addmem

### DIFF
--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -229,7 +229,6 @@ zmsg_pushmem (zmsg_t *self, const void *src, size_t size)
         return -1;
 }
 
-
 //  --------------------------------------------------------------------------
 //  Add block of memory to the end of the message, as a new frame.
 
@@ -246,6 +245,22 @@ zmsg_addmem (zmsg_t *self, const void *src, size_t size)
         return -1;
 }
 
+//  --------------------------------------------------------------------------
+//  Add block of memory to the end of the message, as a new frame.
+//  The new frame is zero-copy-constructed (see zframe_new_zero_copy(...) for detailed description)
+
+int
+zmsg_addmem_zero_copy (zmsg_t *self, void *src, size_t size, zframe_free_fn *free_fn, void *arg)
+{
+    assert (self);
+    zframe_t *frame = zframe_new_zero_copy (src, size, free_fn, arg);
+    if (frame) {
+        self->content_size += size;
+        return zlist_append (self->frames, frame);
+    }
+    else
+        return -1;
+}
 
 //  --------------------------------------------------------------------------
 //  Push string as new frame to front of message


### PR DESCRIPTION
Currently it is not possible to add a zero-copy frame to a zmsg without first constructing it using zframe_new_zero_copy(...) and then adding it using zmsg_add(). This pull request adds zmsg_addmem_zero_copy(...).

In my particular use case, a large number of frames have content that is known at compile-time (therefore there's no need to memcpy() the constant data around and free() it later - I can use zframe_new_zero_copy() with a free function that does nothing) - I think if there's zmsg_addmem(...) as shortcut for zmsg_add(zframe_new(...)), there also should be zmsg_addmem_zero_copy(...) as shortcut for zmsg_add(zframe_new_zero_copy(...)).

Please feel free to tell me your opinion on this!
