### PR TITLE
Cleaned up zbeacon

### DIFF
--- a/doc/zbeacon.txt
+++ b/doc/zbeacon.txt
@@ -28,14 +28,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zbeacon_noecho (zbeacon_t *self);
 
-//  Start/stop listening on unicast packets
-CZMQ_EXPORT void
-    zbeacon_unicast (zbeacon_t *self, int flag);
-
-//  Send a frame directed to a particular unicast IP address once
-CZMQ_EXPORT void
-    zbeacon_send (zbeacon_t *self,  char *ipaddress, byte *transmit, size_t size);
-
 //  Start broadcasting beacon to peers at the specified interval
 CZMQ_EXPORT void
     zbeacon_publish (zbeacon_t *self, byte *transmit, size_t size);
@@ -102,36 +94,12 @@ EXAMPLE
 
     char *ipaddress = zstr_recv (zbeacon_socket (client_beacon));
     if (ipaddress) {
-
         zframe_t *content = zframe_recv (zbeacon_socket (client_beacon));
         int received_port = (zframe_data (content) [0] << 8)
                         +  zframe_data (content) [1];
         assert (received_port == port_nbr);
         zframe_destroy (&content);
-	zbeacon_silence (service_beacon);
-
-	// turn on UDP unicast reception
-	zbeacon_unicast (client_beacon, 1);
-
-	zsocket_set_rcvtimeo (zbeacon_socket (client_beacon), 500);
-
-	// send unicast UDP message to ourselves
-	zbeacon_send (service_beacon, ipaddress, (byte *) "SELF", 4);
-
-        char *addr = zstr_recv (zbeacon_socket (client_beacon));
-	assert(addr != NULL);
-
-	// assert we got it, src IP and contents add up
-	assert(strcmp(addr,ipaddress) == 0);
-
-        content = zframe_recv (zbeacon_socket (client_beacon));
-	assert(content != NULL);
-
-	assert(memcmp((void *) "SELF", zframe_data (content),  zframe_size (content)) == 0);
-        zstr_free (&ipaddress);
-
-	// turn off UDP unicast reception
-	zbeacon_unicast (client_beacon, 0);
+        zbeacon_silence (service_beacon);
     }
     zbeacon_destroy (&client_beacon);
     zbeacon_destroy (&service_beacon);

--- a/doc/zsys.txt
+++ b/doc/zsys.txt
@@ -8,6 +8,8 @@ zsys - system-level methods
 SYNOPSIS
 --------
 ----
+#define UDP_FRAME_MAX   255         //  Max size of UDP frame
+
 //  Callback for interrupt signal handler
 typedef void (zsys_handler_fn) (int signal_value);
 
@@ -84,6 +86,26 @@ CZMQ_EXPORT void
 CZMQ_EXPORT char *
     zsys_vprintf (const char *format, va_list argptr);
 
+//  Create UDP beacon socket; if the routable option is true, uses
+//  multicast (not yet implemented), else uses broadcast. This method
+//  and related ones might _eventually_ be moved to a zudp class.
+CZMQ_EXPORT SOCKET
+    zsys_udp_new (bool routable);
+
+//  Send zframe to UDP socket
+CZMQ_EXPORT void
+    zsys_udp_send (SOCKET udpsock, zframe_t *frame, inaddr_t *address);
+
+//  Receive zframe from UDP socket, and set address of peer that sent it
+//  The peername must be a char [INET_ADDRSTRLEN] array.
+CZMQ_EXPORT zframe_t *
+    zsys_udp_recv (SOCKET udpsock, char *peername);
+
+//  Handle an I/O error on some socket operation; will report and die on
+//  fatal errors, and continue silently on "try again" errors.
+CZMQ_EXPORT void
+    zsys_socket_error (char *reason);
+    
 //  Self test of this class
 CZMQ_EXPORT int
     zsys_test (bool verbose);

--- a/include/zbeacon.h
+++ b/include/zbeacon.h
@@ -54,14 +54,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zbeacon_noecho (zbeacon_t *self);
 
-//  Start/stop listening on unicast packets
-CZMQ_EXPORT void
-    zbeacon_unicast (zbeacon_t *self, int flag);
-
-//  Send a frame directed to a particular unicast IP address once
-CZMQ_EXPORT void
-    zbeacon_send (zbeacon_t *self,  char *ipaddress, byte *transmit, size_t size);
-
 //  Start broadcasting beacon to peers at the specified interval
 CZMQ_EXPORT void
     zbeacon_publish (zbeacon_t *self, byte *transmit, size_t size);

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -31,6 +31,8 @@ extern "C" {
 #endif
 
 //  @interface
+#define UDP_FRAME_MAX   255         //  Max size of UDP frame
+
 //  Callback for interrupt signal handler
 typedef void (zsys_handler_fn) (int signal_value);
 
@@ -107,6 +109,26 @@ CZMQ_EXPORT void
 CZMQ_EXPORT char *
     zsys_vprintf (const char *format, va_list argptr);
 
+//  Create UDP beacon socket; if the routable option is true, uses
+//  multicast (not yet implemented), else uses broadcast. This method
+//  and related ones might _eventually_ be moved to a zudp class.
+CZMQ_EXPORT SOCKET
+    zsys_udp_new (bool routable);
+
+//  Send zframe to UDP socket
+CZMQ_EXPORT void
+    zsys_udp_send (SOCKET udpsock, zframe_t *frame, inaddr_t *address);
+
+//  Receive zframe from UDP socket, and set address of peer that sent it
+//  The peername must be a char [INET_ADDRSTRLEN] array.
+CZMQ_EXPORT zframe_t *
+    zsys_udp_recv (SOCKET udpsock, char *peername);
+
+//  Handle an I/O error on some socket operation; will report and die on
+//  fatal errors, and continue silently on "try again" errors.
+CZMQ_EXPORT void
+    zsys_socket_error (char *reason);
+    
 //  Self test of this class
 CZMQ_EXPORT int
     zsys_test (bool verbose);


### PR DESCRIPTION
- unicast/send methods do not IMO belong in this class -- they are
  nothing to do with beaconing, and are instead a use of classic UDP.
- I've moved some low-level UDP methods into zsys.
- we would better IMO focus on a udp:// transport in libzmq.
- we can recreate the unicast send/recv in zsys if needed, as synchronous
  methods.
