### PR TITLE
zbeacon broadcast address patch and interface selection fix

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -551,6 +551,11 @@ s_get_interface (agent_t *self)
                 self->broadcast = *(inaddr_t *) interface->ifa_broadaddr;
                 self->broadcast.sin_port = htons (self->port_nbr);
 
+                //  If the returned broadcast address is the same as source address build
+                //  the broadcast address from the source address and netmask.
+                if (self->address.sin_addr.s_addr == self->broadcast.sin_addr.s_addr)
+                   self->broadcast.sin_addr.s_addr |= ~(((inaddr_t *) interface->ifa_netmask)->sin_addr.s_addr);
+
                 //  If an interface was specified and this is it OR if no interface was
                 //  specified and this is a wireless interface then desired interface found.
                 if (strlen (zsys_interface ()) != 0) {
@@ -562,11 +567,6 @@ s_get_interface (agent_t *self)
                     break;
             }
             interface = interface->ifa_next;
-        }
-        //  If the returned broadcast address is the same as source address build
-        //  the broadcast address from the source address and netmask.
-        if (self->address.sin_addr.s_addr == self->broadcast.sin_addr.s_addr) {
-            self->broadcast.sin_addr.s_addr &= ((inaddr_t *) interface->ifa_netmask)->sin_addr.s_addr;
         }
     }
     freeifaddrs (interfaces);


### PR DESCRIPTION
On Ubunutu 11.10 Server the broadcast address returned by getifaddrs() is
the same as the interface address. This patch derives the broadcast address
from the interface address and the netmask if this occurs.

Also fixed bug that would potentially choose the wireless interface over
the specified interface if it was encountered first.
