### PR TITLE
test against __WINDOWS__ not __WIN32__

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -106,7 +106,7 @@ zsys_handler_reset (void)
         sigterm_default.sa_handler = NULL;
         s_first_time = true;
     }
-#elif defined (__WIN32__)
+#elif defined (__WINDOWS__)
     if (s_shim_installed) {
         SetConsoleCtrlHandler (s_handler_fn_shim, FALSE);
         s_shim_installed = false;


### PR DESCRIPTION
**WIN32** was defined by MinGW though
