### PR TITLE
Added zsys_run_as () method

### DIFF
--- a/doc/zsys.txt
+++ b/doc/zsys.txt
@@ -13,6 +13,12 @@ SYNOPSIS
 //  Callback for interrupt signal handler
 typedef void (zsys_handler_fn) (int signal_value);
 
+//  Get a new ZMQ socket, automagically creating a ZMQ context
+//  if this is the first time. Caller is responsible for destroying
+//  the ZMQ socket before process exits, to avoid a ZMQ deadlock.
+CZMQ_EXPORT void *
+    zsys_socket (int type);
+
 //  Set interrupt handler (NULL means external handler)
 CZMQ_EXPORT void
     zsys_handler_set (zsys_handler_fn *handler_fn);
@@ -119,6 +125,14 @@ CZMQ_EXPORT void
 //  Windows, does nothing. Returns 0 if OK, -1 if there was an error.
 CZMQ_EXPORT int
     zsys_daemonize (const char *workdir);
+
+//  Drop the process ID into the lockfile, with exclusive lock, and switch
+//  the process to the specified group and/or user. Any of the arguments
+//  may be null, indicating a no-op. Returns 0 on success, -1 on failure.
+//  Note if you combine this with zsys_daemonize, run after, not before
+//  that method, or the lockfile will hold the wrong process ID.
+CZMQ_EXPORT int
+    zsys_run_as (const char *lockfile, const char *group, const char *user);
 
 //  Self test of this class
 CZMQ_EXPORT int

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -137,6 +137,14 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int
     zsys_daemonize (const char *workdir);
 
+//  Drop the process ID into the lockfile, with exclusive lock, and switch
+//  the process to the specified group and/or user. Any of the arguments
+//  may be null, indicating a no-op. Returns 0 on success, -1 on failure.
+//  Note if you combine this with zsys_daemonize, run after, not before
+//  that method, or the lockfile will hold the wrong process ID.
+CZMQ_EXPORT int
+    zsys_run_as (const char *lockfile, const char *group, const char *user);
+
 //  Self test of this class
 CZMQ_EXPORT int
     zsys_test (bool verbose);


### PR DESCRIPTION
Drops PID into lockfile and optionally switches to specified
group/user. Ideal in combination with zsys_daemonize ().
