### PR TITLE
Problem: zsys deadlocked at exit, if ZSOCK_NOCHECK was defined

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -26,8 +26,10 @@ extern "C" {
 //  define ZSOCK_NOCHECK before compiling your code.
 #if defined (ZSOCK_NOCHECK)
 #   define zsock_new(t) zsock_new_((t), NULL, 0)
+#   define zsock_destroy(t) zsock_destroy_((t), NULL, 0)
 #else
 #   define zsock_new(t) zsock_new_((t), __FILE__, __LINE__)
+#   define zsock_destroy(t) zsock_destroy_((t), __FILE__, __LINE__)
 #endif
 
 CZMQ_EXPORT zsock_t *
@@ -36,7 +38,7 @@ CZMQ_EXPORT zsock_t *
 //  Destroy the socket. You must use this for any socket created via the
 //  zsock_new method.
 CZMQ_EXPORT void
-    zsock_destroy (zsock_t **p_self);
+    zsock_destroy_ (zsock_t **self_p, const char *filename, size_t line_nbr);
 
 //  Bind a socket to a formatted endpoint. If the port is specified as '*'
 //  and the endpoint starts with "tcp://", binds to an ephemeral TCP port in

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -43,7 +43,7 @@ CZMQ_EXPORT void *
 //  create using zsys_socket().
 //  *** This is for CZMQ internal use only and may change arbitrarily ***
 CZMQ_EXPORT int
-    zsys_close (void *handle);
+    zsys_close (void *handle, const char *filename, size_t line_nbr);
     
 //  Set interrupt handler (NULL means external handler)
 CZMQ_EXPORT void

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -68,14 +68,14 @@ zsock_new_ (int type, const char *filename, size_t line_nbr)
 //  zsock_new method.
 
 void
-zsock_destroy (zsock_t **self_p)
+zsock_destroy_ (zsock_t **self_p, const char *filename, size_t line_nbr)
 {
     assert (self_p);
     if (*self_p) {
         zsock_t *self = *self_p;
         assert (zsock_is (self));
         self->tag = 0xDeadBeef;
-        int rc = zsys_close (self->handle);
+        int rc = zsys_close (self->handle, filename, line_nbr);
         assert (rc == 0);
         free (self);
         *self_p = NULL;


### PR DESCRIPTION
The code in zsys_close was wrong; it did not close sockets when the
macro was defined (due to sockets not being tracked). This led to a
shutdown deadlock in libzmq (due to 1 or more sockets remaining open).

Solution: when ZSOCK_NOCHECK is defined, do not attempt to use list
of tracked sockets in zsys_close. Always close socket. Second, if there
are sockets remaining open, log an error but don't call zmq_term().
