### PR TITLE
a memory leak bug fix

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -260,6 +260,11 @@ zlist_remove (zlist_t *self, void *item)
             self->tail = prev;
         if (self->cursor == node)
             self->cursor = prev;
+        if (node->free_fn)
+            (node->free_fn) (node->item);
+        else
+        if (self->autofree)
+            free (node->item);
         free (node);
         self->size--;
     }


### PR DESCRIPTION
When an item is removed from a zlist_t, maybe some clean work should be done.

If zlist_free_fn is set, callback this function. If autofree is set, call free(3) to the item.
