### PR TITLE
fix clang errors

### DIFF
--- a/src/zmonitor.c
+++ b/src/zmonitor.c
@@ -281,7 +281,7 @@ s_agent_new (zctx_t *ctx, void *pipe, char *endpoint)
     self->socket = zsocket_new (self->ctx, ZMQ_PAIR);
     assert (self->socket);
 
-    if (zsocket_connect (self->socket, self->endpoint) == 0)
+    if (zsocket_connect (self->socket, "%s", self->endpoint) == 0)
         zstr_send (self->pipe, "OK");
     else
         zstr_send (self->pipe, "ERROR");

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -204,7 +204,7 @@ s_proxy_task (void *args, zctx_t *ctx, void *command_pipe)
                     capture = zsocket_new (self->ctx, ZMQ_PUSH);
                     char *endpoint = zstr_recv (command_pipe);
                     if (capture) {
-                        int rc = zsocket_connect (capture, endpoint);
+                        int rc = zsocket_connect (capture, "%s", endpoint);
                         assert (rc == 0);
                     }
                     zstr_free (&endpoint);


### PR DESCRIPTION
error: format string is not a string literal (potentially insecure)
    [-Werror,-Wformat-security]

(follow up on ceb91d4bf9b01b7272c509a1c9674d217e2b2384)
