### PR TITLE
Add runtime czmq version check function

### DIFF
--- a/doc/zsys.txt
+++ b/doc/zsys.txt
@@ -74,6 +74,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zsys_file_mode_default (void);
 
+//  Return the czmq version for run-time API detection
+CZMQ_EXPORT void
+    zsys_version (int *major, int *minor, int *patch);
+
 //  Format a string with variable arguments, returning a freshly allocated
 //  buffer. If there was insufficient memory, returns NULL. Free the returned
 //  string using zstr_free().
@@ -123,6 +127,12 @@ EXAMPLE
     rc = zsys_dir_delete ("%s/%s", ".", ".testsys/subdir");
     assert (rc == 0);
 
+    int major, minor, patch;
+    zsys_version (&major, &minor, &patch);
+    assert (major == CZMQ_VERSION_MAJOR);
+    assert (minor == CZMQ_VERSION_MINOR);
+    assert (patch == CZMQ_VERSION_PATCH);
+    
     char *string = s_vprintf ("%s %02x", "Hello", 16);
     assert (streq (string, "Hello 10"));
     zstr_free (&string);

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -97,6 +97,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zsys_file_mode_default (void);
 
+//  Return the czmq version for run-time API detection
+CZMQ_EXPORT void
+    zsys_version (int *major, int *minor, int *patch);
+
 //  Format a string with variable arguments, returning a freshly allocated
 //  buffer. If there was insufficient memory, returns NULL. Free the returned
 //  string using zstr_free().

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -350,6 +350,17 @@ zsys_file_mode_default (void)
 
 
 //  --------------------------------------------------------------------------
+//  Return the czmq version for run-time API detection
+
+void zsys_version (int *major, int *minor, int *patch)
+{
+    *major = CZMQ_VERSION_MAJOR;
+    *minor = CZMQ_VERSION_MINOR;
+    *patch = CZMQ_VERSION_PATCH;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Format a string with variable arguments, returning a freshly allocated
 //  buffer. If there was insufficient memory, returns NULL. Free the returned
 //  string using zstr_free().
@@ -431,6 +442,12 @@ zsys_test (bool verbose)
     rc = zsys_dir_delete ("%s/%s", ".", ".testsys/subdir");
     assert (rc == 0);
 
+    int major, minor, patch;
+    zsys_version (&major, &minor, &patch);
+    assert (major == CZMQ_VERSION_MAJOR);
+    assert (minor == CZMQ_VERSION_MINOR);
+    assert (patch == CZMQ_VERSION_PATCH);
+    
     char *string = s_vprintf ("%s %02x", "Hello", 16);
     assert (streq (string, "Hello 10"));
     zstr_free (&string);


### PR DESCRIPTION
This change adds a function to provide CZMQ version details at runtime. This is useful to libczmq users that need to perform version checking at runtime, not compile time. One example is pyczmq which is not linked against libczmq but rather loads libczmq at runtime via the ffi module. 

Adding the version function to the zsys module seems to be the best spot for now.

The README.md was not up to date with the current repo state so when I regenerated it to include my changes it has also added some recent changes that were missing.
