### PR TITLE
﻿make zbeacon interface selection more robust

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ AJ Lewis <aj.lewis@quantum.com>
 Philip Kovacs
 Kaustubh Rawoorkar <kaustubh.rawoorkar@quantum.com>
 Patrick Noffke <patrick.noffke@gmail.com>
+Shane Hubred <shane@hubred.us>


### PR DESCRIPTION
- Bug fix: s_get_interface() was checking for NULL pointer instead
  of empty string to determine if the interface was set.
- If the interface isn't set then the source address and thus the
  hostname wasn't being populated. Now if there is only one IP
  address on the it is set as source address; otherwise it is set
  to INADDR_ANY.
- Commented out s_wireless_nic() function and removed call to it as
  it was not doing anything. Previous to pull request #264 it would
  "select" the wireless interface or the specified interface,
  whichever was encountered first (bug). But right after that the
  broadcast address was being hard coded to INADDR_BROADCAST which
  nullified the selected address/interface.
