### PR TITLE
Use system uuid functions in zuuid.c

### DIFF
--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -28,6 +28,10 @@
 #define HAVE_LIBUUID 1
 #endif
 
+#if defined (__UTYPE_OSX) && !defined (HAVE_LIBUUID)
+#define HAVE_LIBUUID 1
+#endif
+
 #if defined (HAVE_LIBUUID)
 #if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD)
 #   include <uuid.h>


### PR DESCRIPTION
On OS X, libuuid is part of the base system, however isn't found by autoconf as might be expected. Consequently this commit adds an explicit check for OS X and defines the `HAS_LIBUUID` symbol if that is what we are running. This makes `zuuid_new()` significantly faster on OS X.
