### PR TITLE
Support separate lib and include install directories for libzmq.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ William Roberts <bill.c.roberts@gmail.com>
 AJ Lewis <aj.lewis@quantum.com>
 Philip Kovacs
 Kaustubh Rawoorkar <kaustubh.rawoorkar@quantum.com>
+Patrick Noffke <patrick.noffke@gmail.com>

--- a/configure.ac
+++ b/configure.ac
@@ -77,10 +77,26 @@ if test "x$czmq_search_libzmq" = "xyes"; then
     if test -r "${with_libzmq}/include/zmq.h"; then
         CFLAGS="-I${with_libzmq}/include ${CFLAGS}"
         LDFLAGS="-L${with_libzmq}/lib ${LDFLAGS}"
-    else
-        AC_MSG_ERROR([${with_libzmq}/include/zmq.h not found. Please check libzmq prefix])
     fi
 fi
+
+AC_ARG_WITH([libzmq-include-dir],
+            [AS_HELP_STRING([--with-libzmq-include-dir],
+                            [Specify libzmq include prefix])],
+            [czmq_search_libzmq_include="yes"],
+            [])
+
+if test "x$czmq_search_libzmq_include" = "xyes"; then
+    if test -r "${with_libzmq_include_dir}/include/zmq.h"; then
+        CFLAGS="-I${with_libzmq_include_dir}/include ${CFLAGS}"
+    fi
+fi
+
+AC_ARG_WITH([libzmq_lib_dir],
+            [AS_HELP_STRING([--with-libzmq-lib-dir],
+                            [Specify libzmq library prefix])],
+            [czmq_search_libzmq_lib="yes"],
+            [])
 
 AC_CHECK_LIB(zmq, zmq_init, ,[AC_MSG_ERROR([cannot link with -lzmq, install libzmq.])])
 


### PR DESCRIPTION
Added --with-libzmq-include-dir and --with-libzmq-lib-dir configure options.
If --with-libzmq is set, both CFLAGS and LDFLAGS are set using that prefix.
If --with-libzmq-include-dir or --with-libzmq-lib-dir are set, the CFLAGS
and LDFLAGS are set using those prefixes, respectively.  The new configure
options override --with-libzmq, if set.
