### PR TITLE
Incorporation of ZMQ_STREAM socket type

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -46,7 +46,7 @@ CZMQ_EXPORT void
 //  Use this to force the interface for beacons
 //  This is experimental; may be merged into zbeacon class.
 CZMQ_EXPORT void
-    zsys_set_interface (char *interface);
+    zsys_set_interface (char *iinterface);
 
 //  Return network interface name to use for broadcasts.
 //  Returns "" if no interface was set.

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -141,7 +141,7 @@ void
 zconfig_put (zconfig_t *self, const char *path, const char *value)
 {
     //  Check length of next path segment
-    char *slash = strchr (path, '/');
+    const char *slash = strchr (path, '/');
     int length = strlen (path);
     if (slash)
         length = slash - path;
@@ -243,7 +243,7 @@ zconfig_t *
 zconfig_locate (zconfig_t *self, const char *path)
 {
     //  Check length of next path segment
-    char *slash = strchr (path, '/');
+    const char *slash = strchr (path, '/');
     int length = strlen (path);
     if (slash)
         length = slash - path;

--- a/src/zsocket.c
+++ b/src/zsocket.c
@@ -159,10 +159,10 @@ zsocket_type_str (void *self)
     char *type_name [] = {
         "PAIR", "PUB", "SUB", "REQ", "REP",
         "DEALER", "ROUTER", "PULL", "PUSH",
-        "XPUB", "XSUB"
+        "XPUB", "XSUB", "STREAM"
     };
     int type = zsockopt_type (self);
-    if (type < 0 || type > ZMQ_XSUB)
+    if (type < 0 || type > ZMQ_STREAM)
         return "UNKNOWN";
     else
         return type_name [type];

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -101,10 +101,10 @@ zsys_handler_reset (void)
 static char *s_interface = NULL;
 
 void
-zsys_set_interface (char *interface)
+zsys_set_interface (char *iinterface)
 {
     free (s_interface);
-    s_interface = strdup (interface);
+    s_interface = strdup (iinterface);
 }
 
 


### PR DESCRIPTION
Tested for ZMQ_STREAM in zsocket_type function.

Changed variable name interface to iinterface, char\* to const char\* to
allow compilation with MSVC 2012

Signed-off-by: Gavin gavin@mcniff.ie
