### PR TITLE
Problem: need success/failure capacity in zsock signals

### DIFF
--- a/doc/zsock.txt
+++ b/doc/zsock.txt
@@ -68,16 +68,17 @@ CZMQ_EXPORT int
 CZMQ_EXPORT zmsg_t *
     zsock_recv (zsock_t *self);
 
-//  Send a signal over a socket. A signal is a zero-byte message. Signals
-//  are used primarily between threads, over pipe sockets. Returns -1 if
-//  there was an error sending the signal. Accepts a zsock_t or a zactor_t
-//  as argument.
+//  Send a signal over a socket. A signal is a short message carrying a
+//  success/failure code (by convention, 0 means OK). Signals are encoded
+//  to be distinguishable from "normal" messages. Accepts a zock_t or a
+//  zactor_t argument, and returns 0 if successful, -1 if the signal could
+//  not be sent.
 CZMQ_EXPORT int
-    zsock_signal (void *self);
-
+    zsock_signal (void *self, byte status);
+    
 //  Wait on a signal. Use this to coordinate between threads, over pipe
-//  pairs. Blocks until the signal is received. Returns -1 on error, 0 on
-//  success. Accepts a zsock_t or a zactor_t as argument.
+//  pairs. Blocks until the signal is received. Returns -1 on error, 0 or
+//  greater on success. Accepts a zsock_t or a zactor_t as argument.
 CZMQ_EXPORT int
     zsock_wait (void *self);
 
@@ -156,10 +157,10 @@ EXAMPLE
     rc = zsock_connect (reader, "txp://localhost:%d", service);
     assert (rc == -1);
 
-    rc = zsock_signal (writer);
+    rc = zsock_signal (writer, 123);
     assert (rc == 0);
     rc = zsock_wait (reader);
-    assert (rc == 0);
+    assert (rc == 123);
 
     zsock_destroy (&reader);
     zsock_destroy (&writer);

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -79,16 +79,17 @@ CZMQ_EXPORT int
 CZMQ_EXPORT zmsg_t *
     zsock_recv (zsock_t *self);
 
-//  Send a signal over a socket. A signal is a zero-byte message. Signals
-//  are used primarily between threads, over pipe sockets. Returns -1 if
-//  there was an error sending the signal. Accepts a zsock_t or a zactor_t
-//  as argument.
+//  Send a signal over a socket. A signal is a short message carrying a
+//  success/failure code (by convention, 0 means OK). Signals are encoded
+//  to be distinguishable from "normal" messages. Accepts a zock_t or a
+//  zactor_t argument, and returns 0 if successful, -1 if the signal could
+//  not be sent.
 CZMQ_EXPORT int
-    zsock_signal (void *self);
-
+    zsock_signal (void *self, byte status);
+    
 //  Wait on a signal. Use this to coordinate between threads, over pipe
-//  pairs. Blocks until the signal is received. Returns -1 on error, 0 on
-//  success. Accepts a zsock_t or a zactor_t as argument.
+//  pairs. Blocks until the signal is received. Returns -1 on error, 0 or
+//  greater on success. Accepts a zsock_t or a zactor_t as argument.
 CZMQ_EXPORT int
     zsock_wait (void *self);
 

--- a/src/zactor.c
+++ b/src/zactor.c
@@ -62,7 +62,7 @@ s_thread_shim (void *args)
     assert (args);
     shim_t *shim = (shim_t *) args;
     shim->handler (shim->pipe, shim->args);
-    zsock_signal (shim->pipe);
+    zsock_signal (shim->pipe, 0);
     zsock_destroy (&shim->pipe);
     free (shim);
     return NULL;
@@ -77,7 +77,7 @@ s_thread_shim (void *arglist)
     assert (arglist);
     shim_t *shim = (shim_t *) args;
     shim->handler (shim->pipe, shim->args);
-    zsock_signal (shim->pipe);
+    zsock_signal (shim->pipe, 0);
     zsock_destroy (&shim->pipe);
     free (shim);
     _endthreadex (0);           //  Terminates thread
@@ -233,7 +233,7 @@ echo_actor (zsock_t *pipe, void *args)
 {
     //  Do some initialization
     assert (streq ((char *) args, "Hello, World"));
-    zsock_signal (pipe);
+    zsock_signal (pipe, 0);
 
     bool terminated = false;
     while (!terminated) {


### PR DESCRIPTION
Solution: encode 1-byte status code into signal, as magic
8-byte number so that signals can be identified among "normal"
messages.
