### PR TITLE
Issue #167

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -266,7 +266,6 @@
 #   include <pwd.h>
 #   include <grp.h>
 #   include <utime.h>
-#   include <syslog.h>
 #   include <inttypes.h>
 #   include <sys/types.h>
 #   include <sys/param.h>


### PR DESCRIPTION
This silly patch removes syslog.h dependency from czmq_prelude.h allowing the use of czmq.h with log systems that want to use LOG_\* macros.
