### PR TITLE
Fix memory leaks

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -241,6 +241,7 @@ zbeacon_test (bool verbose)
         assert (received_port == port_nbr);
         zframe_destroy (&content);
         zbeacon_silence (service_beacon);
+        zstr_free (&ipaddress);
     }
     zbeacon_destroy (&client_beacon);
     zbeacon_destroy (&service_beacon);

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -746,12 +746,15 @@ zframe_test (bool verbose)
     assert (bit64 == test_64bit);
     char *hello = zframe_get_string (frame);
     assert (streq (hello, test_string));
+    free (hello);
     zuuid_t *uuid = zuuid_new ();
     zframe_get_block (frame, zuuid_data (uuid), 16);
     assert (zuuid_eq (uuid, zuuid_data (test_uuid)));
+    zuuid_destroy (&uuid);
     zframe_destroy (&frame);
     assert (frame == NULL);
 
+    zuuid_destroy (&test_uuid);
     zctx_destroy (&ctx);
     //  @end
     printf ("OK\n");


### PR DESCRIPTION
Fix the memory leaks in zbeacon.c and zframe.c identified when src/selftest is run.
