### PR TITLE
add additional test for zsys_vprintf exposing bug in implementation

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -424,6 +424,12 @@ zsys_test (bool verbose)
     char *string = s_vprintf ("%s %02x", "Hello", 16);
     assert (streq (string, "Hello 10"));
     zstr_free (&string);
+
+    char *str64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890,.";
+    int num10 = 1234567890;
+    string = s_vprintf ("%s%s%s%s%d", str64, str64, str64, str64, num10);
+    assert (strlen (string) == (4*64+10));
+    zstr_free (&string);
     //  @end
     
     printf ("OK\n");


### PR DESCRIPTION
The refactoring of vsnprintf code from zstr.c to zsys.c has created a bug that is exposed by this test.
This test has been executed on the following platforms:
Windows 32-bits: passes
Linux 64-bits: segfaults

The reason: A va_list can only be used once between a va_start / va_end pair. In order to use a va_list more than once, a copy has to be made. On 32-bit platforms, a va_list could be simply a pointer and thus passing it as a function parameter gets it copied. On 64-bit platforms, the va_list may be a more complex structure that can only be copied using C99's va_copy.

There was duplicated code in zstr.c in order to make the code work on compilers not supporting C99.
