### PR TITLE
Added missing header decls

### DIFF
--- a/include/zframe.h
+++ b/include/zframe.h
@@ -51,6 +51,10 @@ CZMQ_EXPORT zframe_t *
     zframe_new_zero_copy (void *data, size_t size,
                           zframe_free_fn *free_fn, void *arg);
 
+//  Create an empty (zero-sized) frame
+CZMQ_EXPORT zframe_t *
+    zframe_new_empty ();
+
 //  Destroy a frame
 CZMQ_EXPORT void
     zframe_destroy (zframe_t **self_p);
@@ -115,6 +119,11 @@ CZMQ_EXPORT void
 //  Set new contents for frame
 CZMQ_EXPORT void
     zframe_reset (zframe_t *self, const void *data, size_t size);
+    
+//  Set new contents for frame, using zero copy.
+CZMQ_EXPORT void
+    zframe_reset_zero_copy (zframe_t *self, void *data, size_t size,
+                                zframe_free_fn *free_fn, void *arg);
 
 //  Set the free callback for frame
 CZMQ_EXPORT void

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -80,6 +80,12 @@ CZMQ_EXPORT int
 //  Returns 0 on success, -1 on error.
 CZMQ_EXPORT int
     zmsg_addmem (zmsg_t *self, const void *src, size_t size);
+    
+//  Push block of memory as new frame to end of message.
+//  The frame is constructed using zero-copy.
+//  Returns 0 on success, -1 on error.
+CZMQ_EXPORT int
+    zmsg_addmem_zero_copy (zmsg_t *self, void *src, size_t size, zframe_free_fn *free_fn, void *arg);
 
 //  Push string as new frame to front of message.
 //  Returns 0 on success, -1 on error.


### PR DESCRIPTION
In previous pull requests, see
https://github.com/zeromq/czmq/pull/156
https://github.com/zeromq/czmq/pull/155
https://github.com/zeromq/czmq/pull/153
I added some zmsg/zframe functionality.

Unfortunately I forgot to add function declarations to the headers because I assumed they are autogenerated.

This pull request adds these missing header function declarations.
