### PR TITLE
fix bug in zstr s_send_string

### DIFF
--- a/src/zstr.c
+++ b/src/zstr.c
@@ -32,7 +32,7 @@ s_send_string (void *socket, bool more, char *string)
     zmq_msg_t message;
     zmq_msg_init_size (&message, len);
     memcpy (zmq_msg_data (&message), string, len);
-    if (zmq_sendmsg (socket, &message, more? ZMQ_SNDMORE: 0)) {
+    if (zmq_sendmsg (socket, &message, more? ZMQ_SNDMORE: 0) == -1) {
         zmq_msg_close (&message);
         return -1;
     }


### PR DESCRIPTION
My buildbot instance indicated that there was a fault in pyczmq, however upon further investigation it turned out to be in czmq. zmq_sendmsg returns the number of bytes sent if successful. Due to the recent code change delivered by #719 a successful send is now falling into the error handling block.

The pyczmq was detecting this error because it is explicitly checking the return code from a zstr_send. Perhaps we need to think about beefing up the error checking in the czmq zstr_test function so as to detect these regressions sooner?
