### PR TITLE
Problem: process hangs on exit if there are open sockets

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -24,12 +24,19 @@ extern "C" {
 //  Callback for interrupt signal handler
 typedef void (zsys_handler_fn) (int signal_value);
 
-//  Get a new ZMQ socket, automagically creating a ZMQ context
-//  if this is the first time. Caller is responsible for destroying
-//  the ZMQ socket before process exits, to avoid a ZMQ deadlock.
+//  Get a new ZMQ socket, automagically creating a ZMQ context if this is
+//  the first time. Caller is responsible for destroying the ZMQ socket
+//  before process exits, to avoid a ZMQ deadlock. Note: you should not use
+//  this method in CZMQ apps, use zsock_new() instead. This is for system
+//  use only, really.
 CZMQ_EXPORT void *
     zsys_socket (int type);
 
+//  Destroy/close a ZMQ socket. You should call this for every socket you
+//  create using zsys_socket().
+CZMQ_EXPORT int
+    zsys_close (void *self);
+    
 //  Set interrupt handler (NULL means external handler)
 CZMQ_EXPORT void
     zsys_handler_set (zsys_handler_fn *handler_fn);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -79,7 +79,7 @@ zsock_destroy (zsock_t **self_p)
         zsock_t *self = *self_p;
         assert (zsock_is (self));
         self->tag = 0xDeadBeef;
-        zmq_close (self->handle);
+        zsys_close (self->handle);
         free (self);
         *self_p = NULL;
     }


### PR DESCRIPTION
Old issue with libzmq shutdown that cannot handle open sockets. The
correct strategy for an application is to correctly call zsock_destroy
on all sockets before exiting. When the app does not do that, we want
to detect it and warn the user, and not call zmq_ctx_term() stupidly.

Solution: count number of open sockets in zsys and if non-zero, do not
call zmq_ctx_term() in exit handler.
