### PR TITLE
vsnprintf: use stack buffer

### DIFF
--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -273,10 +273,8 @@ zmsg_pushstr (zmsg_t *self, const char *format, ...)
 
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
-    if (!string) {
-        return -1;
-    }
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -290,7 +288,7 @@ zmsg_pushstr (zmsg_t *self, const char *format, ...)
 #endif
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
         if (!string) {
             return -1;
         }
@@ -303,7 +301,8 @@ zmsg_pushstr (zmsg_t *self, const char *format, ...)
 
     self->content_size += size;
     zlist_push (self->frames, zframe_new (string, size));
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return 0;
 }
 
@@ -318,10 +317,8 @@ zmsg_addstr (zmsg_t *self, const char *format, ...)
     assert (format);
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
-    if (!string) {
-        return -1;
-    }
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -335,7 +332,7 @@ zmsg_addstr (zmsg_t *self, const char *format, ...)
 #endif    
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
         if (!string) {
             return -1;
         }
@@ -349,7 +346,8 @@ zmsg_addstr (zmsg_t *self, const char *format, ...)
 
     self->content_size += size;
     zlist_append (self->frames, zframe_new (string, size));
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return 0;
 }
 

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -108,7 +108,8 @@ zstr_send (void *zocket, const char *format, ...)
     assert (format);
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -122,14 +123,17 @@ zstr_send (void *zocket, const char *format, ...)
 #endif
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
+        if (!string)
+            return -1;
         va_start (argptr, format);
         vsnprintf (string, size, format, argptr);
         va_end (argptr);
     }
 
     int rc = s_send_string (zocket, false, string);
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return rc;
 }
 
@@ -141,7 +145,8 @@ zstr_sendf (void *zocket, const char *format, ...)
     assert (format);
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -155,14 +160,17 @@ zstr_sendf (void *zocket, const char *format, ...)
 #endif
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
+        if (!string)
+            return -1;
         va_start (argptr, format);
         vsnprintf (string, size, format, argptr);
         va_end (argptr);
     }
 
     int rc = s_send_string (zocket, false, string);
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return rc;
 }
 
@@ -177,7 +185,8 @@ zstr_sendm (void *zocket, const char *format, ...)
     assert (format);
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -191,14 +200,17 @@ zstr_sendm (void *zocket, const char *format, ...)
 #endif
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
+        if (!string)
+            return -1;
         va_start (argptr, format);
         vsnprintf (string, size, format, argptr);
         va_end (argptr);
     }
 
     int rc = s_send_string (zocket, true, string);
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return rc;
 }
 
@@ -210,7 +222,8 @@ zstr_sendfm (void *zocket, const char *format, ...)
     assert (format);
     //  Format string into buffer
     int size = 255 + 1;
-    char *string = (char *) malloc (size);
+    char stackbuffer[255+1];
+    char *string = stackbuffer;
     va_list argptr;
     va_start (argptr, format);
     int required = vsnprintf (string, size, format, argptr);
@@ -224,14 +237,17 @@ zstr_sendfm (void *zocket, const char *format, ...)
 #endif
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        string = (char *) malloc (size);
+        if (!string)
+            return -1;
         va_start (argptr, format);
         vsnprintf (string, size, format, argptr);
         va_end (argptr);
     }
 
     int rc = s_send_string (zocket, true, string);
-    free (string);
+    if (string!=stackbuffer)
+        free (string);
     return rc;
 }
 


### PR DESCRIPTION
this also fixes a leak in usage of realloc. when realloc fails, original buffer was not freed.
