### PR TITLE
Classes that return allocated values now provide a free method

### DIFF
--- a/doc/zstr.txt
+++ b/doc/zstr.txt
@@ -8,11 +8,16 @@ zstr - sending and receiving strings
 SYNOPSIS
 --------
 ----
-//  Receive a string off a socket, caller must free it
+//  Receive C string from socket. Caller must free returned string using
+//  zstr_free(). Returns NULL if the context is being terminated or the
+//  process was interrupted.
 CZMQ_EXPORT char *
     zstr_recv (void *socket);
 
-//  Receive a string off a socket if socket had input waiting
+//  Receive C string from socket, if socket had input ready. Caller must
+//  free returned string using zstr_free. Returns NULL if there was no input
+//  waiting, or if the context was terminated. Use zctx_interrupted to exit
+//  any loop that relies on this method.
 CZMQ_EXPORT char *
     zstr_recv_nowait (void *socket);
 
@@ -29,13 +34,19 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zstr_sendx (void *socket, const char *string, ...);
 
-//  Receive a series of strings (until NULL) from multipart data
+//  Receive a series of strings (until NULL) from multipart data.
 //  Each string is allocated and filled with string data; if there
 //  are not enough frames, unallocated strings are set to NULL.
 //  Returns -1 if the message could not be read, else returns the
-//  number of strings filled, zero or more.
+//  number of strings filled, zero or more. Free each returned string
+//  using zstr_free().
 CZMQ_EXPORT int
     zstr_recvx (void *socket, char **string_p, ...);
+
+//  Free a provided string, and nullify the parent pointer. Safe to call on
+//  a null pointer.
+CZMQ_EXPORT void
+    zstr_free (char **string_p);
 
 //  Self test of this class
 CZMQ_EXPORT int
@@ -76,10 +87,10 @@ EXAMPLE
     for (string_nbr = 0;; string_nbr++) {
         char *string = zstr_recv (input);
         if (streq (string, "END")) {
-            free (string);
+            zstr_free (&string);
             break;
         }
-        free (string);
+        zstr_free (&string);
     }
     assert (string_nbr == 15);
 

--- a/include/zclock.h
+++ b/include/zclock.h
@@ -44,7 +44,7 @@ CZMQ_EXPORT int64_t
 CZMQ_EXPORT void
     zclock_log (const char *format, ...);
 
-//  Return formatted date/time as fresh string.
+//  Return formatted date/time as fresh string. Free using zstr_free().
 CZMQ_EXPORT char *
     zclock_timestr (void);
 

--- a/include/zdir.h
+++ b/include/zdir.h
@@ -61,12 +61,17 @@ CZMQ_EXPORT size_t
     zdir_count (zdir_t *self);
     
 //  Returns a sorted array of zfile objects; returns a single block of memory,
-//  that you destroy by calling free(). Each entry in the array is a pointer
+//  that you destroy by calling zstr_free(). Each entry in the array is a pointer
 //  to a zfile_t item already allocated in the zdir tree. The array ends with
 //  a null pointer. Do not destroy the original zdir tree until you are done
 //  with this array.
 CZMQ_EXPORT zfile_t **
     zdir_flatten (zdir_t *self);
+
+//  Free a provided string, and nullify the parent pointer. Safe to call on
+//  a null pointer.
+CZMQ_EXPORT void
+    zdir_flatten_free (zfile_t ***files_p);
 
 //  Print contents of directory to stderr
 CZMQ_EXPORT void

