### PR TITLE
Marking zero-copy methods as deprecated

### DIFF
--- a/include/zframe.h
+++ b/include/zframe.h
@@ -39,17 +39,9 @@ typedef struct _zframe_t zframe_t;
 #define ZFRAME_REUSE    2
 #define ZFRAME_DONTWAIT 4
 
-//  Callback function for zframe_free_fn method
-typedef void (zframe_free_fn) (void *data, void *arg);
-
 //  Create a new frame with optional size, and optional data
 CZMQ_EXPORT zframe_t *
     zframe_new (const void *data, size_t size);
-
-//  Create a zero-copy frame
-CZMQ_EXPORT zframe_t *
-    zframe_new_zero_copy (void *data, size_t size,
-                          zframe_free_fn *free_fn, void *arg);
 
 //  Create an empty (zero-sized) frame
 CZMQ_EXPORT zframe_t *
@@ -99,10 +91,6 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT bool
     zframe_streq (zframe_t *self, const char *string);
 
-// Return frame zero copy indicator (1 or 0)
-CZMQ_EXPORT int
-    zframe_zero_copy (zframe_t *self);
-
 //  Return frame 'more' property
 CZMQ_EXPORT int
     zframe_more (const zframe_t *self);
@@ -120,7 +108,23 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zframe_reset (zframe_t *self, const void *data, size_t size);
 
+//  Callback function for zframe_free_fn method
+//  DEPRECATED - will be removed for next stable release
+typedef void (zframe_free_fn) (void *data, void *arg);
+
+//  Create a zero-copy frame
+//  DEPRECATED - will be removed for next stable release
+CZMQ_EXPORT zframe_t *
+    zframe_new_zero_copy (void *data, size_t size,
+                          zframe_free_fn *free_fn, void *arg);
+
+// Return frame zero copy indicator (1 or 0)
+//  DEPRECATED - will be removed for next stable release
+CZMQ_EXPORT int
+    zframe_zero_copy (zframe_t *self);
+
 //  Set the free callback for frame
+//  DEPRECATED - will be removed at next stable release
 CZMQ_EXPORT void
     zframe_freefn (zframe_t *self, zframe_free_fn *free_fn, void *arg);
 

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -81,12 +81,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zmsg_addmem (zmsg_t *self, const void *src, size_t size);
     
-//  Push block of memory as new frame to end of message.
-//  The frame is constructed using zero-copy.
-//  Returns 0 on success, -1 on error.
-CZMQ_EXPORT int
-    zmsg_addmem_zero_copy (zmsg_t *self, void *src, size_t size, zframe_free_fn *free_fn, void *arg);
-
 //  Push string as new frame to front of message.
 //  Returns 0 on success, -1 on error.
 CZMQ_EXPORT int
@@ -152,6 +146,13 @@ CZMQ_EXPORT zmsg_t *
 //  Print message to stderr, for debugging
 CZMQ_EXPORT void
     zmsg_dump (zmsg_t *self);
+
+//  Push block of memory as new frame to end of message.
+//  The frame is constructed using zero-copy.
+//  Returns 0 on success, -1 on error.
+//  DEPRECATED - will be removed for next stable release
+CZMQ_EXPORT int
+    zmsg_addmem_zero_copy (zmsg_t *self, void *src, size_t size, zframe_free_fn *free_fn, void *arg);
 
 //  Self test of this class
 CZMQ_EXPORT int

--- a/include/zsocket.h
+++ b/include/zsocket.h
@@ -86,6 +86,7 @@ CZMQ_EXPORT int
 
 //  Send data over a socket as a single frame
 //  Returns -1 on error, 0 on success
