### PR TITLE
mark functions with printf() semantics with GCC format attribute

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -437,6 +437,15 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
     typedef unsigned int uint;
 #endif
 
+//- Printf format error checking --------------------------------------------
+// GCC supports validating format strings for functions that act like printf
+#if defined (__GNUC__) && (__GNUC__ >= 2)
+#   define CZMQ_PRINTF_FUNC(a, b)	__attribute__((format(printf, a, b)))
+#else
+#   define CZMQ_PRINTF_FUNC(a, b)
+#endif
+
+
 //- Error reporting ---------------------------------------------------------
 // If the compiler is GCC or supports C99, include enclosing function
 // in CZMQ assertions

--- a/include/zclock.h
+++ b/include/zclock.h
@@ -42,7 +42,8 @@ CZMQ_EXPORT int64_t
 //  Print formatted string to stdout, prefixed by date/time and
 //  terminated with a newline.
 CZMQ_EXPORT void
-    zclock_log (const char *format, ...);
+    zclock_log (const char *format, ...)
+	CZMQ_PRINTF_FUNC(1,2);
 
 //  Return formatted date/time as fresh string. Free using zstr_free().
 CZMQ_EXPORT char *

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -66,8 +66,9 @@ CZMQ_EXPORT void
 //  comes from an insecure source, you must use '%s' as the format, followed
 //  by the string.
 CZMQ_EXPORT void
-    zconfig_set_value (zconfig_t *self, const char *format, ...);
-
+    zconfig_set_value (zconfig_t *self, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
+    
 //  Find our first child, if any
 CZMQ_EXPORT zconfig_t *
     zconfig_child (zconfig_t *self);

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -109,12 +109,14 @@ CZMQ_EXPORT int
 //  Push formatted string as new frame to front of message.
 //  Returns 0 on success, -1 on error.
 CZMQ_EXPORT int
-    zmsg_pushstrf (zmsg_t *self, const char *format, ...);
+    zmsg_pushstrf (zmsg_t *self, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Push formatted string as new frame to end of message.
 //  Returns 0 on success, -1 on error.
 CZMQ_EXPORT int
-    zmsg_addstrf (zmsg_t *self, const char *format, ...);
+    zmsg_addstrf (zmsg_t *self, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Pop frame off front of message, return as fresh string. If there were
 //  no more frames in the message, returns NULL.

--- a/include/zsocket.h
+++ b/include/zsocket.h
@@ -56,7 +56,8 @@ CZMQ_EXPORT void
 //  bind succeeded with the specified port number. Always returns the
 //  port number if successful.
 CZMQ_EXPORT int
-    zsocket_bind (void *socket, const char *format, ...);
+    zsocket_bind (void *socket, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Unbind a socket from a formatted endpoint.
 //  Returns 0 if OK, -1 if the endpoint was invalid or the function
@@ -67,13 +68,15 @@ CZMQ_EXPORT int
 //  Connect a socket to a formatted endpoint
 //  Returns 0 if OK, -1 if the endpoint was invalid.
 CZMQ_EXPORT int
-    zsocket_connect (void *socket, const char *format, ...);
+    zsocket_connect (void *socket, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Disonnect a socket from a formatted endpoint
 //  Returns 0 if OK, -1 if the endpoint was invalid or the function
 //  isn't supported.
 CZMQ_EXPORT int
-    zsocket_disconnect (void *socket, const char *format, ...);
+    zsocket_disconnect (void *socket, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Poll for input events on the socket. Returns TRUE if there is input
 //  ready on the socket, else FALSE.

--- a/include/zstr.h
+++ b/include/zstr.h
@@ -59,13 +59,15 @@ CZMQ_EXPORT int
 //  user-supplied strings in the format (they may contain '%' which
 //  will create security holes).
 CZMQ_EXPORT int
-    zstr_sendf (void *socket, const char *format, ...);
+    zstr_sendf (void *socket, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Send a formatted string to a socket, as for zstr_sendf(), with a
 //  MORE flag, so that you can send further strings in the same multi-part
 //  message.
 CZMQ_EXPORT int
-    zstr_sendfm (void *socket, const char *format, ...);
+    zstr_sendfm (void *socket, const char *format, ...)
+	CZMQ_PRINTF_FUNC(2,3);
 
 //  Send a series of strings (until NULL) as multipart data
 //  Returns 0 if the strings could be sent OK, or -1 on error.

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -157,7 +157,7 @@ s_tickless_timer (zloop_t *self)
     if (timeout < 0)
         timeout = 0;
     if (self->verbose)
-        zclock_log ("I: zloop: polling for %d msec", timeout);
+	zclock_log ("I: zloop: polling for %d msec", (int)timeout);
     return timeout;
 }
 
@@ -324,7 +324,7 @@ zloop_timer (zloop_t *self, size_t delay, size_t times, zloop_timer_fn handler, 
     if (zlist_append (self->timers, timer))
         return -1;
     if (self->verbose)
-        zclock_log ("I: zloop: register timer id=%d delay=%d times=%d", 
+        zclock_log ("I: zloop: register timer id=%d delay=%zd times=%zd", 
                     timer_id, delay, times);
     
     return timer_id;


### PR DESCRIPTION
This enables format string checks for CZMQ functions that take
variable number of arguments in a manner similar to printf().

It also adds a few casts for places where size_t is passed
to functions with printf like syntax. There is a modifier to allow
use of size_t (%zd) but it is not portable to all operating systems
and compilers.

Signed-off-by: Stephen Hemminger stephen@networkplumber.org