--- a/include/zstr.h
+++ b/include/zstr.h
@@ -31,11 +31,16 @@ extern "C" {
 #endif
 
 //  @interface
-//  Receive a string off a socket, caller must free it
+//  Receive C string from socket. Caller must free returned string using
+//  zstr_free(). Returns NULL if the context is being terminated or the
+//  process was interrupted.
 CZMQ_EXPORT char *
     zstr_recv (void *socket);
 
-//  Receive a string off a socket if socket had input waiting
+//  Receive C string from socket, if socket had input ready. Caller must
+//  free returned string using zstr_free. Returns NULL if there was no input
+//  waiting, or if the context was terminated. Use zctx_interrupted to exit
+//  any loop that relies on this method.
 CZMQ_EXPORT char *
     zstr_recv_nowait (void *socket);
 
@@ -52,13 +57,19 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zstr_sendx (void *socket, const char *string, ...);
 
-//  Receive a series of strings (until NULL) from multipart data
+//  Receive a series of strings (until NULL) from multipart data.
 //  Each string is allocated and filled with string data; if there
 //  are not enough frames, unallocated strings are set to NULL.
 //  Returns -1 if the message could not be read, else returns the
-//  number of strings filled, zero or more.
+//  number of strings filled, zero or more. Free each returned string
+//  using zstr_free().
 CZMQ_EXPORT int
     zstr_recvx (void *socket, char **string_p, ...);
+
+//  Free a provided string, and nullify the parent pointer. Safe to call on
+//  a null pointer.
+CZMQ_EXPORT void
+    zstr_free (char **string_p);
 
 //  Self test of this class
 CZMQ_EXPORT int

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -98,7 +98,8 @@ CZMQ_EXPORT void
     zsys_file_mode_default (void);
 
 //  Format a string with variable arguments, returning a freshly allocated
-//  buffer. If there was insufficient memory, returns NULL.
+//  buffer. If there was insufficient memory, returns NULL. Free the returned
+//  string using zstr_free().
 CZMQ_EXPORT char *
     zsys_vprintf (const char *format, va_list argptr);
 

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -131,7 +131,8 @@ zbeacon_destroy (zbeacon_t **self_p)
     if (*self_p) {
         zbeacon_t *self = *self_p;
         zstr_send (self->pipe, "TERMINATE");
-        free (zstr_recv (self->pipe));
+        char *reply = zstr_recv (self->pipe);
+        zstr_free (&reply);
         zctx_destroy (&self->ctx);
         free (self->hostname);
         free (self);
@@ -273,7 +274,7 @@ zbeacon_test (bool verbose)
                         +  zframe_data (content) [1];
         assert (received_port == port_nbr);
         zframe_destroy (&content);
-        free (ipaddress);
+        zstr_free (&ipaddress);
     }
     zbeacon_destroy (&client_beacon);
     zbeacon_destroy (&service_beacon);
@@ -313,8 +314,8 @@ zbeacon_test (bool verbose)
             char *ipaddress, *beacon;
             zstr_recvx (zbeacon_socket (node1), &ipaddress, &beacon, NULL);
             assert (streq (beacon, "NODE/2"));
-            free (ipaddress);
-            free (beacon);
+            zstr_free (&ipaddress);
+            zstr_free (&beacon);
         }
     }
     zpoller_destroy (&poller);
@@ -387,7 +388,7 @@ s_agent_task (void *args, zctx_t *ctx, void *pipe)
 
     //  Create agent instance
     agent_t *self = s_agent_new (pipe, atoi (port_str));
-    free (port_str);
+    zstr_free (&port_str);
 
     while (!zctx_interrupted) {
         //  Poll on API pipe and on UDP socket
@@ -682,7 +683,7 @@ s_api_command (agent_t *self)
     if (streq (command, "INTERVAL")) {
         char *interval = zstr_recv (self->pipe);
         self->interval = atoi (interval);
-        free (interval);
+        zstr_free (&interval);
     }
     else
     if (streq (command, "NOECHO"))
@@ -714,7 +715,7 @@ s_api_command (agent_t *self)
     else
         printf ("E: unexpected API command '%s'\n", command);
     
-    free (command);
+    zstr_free (&command);
 }
 
 //  Receive and filter the waiting beacon

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -186,7 +186,7 @@ zcert_set_meta (zcert_t *self, char *name, char *format, ...)
     char *value = zsys_vprintf (format, argptr);
     va_end (argptr);
     zhash_insert (self->metadata, name, value);
-    free (value);
+    zstr_free (&value);
 }
 
 
@@ -246,7 +246,7 @@ zcert_load (char *format, ...)
         }
     }
     zconfig_destroy (&root);
-    free (filename);
+    zstr_free (&filename);
     return self;
 #else   
     return NULL;
@@ -277,7 +277,7 @@ s_save_metadata_all (zcert_t *self)
     
     char *timestr = zclock_timestr ();
     zconfig_comment (self->config, "   ****  Generated on %s by CZMQ  ****", timestr);
-    free (timestr);
+    zstr_free (&timestr);
 }
 
 
@@ -307,7 +307,7 @@ zcert_save (zcert_t *self, char *format, ...)
     int rc = zconfig_save (self->config, filename_secret);
     zsys_file_mode_default ();
     
-    free (filename);
+    zstr_free (&filename);
     return rc;
 }
 
@@ -334,7 +334,7 @@ zcert_save_public (zcert_t *self, char *format, ...)
     
     zconfig_put (self->config, "/curve/public-key", self->public_txt);
     int rc = zconfig_save (self->config, filename);
