### PR TITLE
Rationalized _print/_fprint method names

### DIFF
--- a/include/zcert.h
+++ b/include/zcert.h
@@ -107,9 +107,13 @@ CZMQ_EXPORT zcert_t *
 CZMQ_EXPORT bool
     zcert_eq (zcert_t *self, zcert_t *compare);
 
-//  Dump certificate contents to stderr for debugging
+//  Print certificate contents to open stream
 CZMQ_EXPORT void
-    zcert_dump (zcert_t *self);
+    zcert_fprint (zcert_t *self, FILE *file);
+
+//  Print certificate contents to stdout
+CZMQ_EXPORT void
+    zcert_print (zcert_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT int
@@ -119,5 +123,8 @@ CZMQ_EXPORT int
 #ifdef __cplusplus
 }
 #endif
+
+//  Deprecated method aliases
+#define zcert_dump(s) zcert_print(s)
 
 #endif

--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -61,10 +61,13 @@ CZMQ_EXPORT zcert_t *
 CZMQ_EXPORT void
     zcertstore_insert (zcertstore_t *self, zcert_t **cert_p);
 
-//  Print out list of certificates in store to stdout, for debugging
-//  purposes.
+//  Print list of certificates in store to open stream
 CZMQ_EXPORT void
-    zcertstore_dump (zcertstore_t *self);
+    zcertstore_fprint (zcertstore_t *self, FILE *file);
+
+//  Print list of certificates in store to stdout
+CZMQ_EXPORT void
+    zcertstore_print (zcertstore_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT int
@@ -74,5 +77,8 @@ CZMQ_EXPORT int
 #ifdef __cplusplus
 }
 #endif
+
+//  Deprecated method aliases
+#define zcertstore_dump(s) zcertstore_print(s)
 
 #endif

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -111,9 +111,13 @@ CZMQ_EXPORT zconfig_t *
 CZMQ_EXPORT int
     zconfig_save (zconfig_t *self, char *filename);
 
-//  Dump the config file to stderr for tracing
+//  Print the config file to open stream
 CZMQ_EXPORT void
-    zconfig_dump (zconfig_t *self);
+    zconfig_fprint (zconfig_t *self, FILE *file);
+
+//  Print the config file to stdout
+CZMQ_EXPORT void
+    zconfig_print (zconfig_t *self);
 
 //  Self test of this class
 void
@@ -122,5 +126,8 @@ void
 #ifdef __cplusplus
 }
 #endif
+
+//  Deprecated method aliases
+#define zconfig_dump(s) zconfig_print(s)
 
 #endif

--- a/include/zdir.h
+++ b/include/zdir.h
@@ -73,10 +73,6 @@ CZMQ_EXPORT zfile_t **
 CZMQ_EXPORT void
     zdir_flatten_free (zfile_t ***files_p);
 
-//  Print contents of directory to stderr
-CZMQ_EXPORT void
-    zdir_dump (zdir_t *self, int indent);
-
 //  Remove directory, optionally including all files that it contains, at
 //  all levels. If force is false, will only remove the directory if empty.
 //  If force is true, will remove all files and all subdirectories.
@@ -100,6 +96,14 @@ CZMQ_EXPORT zlist_t *
 CZMQ_EXPORT zhash_t *
     zdir_cache (zdir_t *self);
 
+//  Print contents of directory to open stream
+CZMQ_EXPORT void
+    zdir_fprint (zdir_t *self, FILE *file, int indent);
+
+//  Print contents of directory to stdout
+CZMQ_EXPORT void
+    zdir_print (zdir_t *self, int indent);
+
 //  Self test of this class
 CZMQ_EXPORT int
     zdir_test (bool verbose);
@@ -108,5 +112,8 @@ CZMQ_EXPORT int
 #ifdef __cplusplus
 }
 #endif
+
+//  Deprecated method aliases
+#define zdir_dump(s,i) zdir_print(s,i)
 
 #endif

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -172,16 +172,14 @@ CZMQ_EXPORT zmsg_t *
 CZMQ_EXPORT zmsg_t *
     zmsg_dup (zmsg_t *self);
 
