### PR TITLE
the real fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,95 @@ text format for configuration files.
 
 This is the class interface:
 
+    //  Function that executes config
+    typedef int (zconfig_fct) (zconfig_t *self, void *arg, int level);
+    
+    //  Create new config item
+    CZMQ_EXPORT zconfig_t *
+        zconfig_new (char *name, zconfig_t *parent);
+    
+    //  Destroy a config item and all its children
+    CZMQ_EXPORT void
+        zconfig_destroy (zconfig_t **self_p);
+    
+    //  Return name of config item
+    CZMQ_EXPORT char *
+        zconfig_name (zconfig_t *self);
+    
+    //  Return value of config item
+    CZMQ_EXPORT char *
+        zconfig_value (zconfig_t *self);
+    
+    //  Insert or update configuration key with value
+    CZMQ_EXPORT void
+        zconfig_put (zconfig_t *self, char *path, char *value);
+    
+    //  Set config item name, name may be NULL
+    CZMQ_EXPORT void
+        zconfig_set_name (zconfig_t *self, char *name);
+    
+    //  Set new value for config item. The new value may be a string, a printf
+    //  format, or NULL. Note that if string may possibly contain '%', or if it
+    //  comes from an insecure source, you must use '%s' as the format, followed
+    //  by the string.
+    CZMQ_EXPORT void
+        zconfig_set_value (zconfig_t *self, char *format, ...);
+    
+    //  Find our first child, if any
+    CZMQ_EXPORT zconfig_t *
+        zconfig_child (zconfig_t *self);
+    
+    //  Find our first sibling, if any
+    CZMQ_EXPORT zconfig_t *
+        zconfig_next (zconfig_t *self);
+    
+    //  Find a config item along a path; leading slash is optional and ignored.
+    CZMQ_EXPORT zconfig_t *
+        zconfig_locate (zconfig_t *self, char *path);
+    
+    //  Resolve a config path into a string value; leading slash is optional
+    //  and ignored.
+    CZMQ_EXPORT char *
+        zconfig_resolve (zconfig_t *self, char *path, char *default_value);
+    
+    //  Set config item name, name may be NULL
+    CZMQ_EXPORT void
+        zconfig_set_path (zconfig_t *self, char *path, char *value);
+    
+    //  Locate the last config item at a specified depth
+    CZMQ_EXPORT zconfig_t *
+        zconfig_at_depth (zconfig_t *self, int level);
+    
+    //  Execute a callback for each config item in the tree
+    CZMQ_EXPORT int
+        zconfig_execute (zconfig_t *self, zconfig_fct handler, void *arg);
+    
+    //  Add comment to config item before saving to disk. You can add as many
+    //  comment lines as you like. If you use a null format, all comments are
+    //  deleted.
+    CZMQ_EXPORT void
+        zconfig_set_comment (zconfig_t *self, char *format, ...);
+    
+    //  Return comments of config item, as zlist.
+    CZMQ_EXPORT zlist_t *
+        zconfig_comments (zconfig_t *self);
+    
+    //  Load a config item tree from a specified ZPL text file
+    CZMQ_EXPORT zconfig_t *
+        zconfig_load (char *filename);
+    
+    //  Save a config item tree to a specified ZPL text file, where a filename
+    //  "-" means dump to standard output.
+    CZMQ_EXPORT int
+        zconfig_save (zconfig_t *self, char *filename);
+    
+    //  Print the config file to open stream
+    CZMQ_EXPORT void
+        zconfig_fprint (zconfig_t *self, FILE *file);
+    
+    //  Print the config file to stdout
+    CZMQ_EXPORT void
+        zconfig_print (zconfig_t *self);
 
 
 <A name="toc4-210" title="zctx - working with ØMQ contexts" />

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -9,16 +9,16 @@
     http://czmq.zeromq.org.
 
     This is free software; you can redistribute it and/or modify it under
-    the terms of the GNU Lesser General Public License as published by the 
-    Free Software Foundation; either version 3 of the License, or (at your 
+    the terms of the GNU Lesser General Public License as published by the
+    Free Software Foundation; either version 3 of the License, or (at your
     option) any later version.
 
     This software is distributed in the hope that it will be useful, but
     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABIL-
-    ITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General 
+    ITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
     Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License 
+    You should have received a copy of the GNU Lesser General Public License
     along with this program. If not, see <http://www.gnu.org/licenses/>.
     =========================================================================
 */
@@ -33,6 +33,7 @@ extern "C" {
 //  Opaque class structure
 typedef struct _zconfig_t zconfig_t;
 
+//  @interface
 //  Function that executes config
 typedef int (zconfig_fct) (zconfig_t *self, void *arg, int level);
 
@@ -51,7 +52,7 @@ CZMQ_EXPORT char *
 //  Return value of config item
 CZMQ_EXPORT char *
     zconfig_value (zconfig_t *self);
-    
+
 //  Insert or update configuration key with value
 CZMQ_EXPORT void
     zconfig_put (zconfig_t *self, char *path, char *value);
@@ -66,7 +67,7 @@ CZMQ_EXPORT void
 //  by the string.
 CZMQ_EXPORT void
     zconfig_set_value (zconfig_t *self, char *format, ...);
-    
+
 //  Find our first child, if any
 CZMQ_EXPORT zconfig_t *
     zconfig_child (zconfig_t *self);
@@ -79,7 +80,7 @@ CZMQ_EXPORT zconfig_t *
 CZMQ_EXPORT zconfig_t *
     zconfig_locate (zconfig_t *self, char *path);
 
-//  Resolve a config path into a string value; leading slash is optional 
+//  Resolve a config path into a string value; leading slash is optional
 //  and ignored.
 CZMQ_EXPORT char *
     zconfig_resolve (zconfig_t *self, char *path, char *default_value);
@@ -97,7 +98,7 @@ CZMQ_EXPORT int
     zconfig_execute (zconfig_t *self, zconfig_fct handler, void *arg);
 
 //  Add comment to config item before saving to disk. You can add as many
-//  comment lines as you like. If you use a null format, all comments are 
+//  comment lines as you like. If you use a null format, all comments are
 //  deleted.
 CZMQ_EXPORT void
     zconfig_set_comment (zconfig_t *self, char *format, ...);
@@ -122,6 +123,7 @@ CZMQ_EXPORT void
 //  Print the config file to stdout
 CZMQ_EXPORT void
     zconfig_print (zconfig_t *self);
+//  @end
 
 //  Self test of this class
 void


### PR DESCRIPTION
This change actually includes zconfig interface into the readme. The //@interface and //@end were missing from hte .h file which prevented gitdown from including the header into the README.md. I wonder how this ever worked as I can't find these gitdown tokens anywhere in the zconfig.h file's history?
