### PR TITLE
Add zmutex_try_lock

### DIFF
--- a/include/zmutex.h
+++ b/include/zmutex.h
@@ -50,6 +50,11 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zmutex_unlock (zmutex_t *self);
 
+//  Try to lock mutex
+CZMQ_EXPORT int
+    zmutex_try_lock (zmutex_t *self);
+
+
 //  Self test of this class
 CZMQ_EXPORT int
     zmutex_test (bool verbose);


### PR DESCRIPTION
dds this and zmutex is currently missing a try_lock function.
This pull request adds zmutex_try_lock and a corresponding unit test.

Please test the WINAPI implementation before merging this, I can currently only test the pthread implementation