-//  Dump message to stderr, for debugging and tracing.
-//  See zmsg_dump_to_stream() for details
+//  Print message to open stream
+//  Truncates to first 10 frames, for readability.
 CZMQ_EXPORT void
-    zmsg_dump (zmsg_t *self);
+    zmsg_fprint (zmsg_t *self, FILE *file);
 
-//  Dump message to FILE stream, for debugging and tracing. 
-//  Truncates to first 10 frames, for readability; this may be unfortunate
-//  when debugging larger and more complex messages.
+//  Print message to stdout
 CZMQ_EXPORT void
-    zmsg_dump_to_stream (zmsg_t *self, FILE *file);
+    zmsg_print (zmsg_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT int
@@ -191,5 +189,9 @@ CZMQ_EXPORT int
 #ifdef __cplusplus
 }
 #endif
+
+//  Deprecated method aliases
+#define zmsg_dump(s) zmsg_print(s)
+#define zmsg_dump_to_stream(s,F) zmsg_fprint(s,F)
 
 #endif

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -396,25 +396,34 @@ zcert_eq (zcert_t *self, zcert_t *compare)
 }
 
 
-//  --------------------------------------------------------------------------
-//  Dump certificate contents to stderr for debugging
-
 static int
-s_dump_metadata (const char *name, void *value, void *args)
+s_print_metadata (const char *name, void *value, void *args)
 {
-    fprintf (stderr, "    %s = \"%s\"\n", name, (char *) value);
+    fprintf ((FILE *) args, "    %s = \"%s\"\n", name, (char *) value);
     return 0;
 }
 
+//  --------------------------------------------------------------------------
+//  Print certificate contents to open stream
+
 void
-zcert_dump (zcert_t *self)
+zcert_fprint (zcert_t *self, FILE *file)
 {
     assert (self);
-    fprintf (stderr, "metadata\n");
-    zhash_foreach (self->metadata, s_dump_metadata, NULL);
-    fprintf (stderr, "curve\n");
-    fprintf (stderr, "    public-key = \"%s\"\n", self->public_txt);
-    fprintf (stderr, "    secret-key = \"%s\"\n", self->secret_txt);
+    fprintf (file, "metadata\n");
+    zhash_foreach (self->metadata, s_print_metadata, file);
+    fprintf (file, "curve\n");
+    fprintf (file, "    public-key = \"%s\"\n", self->public_txt);
+    fprintf (file, "    secret-key = \"%s\"\n", self->secret_txt);
+}
+
+//  --------------------------------------------------------------------------
+//  Print certificate contents to stdout
+
+void
+zcert_print (zcert_t *self)
+{
+    zcert_fprint (self, stdout);
 }
 
 

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -202,22 +202,31 @@ zcertstore_insert (zcertstore_t *self, zcert_t **cert_p)
 
 
 //  --------------------------------------------------------------------------
-//  Print out list of certificates in store to stdout, for debugging
-//  purposes.
+//  Print list of certificates in store to open stream
 
 void
-zcertstore_dump (zcertstore_t *self)
+zcertstore_fprint (zcertstore_t *self, FILE *file)
 {
     if (self->location)
-        printf ("Certificate store at %s:\n", self->location);
+        fprintf (file, "Certificate store at %s:\n", self->location);
     else
-        printf ("Certificate store\n");
-        
+        fprintf (file, "Certificate store\n");
+
     zcert_t *cert = (zcert_t *) zlist_first (self->cert_list);
     while (cert) {
-        zcert_dump (cert);
+        zcert_fprint (cert, file);
         cert = (zcert_t *) (zcert_t *) zlist_next (self->cert_list);
     }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print list of certificates in store to stdout
+
+void
+zcertstore_print (zcertstore_t *self)
+{
+    zcertstore_fprint (self, stdout);
 }
 
 
@@ -252,7 +261,7 @@ zcertstore_test (bool verbose)
     free (client_key);
 #   endif
     if (verbose)
-        zcertstore_dump (certstore);
+        zcertstore_print (certstore);
     zcertstore_destroy (&certstore);
 
     //  Delete all test files

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -324,16 +324,6 @@ zconfig_execute (zconfig_t *self, zconfig_fct handler, void *arg)
 
 
 //  --------------------------------------------------------------------------
-//  Dump the config file to stderr for tracing
-
-void
-zconfig_dump (zconfig_t *self)
-{
-    zconfig_execute (self, s_config_save, stderr);
-}
-
-
-//  --------------------------------------------------------------------------
 //  Load a config item tree from a specified ZPL text file
 //
 //  Here is an example ZPL stream and corresponding config structure:
@@ -654,6 +644,26 @@ s_config_save (zconfig_t *self, void *arg, int level)
                 self->name? self->name: "(Unnamed)");
     }
     return 0;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print the config file to open stream
