### PR TITLE
zsys_interface: use default value from an environment variable if supplied.

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -199,6 +199,10 @@ zbeacon_hostname (zbeacon_t *self)
 
 //  --------------------------------------------------------------------------
 //  Self test of this class
+//
+// If this test fails with an unable to bind error, try specifying the default
+// interface to be used for zbeacon with the ZSYS_INTERFACE environment
+// variable.
 
 void
 zbeacon_test (bool verbose)

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -140,7 +140,16 @@ zsys_set_interface (char *interface_name)
 char *
 zsys_interface (void)
 {
-    return (s_interface? s_interface: "");
+    if (s_interface) return s_interface;
+
+    // if the environment variable ZSYS_INTERFACE is set, use that as the
+    // default interface name. This lets the environment variable be configured
+    // for test environments where required. For example, on Mac OS X, zbeacon
+    // cannot bind to 255.255.255.255 which is the default when there is no
+    // specified interface.
+    char* env = getenv ("ZSYS_INTERFACE");
+    if (env) return env;
+    return "";
 }
 
 


### PR DESCRIPTION
On Mac OS X, it appears that INADDR_BROADCAST (255.255.255.255) cannot be bound to. According to the man page:

> In addition broadcast packets may be sent (assuming the underlying network supports this) by using a reserved ``broadcast address''; this address is network interface dependent.

If I use this patch and specify `ZSYS_INTERFACE=en0 make check` then the beacon tests pass on Mac OS X. Without specifying an interface, 255.255.255.255 is chosen which returns an error code EADDRNOTAVAIL causing an assert.
