### PR TITLE
Ensure zctx_destroy ignores NULL zockets, instead of asserting

### DIFF
--- a/src/zctx.c
+++ b/src/zctx.c
@@ -292,9 +292,10 @@ void
 zctx__socket_destroy (zctx_t *self, void *zocket)
 {
     assert (self);
-    assert (zocket);
-    zsocket_set_linger (zocket, self->linger);
-    zmq_close (zocket);
+    if(zocket != NULL) {
+        zsocket_set_linger (zocket, self->linger);
+        zmq_close (zocket);
+    }
     zlist_remove (self->sockets, zocket);
 }
 


### PR DESCRIPTION
My application can be canceled using Ctrl+C / SIGINT, but in about 20% of the cases the following assertion fails:

```
zctx.c:295: zctx__socket_destroy: Assertion `zocket' failed.
```

The fails seem to be random. Most sockets should destroyed before _zctx_destroy()_ is called.

I think _zctx_destroy()_ should never fail an assertion. I'm not sure why _NULL_ zockets are inserted into the _zctx_ socket list, but this PR at least fixes the symptom of a failing assertion and just skips _NULL_ sockets.