+
+void
+zconfig_fprint (zconfig_t *self, FILE *file)
+{
+    zconfig_execute (self, s_config_save, file);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print the config file to stdout
+
+void
+zconfig_print (zconfig_t *self)
+{
+    zconfig_fprint (self, stdout);
 }
 
 

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -345,26 +345,6 @@ zdir_flatten_free (zfile_t ***files_p)
 
 
 //  --------------------------------------------------------------------------
-//  Print contents of directory
-
-void
-zdir_dump (zdir_t *self, int indent)
-{
-    assert (self);
-
-    zfile_t **files = zdir_flatten (self);
-    uint index;
-    for (index = 0;; index++) {
-        zfile_t *file = files [index];
-        if (!file)
-            break;
-        puts (zfile_filename (file, NULL));
-    }
-    zdir_flatten_free (&files);
-}
-
-
-//  --------------------------------------------------------------------------
 //  Remove directory, optionally including all files that it contains, at
 //  all levels. If force is false, will only remove the directory if empty.
 //  If force is true, will remove all files and all subdirectories.
@@ -519,6 +499,36 @@ zdir_cache (zdir_t *self)
     zhash_save (cache, cache_file);
     free (cache_file);
     return cache;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print contents of directory to open stream
+
+void
+zdir_fprint (zdir_t *self, FILE *stream, int indent)
+{
+    assert (self);
+
+    zfile_t **files = zdir_flatten (self);
+    uint index;
+    for (index = 0;; index++) {
+        zfile_t *file = files [index];
+        if (!file)
+            break;
+        fprintf (stream, "%s\n", zfile_filename (file, NULL));
+    }
+    zdir_flatten_free (&files);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print contents of directory to stdout
+
+void
+zdir_print (zdir_t *self, int indent)
+{
+    zdir_fprint (self, stdout, indent);
 }
 
 

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -598,23 +598,11 @@ zmsg_dup (zmsg_t *self)
 
 
 //  --------------------------------------------------------------------------
-//  Dump message to stderr, for debugging and tracing.
-//  See zmsg_dump_to_stream() for details
+//  Dump message to FILE stream, for debugging and tracing.
+//  Truncates to first 10 frames, for readability.
 
 void
-zmsg_dump (zmsg_t *self)
-{
-   zmsg_dump_to_stream (self, stderr);
-}
-
-
-//  --------------------------------------------------------------------------
-//  Dump message to FILE stream, for debugging and tracing. 
-//  Truncates to first 10 frames, for readability; this may be unfortunate
-//  when debugging larger and more complex messages.
-
-void
-zmsg_dump_to_stream (zmsg_t *self, FILE *file)
+zmsg_fprint (zmsg_t *self, FILE *file)
 {
     fprintf (file, "--------------------------------------\n");
     if (!self) {
@@ -627,6 +615,17 @@ zmsg_dump_to_stream (zmsg_t *self, FILE *file)
         zframe_print_to_stream(frame, NULL, file);
         frame = zmsg_next (self);
     }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Dump message to stderr, for debugging and tracing.
+//  See zmsg_fprint for details
+
+void
+zmsg_print (zmsg_t *self)
+{
+   zmsg_fprint (self, stderr);
 }
 
 


### PR DESCRIPTION
- library used a mix of _dump and _print
- now _print consistently sends to stdout
- _fprint consistently present, accepting FILE *
- _dump reimplemented as deprecated macros
