### PR TITLE
close file before delete

### DIFF
--- a/src/zfile.c
+++ b/src/zfile.c
@@ -446,6 +446,7 @@ zfile_test (bool verbose)
     assert (chunk);
     assert (zchunk_size (chunk) == 1000100);
     zchunk_destroy (&chunk);
+    zfile_close (file);
 
     //  Remove file and directory
     zdir_t *dir = zdir_new ("./this", NULL);


### PR DESCRIPTION
zfile_test() was failing under Windows.
Test file "bilbo" could not be deleted as it was still open.
