### PR TITLE
Adds missing zsocket_sendmem declaration

### DIFF
--- a/include/zsocket.h
+++ b/include/zsocket.h
@@ -95,6 +95,11 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsocket_wait (void *socket);
 
+//  Send data over a socket as a single message frame.
+//  Returns -1 on error, 0 on success
+CZMQ_EXPORT int
+    zsocket_sendmem (void *socket, const void *data, size_t size, int flags);
+
 //  Self test of this class
 CZMQ_EXPORT int
     zsocket_test (bool verbose);


### PR DESCRIPTION
The zsocket_sendmem declaration was missing from zsocket.h, causing compiler warnings when I tried to use it. This commit fixes it.
