### PR TITLE
zlist now doesn't accept NULL items.

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -162,6 +162,9 @@ zlist_next (zlist_t *self)
 int
 zlist_append (zlist_t *self, void *item)
 {
+    if (!item)
+        return -1;
+
     node_t *node;
     node = (node_t *) zmalloc (sizeof (node_t));
     if (!node)


### PR DESCRIPTION
NULL seems to have a special meaning (e.g. end of list), so I propose considering useless and misleading to store them.
