### PR TITLE
Distribute zsocket_option.h to library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ include_HEADERS = \
     ../include/zsocket.h \
     ../include/zsockopt.h \
     ../include/zsock.h \
+    ../include/zsock_option.h \
     ../include/zstr.h \
     ../include/zsys.h \
     ../include/zthread.h \


### PR DESCRIPTION
Otherwise projects that use czmq wont compile, e.g. zyre.