-    free (filename);
+    zstr_free (&filename);
     return rc;
 }
 

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -133,7 +133,7 @@ s_load_certs_from_disk (zcertstore_t *self)
                     zcertstore_insert (self, &cert);
             }
         }
-        free (filelist);
+        zdir_flatten_free (&filelist);
         self->modified = zdir_modified (dir);
         self->count = zdir_count (dir);
         self->cursize = zdir_cursize (dir);

--- a/src/zclock.c
+++ b/src/zclock.c
@@ -125,7 +125,7 @@ zclock_log (const char *format, ...)
 
 
 //  --------------------------------------------------------------------------
-//  Return formatted date/time as fresh string.
+//  Return formatted date/time as fresh string. Free using zstr_free().
 
 char *
 zclock_timestr (void)

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -259,10 +259,10 @@ zdir_count (zdir_t *self)
 
 //  --------------------------------------------------------------------------
 //  Returns a sorted array of zfile objects; returns a single block of memory,
-//  that you destroy by calling free(). Each entry in the array is a pointer
-//  to a zfile_t item already allocated in the zdir tree. The array ends with
-//  a null pointer. Do not destroy the original zdir tree until you are done
-//  with this array.
+//  that you destroy by calling zdir_flatten_free(). Each entry in the array
+//  is a pointer to a zfile_t item already allocated in the zdir tree. The
+//  array ends with a null pointer. Do not destroy the original zdir tree
+//  until you are done with this array.
 
 static int  s_dir_flatten (zdir_t *self, zfile_t **files, int index);
 static bool s_dir_compare (void *item1, void *item2);
@@ -333,6 +333,19 @@ s_file_compare (void *item1, void *item2)
 
 
 //  --------------------------------------------------------------------------
+//  Free a provided string, and nullify the parent pointer. Safe to call on
+//  a null pointer.
+
+void
+zdir_flatten_free (zfile_t ***files_p)
+{
+    assert (files_p);
+    free (*files_p);
+    *files_p = NULL;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Print contents of directory
 
 void
@@ -348,7 +361,7 @@ zdir_dump (zdir_t *self, int indent)
             break;
         puts (zfile_filename (file, NULL));
     }
-    free (files);
+    zdir_flatten_free (&files);
 }
 
 

--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -206,7 +206,7 @@ zpoller_test (bool verbose)
     assert (zpoller_terminated (poller) == false);
     char *message = zstr_recv (which);
     assert (streq (message, "Hello, World"));
-    free (message);
+    zstr_free (&message);
     
     //  Destroy poller and context
     zpoller_destroy (&poller);

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -324,7 +324,8 @@ zsys_file_mode_default (void)
 
 //  --------------------------------------------------------------------------
 //  Format a string with variable arguments, returning a freshly allocated
-//  buffer. If there was insufficient memory, returns NULL.
+//  buffer. If there was insufficient memory, returns NULL. Free the returned
+//  string using zstr_free().
  
 char *
 zsys_vprintf (const char *format, va_list argptr)
@@ -395,7 +396,7 @@ zsys_test (bool verbose)
 
     char *string = s_vprintf ("%s %02x", "Hello", 16);
     assert (streq (string, "Hello 10"));
-    free (string);
+    zstr_free (&string);
     //  @end
     
     printf ("OK\n");

--- a/src/zthread.c
+++ b/src/zthread.c
@@ -231,7 +231,8 @@ s_test_attached (void *args, zctx_t *ctx, void *pipe)
     //  Create a socket to check it'll be automatically deleted
     zsocket_new (ctx, ZMQ_PUSH);
     //  Wait for our parent to ping us, and pong back
-    free (zstr_recv (pipe));
+    char *ping = zstr_recv (pipe);
+    zstr_free (&ping);
     zstr_send (pipe, "pong");
 }
 
@@ -258,7 +259,7 @@ zthread_test (bool verbose)
     zstr_send (pipe, "ping");
     char *pong = zstr_recv (pipe);
     assert (streq (pong, "pong"));
-    free (pong);
+    zstr_free (&pong);
 
     //  Everything should be cleanly closed now
     zctx_destroy (&ctx);


### PR DESCRIPTION
- zstr_free for strings
- zdir_flatten_free for file lists

This ensures frees are done in the same compile unit as mallocs,
which is necessary when using CZMQ in a DLL that may use a heap
separate from the caller's heap.
