### PR TITLE
Update zsys.c

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -584,6 +584,8 @@ zsys_test (bool verbose)
     assert (when > 0);
     rc = zsys_dir_delete ("%s/%s", ".", ".testsys/subdir");
     assert (rc == 0);
+    rc = zsys_dir_delete ("%s/%s", ".", ".testsys");
+    assert (rc == 0);
 
     int major, minor, patch;
     zsys_version (&major, &minor, &patch);


### PR DESCRIPTION
The czmq self test "forgets" to delete the folder ".testsys" (correct me if I'm wrong)
On my Linux machine, this adjustment fixes the problem.

///////////////////////////////////////////

This pull request is wrongfully being "failed" by the testing system:
zsys: OK 
...
line 2185: lt-czmq_selftest: zbeacon.c:254: zbeacon_test: Assertion `*zbeacon_hostname (node3)' failed. 
-> this failure is the legacy from the previous merge
