### PR TITLE
zdir now resistant to all file types

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -323,6 +323,11 @@ s_dir_compare (void *item1, void *item2)
 static bool
 s_file_compare (void *item1, void *item2)
 {
+    if (!item2)
+        return false;
+    if (!item1)
+        return true;
+
     if (strcmp (zfile_filename ((zfile_t *) item1, NULL),
                 zfile_filename ((zfile_t *) item2, NULL)) > 0)
         return true;


### PR DESCRIPTION
A directory full of UNIX sockets caused a zlist full of NULL. When the comparison
hook was called, no check was performed on the pointer's validity. Now it
doesn't segfault (for this reason).
