### PR TITLE
zloop_poller_end

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -413,6 +413,13 @@ zloop_start (zloop_t *self)
                 rc = poller->handler (self, &self->pollset [item_nbr], poller->arg);
                 if (rc == -1)
                     break;      //  Poller handler signaled break
+                // If the poller handler calls zloop_poller_end on poller other than itself
+                // we need to force rebuild in order to avoid reading from freed memory in the handler
+                if (self->dirty) {
+                    if (self->verbose)
+                        zclock_log ("I: zloop: pollers canceled, forcing rebuild");
+                    break;
+                }
             }
         }
         //  Now handle any timer zombies


### PR DESCRIPTION
Disclaimer: I have not tested this extensively but logically this should work.

The issue: At the moment there is no clean way to terminate socket from other handler than the one for that specific socket. The problem is that if a handler terminates socket and calls zloop_poller_end the for loop here will still trigger if there are events pending and a potentially uninitialised socket is accessed.

Solution: self->dirty is checked in the loop after handler and rebuild is done in case there has been pollers ended

Comments?
