### PR TITLE
Added zframe_sendmem + zero-copy version + tests

### DIFF
--- a/include/zframe.h
+++ b/include/zframe.h
@@ -70,6 +70,16 @@ CZMQ_EXPORT zframe_t *
 // non-zero error code on failure.
 CZMQ_EXPORT int
     zframe_send (zframe_t **self_p, void *socket, int flags);
+    
+// Create a new frame, send it to socket, destroy frame after sending.
+// Returns -1 on error, 0 on success
+CZMQ_EXPORT int
+zframe_sendmem (const void* data, size_t size, void *socket, int flags);
+
+// Create a new frame using zero-copy, send it to socket, destroy frame after sending.
+// Returns -1 on error, 0 on success
+CZMQ_EXPORT int
+zframe_sendmem_zero_copy (void *data, size_t size, zframe_free_fn *free_fn, void *hint, void *socket, int flags);
 
 //  Return number of bytes in frame data
 CZMQ_EXPORT size_t

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -215,6 +215,51 @@ zframe_send (zframe_t **self_p, void *zocket, int flags)
     return 0;
 }
 
+//  --------------------------------------------------------------------------
+//  Send data over a socket as if you would call zframe_new(...) followed by
+//  zframe_send(...).
+//  ZFRAME_REUSE flag is ignored in this function.
+
+int
+zframe_sendmem (const void* data, size_t size, void *zocket, int flags)
+{
+    assert (zocket);
+    assert (data);
+    
+    int snd_flags = (flags & ZFRAME_MORE)? ZMQ_SNDMORE : 0;
+    snd_flags |= (flags & ZFRAME_DONTWAIT)? ZMQ_DONTWAIT : 0;
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, size);
+    memcpy (zmq_msg_data(&msg), data, size);
+    int rc = zmq_sendmsg (zocket, &msg, snd_flags);
+    if(rc == -1) {
+        return -1;
+    }
+    return 0;
+}
+
+//  --------------------------------------------------------------------------
+//  Send data over a socket as if you would call zframe_new_zero_copy(...) followed by
+//  zframe_send(...).
+//  ZFRAME_REUSE flag is ignored in this function.
+
+int
+zframe_sendmem_zero_copy (void *data, size_t size, zframe_free_fn *free_fn, void *hint, void *zocket, int flags)
+{
+    assert (zocket);
+    assert (data);
+    
+    int snd_flags = (flags & ZFRAME_MORE)? ZMQ_SNDMORE : 0;
+    snd_flags |= (flags & ZFRAME_DONTWAIT)? ZMQ_DONTWAIT : 0;
+    zmq_msg_t msg;
+    zmq_msg_init_data(&msg, data, size, free_fn, hint);
+    int rc = zmq_sendmsg (zocket, &msg, snd_flags);
+    if(rc == -1) {
+        return -1;
+    }
+    return 0;
+}
+
 
 //  --------------------------------------------------------------------------
 //  Return size of frame.
@@ -454,6 +499,7 @@ zframe_test (bool verbose)
 {
     printf (" * zframe: ");
     int rc;
+    zframe_t* frame;
 
     //  @selftest
     zctx_t *ctx = zctx_new ();
@@ -465,16 +511,44 @@ zframe_test (bool verbose)
     void *input = zsocket_new (ctx, ZMQ_PAIR);
     assert (input);
     zsocket_connect (input, "inproc://zframe.test");
+    
+    //Test zframe_sendmem
+    rc = zframe_sendmem("ABC", 3, output, ZFRAME_MORE);
+    assert(rc == 0);
+    rc = zframe_sendmem("DEFG", 4, output, 0);
+    assert(rc == 0);
+    frame = zframe_recv(input);
+    assert(frame);
+    assert(zframe_streq(frame, "ABC"));
+    assert(zframe_more(frame));
+    frame = zframe_recv(input);
+    assert(frame);
+    assert(zframe_streq(frame, "DEFG"));
+    assert(!zframe_more(frame));
+    
+    //Test zframe_sendmem_zero_copy
+    rc = zframe_sendmem_zero_copy(strdup("ABC"), 3, s_test_free_cb, NULL, output, ZFRAME_MORE);
+    assert(rc == 0);
+    rc = zframe_sendmem_zero_copy(strdup("DEFG"), 4, s_test_free_cb, NULL, output, 0);
+    assert(rc == 0);
+    frame = zframe_recv(input);
+    assert(frame);
+    assert(zframe_streq(frame, "ABC"));
+    assert(zframe_more(frame));
+    frame = zframe_recv(input);
+    assert(frame);
+    assert(zframe_streq(frame, "DEFG"));
+    assert(!zframe_more(frame));
 
     //  Send five different frames, test ZFRAME_MORE
     int frame_nbr;
     for (frame_nbr = 0; frame_nbr < 5; frame_nbr++) {
-        zframe_t *frame = zframe_new ("Hello", 5);
+        frame = zframe_new ("Hello", 5);
         rc = zframe_send (&frame, output, ZFRAME_MORE);
         assert (rc == 0);
     }
     //  Send same frame five times, test ZFRAME_REUSE
-    zframe_t *frame = zframe_new ("Hello", 5);
+    frame = zframe_new ("Hello", 5);
     assert (frame);
     for (frame_nbr = 0; frame_nbr < 5; frame_nbr++) {
         rc = zframe_send (&frame, output, ZFRAME_MORE + ZFRAME_REUSE);


### PR DESCRIPTION
Currently you need to allocate a zframe_t on the heap and use zframe_send to send it. Additionally, this yields at least two SLOC.

This pull requests adds zframe_sendmem and zframe_sendmem_zero_copy.
These functions allow the user to send a ZMQ message part (=CZMQ frame) in a singl&e line (with or without MORE flag), without unneccessary heap allocations. Even if these functions do not use frames internally, I think the best place for them is zframe.c, because it looks like a wrapper for

```
zframe_t* frame = zframe_new();
zframe_send(&frame);
```

to the user.

Please feel free to comment!
