### PR TITLE
zmsg_load should return NULL if unable to load msg

### DIFF
--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -125,7 +125,8 @@ CZMQ_EXPORT int
     zmsg_save (zmsg_t *self, FILE *file);
 
 //  Load/append an open file into message, create new message if
-//  null message provided.
+//  null message provided. Returns NULL if the message could not 
+//  be loaded.
 CZMQ_EXPORT zmsg_t *
     zmsg_load (zmsg_t *self, FILE *file);
 


### PR DESCRIPTION
The comments above the zmsg_load function in the zmsg.c file indicate that in a error condition the return value should be NULL. Instead it seems that an empty zmsg_t is returned. Updated to return NULL in error condition and zmsg_test function updated.