+//  DEPRECATED - will be removed for next stable release
 CZMQ_EXPORT int
     zsocket_sendmem_zero_copy (void *socket, void *data, size_t size, 
                                zsocket_free_fn *free_fn,

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -95,6 +95,12 @@ zframe_new_empty (void)
 //  Constructor; Allows zero-copy semantics.
 //  Zero-copy frame is initialised if data != NULL, size > 0, free_fn != 0
 //  'arg' is a void pointer that is passed to free_fn as second argument
+//  NOTE: this method is DEPRECATED and is slated for removal. These are the
+//  problems with the method:
+//  - premature optimization: do we really need this? It makes the API more
+//    complex; high-performance applications would not use zmsg in any case,
+//    they would work directly with zmq_msg objects.
+//  (PH, 2013/05/18)
 
 zframe_t *
 zframe_new_zero_copy (void *data, size_t size, zframe_free_fn *free_fn, void *arg)
@@ -311,7 +317,10 @@ zframe_more (const zframe_t *self)
 }
 
 // --------------------------------------------------------------------------
-// Return frame zero copy indicator (1 or 0)
+//  Return frame zero copy indicator (1 or 0)
+//  NOTE: this method is DEPRECATED and is slated for removal.
+//  Attached to zframe_new_zero_copy
+//  (PH, 2013/05/18)
 
 int
 zframe_zero_copy (zframe_t *self)
@@ -389,6 +398,13 @@ zframe_reset (zframe_t *self, const void *data, size_t size)
 
 //  --------------------------------------------------------------------------
 //  Set the free callback for frame
+//  NOTE: this method is DEPRECATED and is slated for removal. These are the
+//  problems with the method:
+//  - name is not accurate, should be "set_free_fn"
+//  - use case is unclear - why do we need this method?
+//  - fuzzy overlap with existing semantics - reuses zero-copy free_fn but 
+//    is not actually zero-copy.
+//  (PH, 2013/05/18)
 
 void
 zframe_freefn (zframe_t *self, zframe_free_fn *free_fn, void *arg)

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -247,7 +247,14 @@ zmsg_addmem (zmsg_t *self, const void *src, size_t size)
 
 //  --------------------------------------------------------------------------
 //  Add block of memory to the end of the message, as a new frame.
-//  The new frame is zero-copy-constructed (see zframe_new_zero_copy(...) for detailed description)
+//  The new frame is zero-copy-constructed (see zframe_new_zero_copy(...) 
+//  for detailed description)
+//  NOTE: this method is DEPRECATED and is slated for removal. These are the
+//  problems with the method:
+//  - premature optimization: do we really need this? It makes the API more
+//    complex; high-performance applications would not use zmsg in any case,
+//    they would work directly with zmq_msg objects.
+//  (PH, 2013/05/18)
 
 int
 zmsg_addmem_zero_copy (zmsg_t *self, void *src, size_t size, zframe_free_fn *free_fn, void *arg)

--- a/src/zsocket.c
+++ b/src/zsocket.c
@@ -194,6 +194,13 @@ zsocket_sendmem (void *zocket, const void* data, size_t size, int flags)
 //  --------------------------------------------------------------------------
 //  Send data over a socket as a single message frame
 //  Accepts these flags: ZFRAME_MORE and ZFRAME_DONTWAIT.
+//  NOTE: this method is DEPRECATED and is slated for removal. These are the
+//  problems with the method:
+//  - premature optimization: do we really need this? It makes the API more
+//    complex; high-performance applications would not use this in any case,
+//    they would work directly with zmq_msg objects.
+//  - selftest method leaks memory
+//  (PH, 2013/05/18)
 
 int
 zsocket_sendmem_zero_copy (void *zocket, void *data, size_t size,
@@ -206,8 +213,7 @@ zsocket_sendmem_zero_copy (void *zocket, void *data, size_t size,
     snd_flags |= (flags & ZFRAME_DONTWAIT)? ZMQ_DONTWAIT : 0;
     
     zmq_msg_t msg;
-    zmq_msg_init_data(&msg, data, size, free_fn, hint);
-    
+    zmq_msg_init_data (&msg, data, size, free_fn, hint);
     int rc = zmq_sendmsg (zocket, &msg, snd_flags);
     return rc == -1? -1: 0;
 }


### PR DESCRIPTION
I'd like to move these to a single module (e.g. znocopy) because they make the other APIs complex and nasty, and it's possibly a case of premature optimization. If we really want a zero-copy API we should find a neater API for it, the current design where we pass free_fn's around is nasty.
