### PR TITLE
zloop_timer: correct documentation of return value

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -308,8 +308,8 @@ zloop_set_tolerant (zloop_t *self, zmq_pollitem_t *item)
 //  --------------------------------------------------------------------------
 //  Register a timer that expires after some delay and repeats some number of
 //  times. At each expiry, will call the handler, passing the arg. To
-//  run a timer forever, use 0 times. Returns 0 if OK, -1 if there was an
-//  error.
+//  run a timer forever, use 0 times. Returns a non-negative timer id if OK, 
+//  or -1 if there was an error.
 
 int
 zloop_timer (zloop_t *self, size_t delay, size_t times, zloop_timer_fn handler, void *arg)


### PR DESCRIPTION
just a documentation touchup
