### PR TITLE
Generates a more informative assert when the user calls zsocket_destroy with a void** instead of a void*

### DIFF
--- a/src/zsockopt.c
+++ b/src/zsockopt.c
@@ -885,7 +885,7 @@ zsocket_set_linger (void *zocket, int linger)
 {
 #   if defined (ZMQ_LINGER)
     int rc = zmq_setsockopt (zocket, ZMQ_LINGER, &linger, sizeof (int));
-    assert (rc == 0 || errno == ETERM || errno == ENOTSOCK);
+    assert ((rc == 0 || errno == ETERM) && "Are you passing a void** instead of a void*?");
 #   endif
 }
 


### PR DESCRIPTION
Related issues #164 and #175
