### PR TITLE
Initialize priority

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1184,7 +1184,7 @@ s_log (char loglevel, char *string)
     }
 #if defined (__UNIX__)
     if (s_logsystem) {
-        int priority;
+        int priority = LOG_INFO;
         if (loglevel == 'E')
             priority = LOG_ERR;
         else


### PR DESCRIPTION
Fixing following compilation error

```
  CC       zsys.lo                                                                                                                                                                                    
cc1: warnings being treated as errors                                                                                                                                                                 
zsys.c: In function 's_log':                                                                                                                                                                          
zsys.c:1187: error: 'priority' may be used uninitialized in this function                                                                                                                             
make[2]: *** [zsys.lo] Error 1 
```
