### PR TITLE
Problem: unreliable dependency on libsodium

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,44 +54,6 @@ AC_PROG_AWK
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([uuid], [uuid_generate])
 
-# Allow libsodium to be installed in a custom path:
-AC_ARG_WITH([libsodium],
-            [AS_HELP_STRING([--with-libsodium],
-                            [Specify libsodium prefix])],
-            [zmq_search_libsodium="yes"],
-            [])
-
-if test "x$zmq_search_libsodium" = "xyes"; then
-    if test -r "${with_libsodium}/include/sodium.h"; then
-        CPPFLAGS="-I${with_libsodium}/include ${CPPFLAGS}"
-        LDFLAGS="-L${with_libsodium}/lib ${LDFLAGS}"
-    fi
-fi
-
-AC_ARG_WITH([libsodium-include-dir],
-            [AS_HELP_STRING([--with-libsodium-include-dir],
-                            [Specify libsodium include prefix])],
-            [zmq_search_libsodium_include="yes"],
-            [])
-
-if test "x$zmq_search_libsodium_include" = "xyes"; then
-    if test -r "${with_libsodium_include_dir}/sodium.h"; then
-        CPPFLAGS="-I${with_libsodium_include_dir}/include ${CPPFLAGS}"
-    fi
-fi
-
-AC_ARG_WITH([libsodium_lib_dir],
-            [AS_HELP_STRING([--with-libsodium-lib-dir],
-                            [Specify libsodium library prefix])],
-            [zmq_search_libsodium_lib="yes"],
-            [])
-
-if test "x$zmq_search_libsodium_lib" = "xyes"; then
-    if test -r "${with_libsodium_lib_dir}/libsodium.{a|so|dylib}"; then
-        LDFLAGS="-L${with_libsodium}/lib ${LDFLAGS}"
-    fi
-fi
-
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting.])],
@@ -266,9 +228,6 @@ case "${host_os}" in
         AC_MSG_ERROR([unsupported system: ${host_os}.])
         ;;
 esac
-
-# Check for libsodium
-AC_CHECK_LIB([sodium], [sodium_init],,AC_MSG_WARN(libsodium is needed for CURVE security))
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -500,14 +500,6 @@ typedef int SOCKET;
 #   endif
 #endif
 
-#if defined (HAVE_LIBSODIUM)
-#   include <sodium.h>
-#   if crypto_box_PUBLICKEYBYTES != 32 \
-    || crypto_box_SECRETKEYBYTES != 32
-#       error "libsodium not built correctly"
-#   endif
-#endif
-
 #if defined (__WINDOWS__) && !defined (HAVE_LIBUUID)
 #   define HAVE_LIBUUID 1
 #endif

--- a/include/zsock_option.h
+++ b/include/zsock_option.h
@@ -28,6 +28,8 @@ extern "C" {
 #if (ZMQ_VERSION_MAJOR == 4)
 //  Get socket options
 CZMQ_EXPORT int zsock_tos (zsock_t *self);
+CZMQ_EXPORT char * zsock_zap_domain (zsock_t *self);
+CZMQ_EXPORT int zsock_mechanism (zsock_t *self);
 CZMQ_EXPORT int zsock_plain_server (zsock_t *self);
 CZMQ_EXPORT char * zsock_plain_username (zsock_t *self);
 CZMQ_EXPORT char * zsock_plain_password (zsock_t *self);
@@ -35,8 +37,6 @@ CZMQ_EXPORT int zsock_curve_server (zsock_t *self);
 CZMQ_EXPORT char * zsock_curve_publickey (zsock_t *self);
 CZMQ_EXPORT char * zsock_curve_secretkey (zsock_t *self);
 CZMQ_EXPORT char * zsock_curve_serverkey (zsock_t *self);
-CZMQ_EXPORT char * zsock_zap_domain (zsock_t *self);
-CZMQ_EXPORT int zsock_mechanism (zsock_t *self);
 CZMQ_EXPORT int zsock_ipv6 (zsock_t *self);
 CZMQ_EXPORT int zsock_immediate (zsock_t *self);
 CZMQ_EXPORT int zsock_ipv4only (zsock_t *self);
@@ -75,6 +75,7 @@ CZMQ_EXPORT void zsock_set_probe_router (zsock_t *self, int probe_router);
 CZMQ_EXPORT void zsock_set_req_relaxed (zsock_t *self, int req_relaxed);
 CZMQ_EXPORT void zsock_set_req_correlate (zsock_t *self, int req_correlate);
 CZMQ_EXPORT void zsock_set_conflate (zsock_t *self, int conflate);
+CZMQ_EXPORT void zsock_set_zap_domain (zsock_t *self, const char * zap_domain);
 CZMQ_EXPORT void zsock_set_plain_server (zsock_t *self, int plain_server);
 CZMQ_EXPORT void zsock_set_plain_username (zsock_t *self, const char * plain_username);
 CZMQ_EXPORT void zsock_set_plain_password (zsock_t *self, const char * plain_password);
@@ -85,7 +86,6 @@ CZMQ_EXPORT void zsock_set_curve_secretkey (zsock_t *self, const char * curve_se
 CZMQ_EXPORT void zsock_set_curve_secretkey_bin (zsock_t *self, const byte *curve_secretkey);
 CZMQ_EXPORT void zsock_set_curve_serverkey (zsock_t *self, const char * curve_serverkey);
 CZMQ_EXPORT void zsock_set_curve_serverkey_bin (zsock_t *self, const byte *curve_serverkey);
-CZMQ_EXPORT void zsock_set_zap_domain (zsock_t *self, const char * zap_domain);
 CZMQ_EXPORT void zsock_set_ipv6 (zsock_t *self, int ipv6);
 CZMQ_EXPORT void zsock_set_immediate (zsock_t *self, int immediate);
 CZMQ_EXPORT void zsock_set_router_raw (zsock_t *self, int router_raw);

--- a/include/zsockopt.h
+++ b/include/zsockopt.h
@@ -28,6 +28,8 @@ extern "C" {
 #if (ZMQ_VERSION_MAJOR == 4)
 //  Get socket options
 CZMQ_EXPORT int zsocket_tos (void *zocket);
+CZMQ_EXPORT char * zsocket_zap_domain (void *zocket);
+CZMQ_EXPORT int zsocket_mechanism (void *zocket);
 CZMQ_EXPORT int zsocket_plain_server (void *zocket);
 CZMQ_EXPORT char * zsocket_plain_username (void *zocket);
 CZMQ_EXPORT char * zsocket_plain_password (void *zocket);
@@ -35,8 +37,6 @@ CZMQ_EXPORT int zsocket_curve_server (void *zocket);
 CZMQ_EXPORT char * zsocket_curve_publickey (void *zocket);
 CZMQ_EXPORT char * zsocket_curve_secretkey (void *zocket);
 CZMQ_EXPORT char * zsocket_curve_serverkey (void *zocket);
-CZMQ_EXPORT char * zsocket_zap_domain (void *zocket);
-CZMQ_EXPORT int zsocket_mechanism (void *zocket);
 CZMQ_EXPORT int zsocket_ipv6 (void *zocket);
 CZMQ_EXPORT int zsocket_immediate (void *zocket);
 CZMQ_EXPORT int zsocket_ipv4only (void *zocket);
@@ -75,6 +75,7 @@ CZMQ_EXPORT void zsocket_set_probe_router (void *zocket, int probe_router);
 CZMQ_EXPORT void zsocket_set_req_relaxed (void *zocket, int req_relaxed);
 CZMQ_EXPORT void zsocket_set_req_correlate (void *zocket, int req_correlate);
 CZMQ_EXPORT void zsocket_set_conflate (void *zocket, int conflate);
+CZMQ_EXPORT void zsocket_set_zap_domain (void *zocket, const char * zap_domain);
 CZMQ_EXPORT void zsocket_set_plain_server (void *zocket, int plain_server);
 CZMQ_EXPORT void zsocket_set_plain_username (void *zocket, const char * plain_username);
 CZMQ_EXPORT void zsocket_set_plain_password (void *zocket, const char * plain_password);
@@ -85,7 +86,6 @@ CZMQ_EXPORT void zsocket_set_curve_secretkey (void *zocket, const char * curve_s
 CZMQ_EXPORT void zsocket_set_curve_secretkey_bin (void *zocket, const byte *curve_secretkey);
 CZMQ_EXPORT void zsocket_set_curve_serverkey (void *zocket, const char * curve_serverkey);
 CZMQ_EXPORT void zsocket_set_curve_serverkey_bin (void *zocket, const byte *curve_serverkey);
-CZMQ_EXPORT void zsocket_set_zap_domain (void *zocket, const char * zap_domain);
 CZMQ_EXPORT void zsocket_set_ipv6 (void *zocket, int ipv6);
 CZMQ_EXPORT void zsocket_set_immediate (void *zocket, int immediate);
 CZMQ_EXPORT void zsocket_set_router_raw (void *zocket, int router_raw);

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -169,6 +169,11 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsys_run_as (const char *lockfile, const char *group, const char *user);
 
+//  Returns true if the underlying libzmq supports CURVE security.
+//  Uses a heuristic probe according to the version of libzmq being used.
+CZMQ_EXPORT bool
+    zsys_has_curve (void);
+
 //  Configure the number of I/O threads that ZeroMQ will use. A good
 //  rule of thumb is one thread per gigabit of traffic in or out. The
 //  default is 1, sufficient for most applications. If the environment

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -3,6 +3,7 @@
      Requires gsl4 from https://github.com/imatix/gsl
      use 'gsl sockopts'
 -->
+
 <options script = "sockopts">
     <version major = "4" style = "macro">
         <!-- Options that are new in 4.1 -->
@@ -35,22 +36,18 @@
         </option>
         
         <!-- Security options -->
+        <option name = "zap_domain"        type = "string" mode = "rw" test = "SUB" />
+        <option name = "mechanism"         type = "int"    mode = "r"  test = "SUB" />
+
         <option name = "plain_server"      type = "int"    mode = "rw" test = "PUB" />
         <option name = "plain_username"    type = "string" mode = "rw" test = "SUB" />
         <option name = "plain_password"    type = "string" mode = "rw" test = "SUB" />
-        <option name = "curve_server"      type = "int"    mode = "rw" test = "PUB"
-                ifdef = "HAVE_LIBSODIUM" />
-        <option name = "curve_publickey"   type = "key"    mode = "rw" test = "PUB"
-                ifdef = "HAVE_LIBSODIUM"
-                test_value = "Yne@$w-vo<fVvi]a<NY6T1ed:M$fCG*[IaLV{hID" />
-        <option name = "curve_secretkey"   type = "key"    mode = "rw" test = "PUB"
-                ifdef = "HAVE_LIBSODIUM"
-                test_value = "D:)Q[IlAW!ahhC2ac:9*A}h:p?([4%wOTJ%JR%cs" />
-        <option name = "curve_serverkey"   type = "key"    mode = "rw" test = "SUB"
-                ifdef = "HAVE_LIBSODIUM"
-                test_value = "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7" />
-        <option name = "zap_domain"        type = "string" mode = "rw" test = "SUB" />
-        <option name = "mechanism"         type = "int"    mode = "r"  test = "SUB" />
+
+        <!-- We don't test these as libzmq doesn't always support CURVE security -->
+        <option name = "curve_server"      type = "int"    mode = "rw" />
+        <option name = "curve_publickey"   type = "key"    mode = "rw" />
+        <option name = "curve_secretkey"   type = "key"    mode = "rw" />
+        <option name = "curve_serverkey"   type = "key"    mode = "rw" />
 
         <!-- New names for deprecated 3.x options -->
         <option name = "ipv6"              type = "int"    mode = "rw" test = "SUB" />

--- a/src/zauth.c
+++ b/src/zauth.c
@@ -684,45 +684,45 @@ zauth_test (bool verbose)
     success = s_can_connect (ctx, &server, &client);
     assert (!success);
 
-#   if defined (HAVE_LIBSODIUM)
-    //  Try CURVE authentication
-    //  We'll create two new certificates and save the client public
-    //  certificate on disk; in a real case we'd transfer this securely
-    //  from the client machine to the server machine.
-    zcert_t *server_cert = zcert_new ();
-    zcert_t *client_cert = zcert_new ();
-    char *server_key = zcert_public_txt (server_cert);
-    
-    //  Test without setting-up any authentication
-    zcert_apply (server_cert, server);
-    zcert_apply (client_cert, client);
-    zsocket_set_curve_server (server, 1);
-    zsocket_set_curve_serverkey (client, server_key);
-    success = s_can_connect (ctx, &server, &client);
-    assert (!success);
+    if (zsys_has_curve ()) {
+        //  Try CURVE authentication
+        //  We'll create two new certificates and save the client public
+        //  certificate on disk; in a real case we'd transfer this securely
+        //  from the client machine to the server machine.
+        zcert_t *server_cert = zcert_new ();
+        zcert_t *client_cert = zcert_new ();
+        char *server_key = zcert_public_txt (server_cert);
 
-    //  Test CURVE_ALLOW_ANY
-    zcert_apply (server_cert, server);
-    zcert_apply (client_cert, client);
-    zsocket_set_curve_server (server, 1);
-    zsocket_set_curve_serverkey (client, server_key);
-    zauth_configure_curve (auth, "*", CURVE_ALLOW_ANY);
-    success = s_can_connect (ctx, &server, &client);
-    assert (success);
+        //  Test without setting-up any authentication
+        zcert_apply (server_cert, server);
+        zcert_apply (client_cert, client);
+        zsocket_set_curve_server (server, 1);
+        zsocket_set_curve_serverkey (client, server_key);
+        success = s_can_connect (ctx, &server, &client);
+        assert (!success);
 
-    //  Test full client authentication using certificates
-    zcert_apply (server_cert, server);
-    zcert_apply (client_cert, client);
-    zsocket_set_curve_server (server, 1);
-    zsocket_set_curve_serverkey (client, server_key);
-    zcert_save_public (client_cert, TESTDIR "/mycert.txt");
-    zauth_configure_curve (auth, "*", TESTDIR);
-    success = s_can_connect (ctx, &server, &client);
-    assert (success);
-    
-    zcert_destroy (&server_cert);
-    zcert_destroy (&client_cert);
-#   endif
+        //  Test CURVE_ALLOW_ANY
+        zcert_apply (server_cert, server);
+        zcert_apply (client_cert, client);
+        zsocket_set_curve_server (server, 1);
+        zsocket_set_curve_serverkey (client, server_key);
+        zauth_configure_curve (auth, "*", CURVE_ALLOW_ANY);
+        success = s_can_connect (ctx, &server, &client);
+        assert (success);
+
+        //  Test full client authentication using certificates
+        zcert_apply (server_cert, server);
+        zcert_apply (client_cert, client);
+        zsocket_set_curve_server (server, 1);
+        zsocket_set_curve_serverkey (client, server_key);
+        zcert_save_public (client_cert, TESTDIR "/mycert.txt");
+        zauth_configure_curve (auth, "*", TESTDIR);
+        success = s_can_connect (ctx, &server, &client);
+        assert (success);
+
+        zcert_destroy (&server_cert);
+        zcert_destroy (&client_cert);
+    }
     //  Remove the authenticator and check a normal connection works
     zauth_destroy (&auth);
     success = s_can_connect (ctx, &server, &client);

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -221,7 +221,6 @@ void
 zcertstore_test (bool verbose)
 {
     printf (" * zcertstore: ");
-#if (ZMQ_VERSION_MAJOR == 4)
     //  @selftest
     //  Create temporary directory for test files
 #   define TESTDIR ".test_zcertstore"
@@ -230,7 +229,6 @@ zcertstore_test (bool verbose)
     //  Load certificate store from disk; it will be empty
     zcertstore_t *certstore = zcertstore_new (TESTDIR);
     
-#   if defined (HAVE_LIBSODIUM)
     //  Create a single new certificate and save to disk
     zcert_t *cert = zcert_new ();
     char *client_key = strdup (zcert_public_txt (cert));
@@ -243,7 +241,7 @@ zcertstore_test (bool verbose)
     assert (cert);
     assert (streq (zcert_meta (cert, "name"), "John Doe"));
     free (client_key);
-#   endif
+    
     if (verbose)
         zcertstore_print (certstore);
     zcertstore_destroy (&certstore);
@@ -253,6 +251,5 @@ zcertstore_test (bool verbose)
     zdir_remove (dir, true);
     zdir_destroy (&dir);
     //  @end
-#endif    
     printf ("OK\n");
 }

--- a/src/zsock_option.c
+++ b/src/zsock_option.c
@@ -186,6 +186,59 @@ zsock_set_conflate (zsock_t *self, int conflate)
 
 
 //  --------------------------------------------------------------------------
+//  Set socket ZMQ_ZAP_DOMAIN value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsock_set_zap_domain (zsock_t *self, const char * zap_domain)
+{
+    assert(self);
+#   if defined (ZMQ_ZAP_DOMAIN)
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, strlen (zap_domain));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_ZAP_DOMAIN value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+char * 
+zsock_zap_domain (zsock_t *self)
+{
+    assert(self);
+#   if defined (ZMQ_ZAP_DOMAIN)
+    size_t option_len = 255;
+    char *zap_domain = (char *) zmalloc (option_len);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, &option_len);
+    return (char *) zap_domain;
+#   else
+    return NULL;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_MECHANISM value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int 
+zsock_mechanism (zsock_t *self)
+{
+    assert(self);
+#   if defined (ZMQ_MECHANISM)
+    int mechanism;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_MECHANISM, &mechanism, &option_len);
+    return mechanism;
+#   else
+    return 0;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_PLAIN_SERVER value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -296,10 +349,8 @@ zsock_set_curve_server (zsock_t *self, int curve_server)
 {
     assert(self);
 #   if defined (ZMQ_CURVE_SERVER)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVER, &curve_server, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -332,10 +383,8 @@ zsock_set_curve_publickey (zsock_t *self, const char * curve_publickey)
 {
     assert(self);
 #   if defined (ZMQ_CURVE_PUBLICKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_PUBLICKEY, curve_publickey, strlen (curve_publickey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -348,10 +397,8 @@ void
 zsock_set_curve_publickey_bin (zsock_t *self, const byte *curve_publickey)
 {
 #   if defined (ZMQ_CURVE_PUBLICKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_PUBLICKEY, curve_publickey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -384,10 +431,8 @@ zsock_set_curve_secretkey (zsock_t *self, const char * curve_secretkey)
 {
     assert(self);
 #   if defined (ZMQ_CURVE_SECRETKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SECRETKEY, curve_secretkey, strlen (curve_secretkey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -400,10 +445,8 @@ void
 zsock_set_curve_secretkey_bin (zsock_t *self, const byte *curve_secretkey)
 {
 #   if defined (ZMQ_CURVE_SECRETKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SECRETKEY, curve_secretkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -436,10 +479,8 @@ zsock_set_curve_serverkey (zsock_t *self, const char * curve_serverkey)
 {
     assert(self);
 #   if defined (ZMQ_CURVE_SERVERKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVERKEY, curve_serverkey, strlen (curve_serverkey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -452,10 +493,8 @@ void
 zsock_set_curve_serverkey_bin (zsock_t *self, const byte *curve_serverkey)
 {
 #   if defined (ZMQ_CURVE_SERVERKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVERKEY, curve_serverkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -475,59 +514,6 @@ zsock_curve_serverkey (zsock_t *self)
     return (char *) curve_serverkey;
 #   else
     return NULL;
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_ZAP_DOMAIN value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_zap_domain (zsock_t *self, const char * zap_domain)
-{
-    assert(self);
-#   if defined (ZMQ_ZAP_DOMAIN)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, strlen (zap_domain));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_ZAP_DOMAIN value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char * 
-zsock_zap_domain (zsock_t *self)
-{
-    assert(self);
-#   if defined (ZMQ_ZAP_DOMAIN)
-    size_t option_len = 255;
-    char *zap_domain = (char *) zmalloc (option_len);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, &option_len);
-    return (char *) zap_domain;
-#   else
-    return NULL;
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_MECHANISM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int 
-zsock_mechanism (zsock_t *self)
-{
-    assert(self);
-#   if defined (ZMQ_MECHANISM)
-    int mechanism;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_MECHANISM, &mechanism, &option_len);
-    return mechanism;
-#   else
-    return 0;
 #   endif
 }
 
@@ -3221,6 +3207,21 @@ zsock_option_test (bool verbose)
     zsock_set_conflate (self, 1);
     zsock_destroy (&self);
 #     endif
+#     if defined (ZMQ_ZAP_DOMAIN)
+    self = zsock_new (ZMQ_SUB);
+    assert (self);
+    zsock_set_zap_domain (self, "test");
+    char *zap_domain = zsock_zap_domain (self);
+    assert (zap_domain);
+    free (zap_domain);
+    zsock_destroy (&self);
+#     endif
+#     if defined (ZMQ_MECHANISM)
+    self = zsock_new (ZMQ_SUB);
+    assert (self);
+    zsock_mechanism (self);
+    zsock_destroy (&self);
+#     endif
 #     if defined (ZMQ_PLAIN_SERVER)
     self = zsock_new (ZMQ_PUB);
     assert (self);
@@ -3245,64 +3246,6 @@ zsock_option_test (bool verbose)
     char *plain_password = zsock_plain_password (self);
     assert (plain_password);
     free (plain_password);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_CURVE_SERVER)
-#       if defined (HAVE_LIBSODIUM)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_curve_server (self, 1);
-    assert (zsock_curve_server (self) == 1);
-    zsock_curve_server (self);
-    zsock_destroy (&self);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_PUBLICKEY)
-#       if defined (HAVE_LIBSODIUM)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_curve_publickey (self, "Yne@$w-vo<fVvi]a<NY6T1ed:M$fCG*[IaLV{hID");
-    char *curve_publickey = zsock_curve_publickey (self);
-    assert (curve_publickey);
-    free (curve_publickey);
-    zsock_destroy (&self);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_SECRETKEY)
-#       if defined (HAVE_LIBSODIUM)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_curve_secretkey (self, "D:)Q[IlAW!ahhC2ac:9*A}h:p?([4%wOTJ%JR%cs");
-    char *curve_secretkey = zsock_curve_secretkey (self);
-    assert (curve_secretkey);
-    free (curve_secretkey);
-    zsock_destroy (&self);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_SERVERKEY)
-#       if defined (HAVE_LIBSODIUM)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_curve_serverkey (self, "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7");
-    char *curve_serverkey = zsock_curve_serverkey (self);
-    assert (curve_serverkey);
-    free (curve_serverkey);
-    zsock_destroy (&self);
-#       endif
-#     endif
-#     if defined (ZMQ_ZAP_DOMAIN)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_zap_domain (self, "test");
-    char *zap_domain = zsock_zap_domain (self);
-    assert (zap_domain);
-    free (zap_domain);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_MECHANISM)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_mechanism (self);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_IPV6)

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -127,9 +127,6 @@ zsock_set_$(name) (zsock_t *self, $(ctype_const) $(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
-.       if defined (.ifdef)
-#     if defined ($(ifdef:))
-.       endif
 .           if count (restrict)
 .               for restrict
 .                   if first()
@@ -165,9 +162,6 @@ zsock_set_$(name) (zsock_t *self, $(ctype_const) $(name))
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), strlen ($(name)));
 .           endif
     assert (rc == 0 || zmq_errno () == ETERM);
-.       if defined (.ifdef)
-#     endif
-.       endif
 .       if style = "macro"
 #   endif
 .       endif
@@ -186,14 +180,8 @@ zsock_set_$(name)_bin (zsock_t *self, const byte *$(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
-.       if defined (.ifdef)
-#     if defined ($(ifdef:))
-.       endif
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-.       if defined (.ifdef)
-#     endif
-.       endif
 .       if style = "macro"
 #   endif
 .       endif
@@ -281,15 +269,12 @@ zsock_option_test (bool verbose)
     zsock_t *self;
 .for version
 #if (ZMQ_VERSION_MAJOR == $(major))
-.   for option
+.   for option where defined (test)
 .       if defined (.minor)
 #   if (ZMQ_VERSION_MINOR == $(minor))
 .       endif
 .       if style = "macro"
 #     if defined (ZMQ_$(NAME))
-.       endif
-.       if defined (.ifdef)
-#       if defined ($(ifdef:))
 .       endif
     self = zsock_new (ZMQ_$(TEST));
     assert (self);
@@ -313,9 +298,6 @@ zsock_option_test (bool verbose)
 .           endif
 .       endif
     zsock_destroy (&self);
-.       if defined (.ifdef)
-#       endif
-.       endif
 .       if style = "macro"
 #     endif
 .       endif

--- a/src/zsockopt.c
+++ b/src/zsockopt.c
@@ -178,6 +178,56 @@ zsocket_set_conflate (void *zocket, int conflate)
 
 
 //  --------------------------------------------------------------------------
+//  Set socket ZMQ_ZAP_DOMAIN value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsocket_set_zap_domain (void *zocket, const char * zap_domain)
+{
+#   if defined (ZMQ_ZAP_DOMAIN)
+    int rc = zmq_setsockopt (zocket, ZMQ_ZAP_DOMAIN, zap_domain, strlen (zap_domain));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_ZAP_DOMAIN value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+char * 
+zsocket_zap_domain (void *zocket)
+{
+#   if defined (ZMQ_ZAP_DOMAIN)
+    size_t option_len = 255;
+    char *zap_domain = (char *) zmalloc (option_len);
+    zmq_getsockopt (zocket, ZMQ_ZAP_DOMAIN, zap_domain, &option_len);
+    return (char *) zap_domain;
+#   else
+    return NULL;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_MECHANISM value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int 
+zsocket_mechanism (void *zocket)
+{
+#   if defined (ZMQ_MECHANISM)
+    int mechanism;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zocket, ZMQ_MECHANISM, &mechanism, &option_len);
+    return mechanism;
+#   else
+    return 0;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_PLAIN_SERVER value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -281,10 +331,8 @@ void
 zsocket_set_curve_server (void *zocket, int curve_server)
 {
 #   if defined (ZMQ_CURVE_SERVER)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_SERVER, &curve_server, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -315,10 +363,8 @@ void
 zsocket_set_curve_publickey (void *zocket, const char * curve_publickey)
 {
 #   if defined (ZMQ_CURVE_PUBLICKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_PUBLICKEY, curve_publickey, strlen (curve_publickey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -331,10 +377,8 @@ void
 zsocket_set_curve_publickey_bin (void *zocket, const byte *curve_publickey)
 {
 #   if defined (ZMQ_CURVE_PUBLICKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_PUBLICKEY, curve_publickey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -365,10 +409,8 @@ void
 zsocket_set_curve_secretkey (void *zocket, const char * curve_secretkey)
 {
 #   if defined (ZMQ_CURVE_SECRETKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_SECRETKEY, curve_secretkey, strlen (curve_secretkey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -381,10 +423,8 @@ void
 zsocket_set_curve_secretkey_bin (void *zocket, const byte *curve_secretkey)
 {
 #   if defined (ZMQ_CURVE_SECRETKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_SECRETKEY, curve_secretkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -415,10 +455,8 @@ void
 zsocket_set_curve_serverkey (void *zocket, const char * curve_serverkey)
 {
 #   if defined (ZMQ_CURVE_SERVERKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_SERVERKEY, curve_serverkey, strlen (curve_serverkey));
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -431,10 +469,8 @@ void
 zsocket_set_curve_serverkey_bin (void *zocket, const byte *curve_serverkey)
 {
 #   if defined (ZMQ_CURVE_SERVERKEY)
-#     if defined (HAVE_LIBSODIUM)
     int rc = zmq_setsockopt (zocket, ZMQ_CURVE_SERVERKEY, curve_serverkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-#     endif
 #   endif
 }
 
@@ -453,56 +489,6 @@ zsocket_curve_serverkey (void *zocket)
     return (char *) curve_serverkey;
 #   else
     return NULL;
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_ZAP_DOMAIN value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsocket_set_zap_domain (void *zocket, const char * zap_domain)
-{
-#   if defined (ZMQ_ZAP_DOMAIN)
-    int rc = zmq_setsockopt (zocket, ZMQ_ZAP_DOMAIN, zap_domain, strlen (zap_domain));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_ZAP_DOMAIN value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char * 
-zsocket_zap_domain (void *zocket)
-{
-#   if defined (ZMQ_ZAP_DOMAIN)
-    size_t option_len = 255;
-    char *zap_domain = (char *) zmalloc (option_len);
-    zmq_getsockopt (zocket, ZMQ_ZAP_DOMAIN, zap_domain, &option_len);
-    return (char *) zap_domain;
-#   else
-    return NULL;
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_MECHANISM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int 
-zsocket_mechanism (void *zocket)
-{
-#   if defined (ZMQ_MECHANISM)
-    int mechanism;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zocket, ZMQ_MECHANISM, &mechanism, &option_len);
-    return mechanism;
-#   else
-    return 0;
 #   endif
 }
 
@@ -3048,6 +3034,21 @@ zsockopt_test (bool verbose)
     zsocket_set_conflate (zocket, 1);
     zsocket_destroy (ctx, zocket);
 #     endif
+#     if defined (ZMQ_ZAP_DOMAIN)
+    zocket = zsocket_new (ctx, ZMQ_SUB);
+    assert (zocket);
+    zsocket_set_zap_domain (zocket, "test");
+    char *zap_domain = zsocket_zap_domain (zocket);
+    assert (zap_domain);
+    free (zap_domain);
+    zsocket_destroy (ctx, zocket);
+#     endif
+#     if defined (ZMQ_MECHANISM)
+    zocket = zsocket_new (ctx, ZMQ_SUB);
+    assert (zocket);
+    zsocket_mechanism (zocket);
+    zsocket_destroy (ctx, zocket);
+#     endif
 #     if defined (ZMQ_PLAIN_SERVER)
     zocket = zsocket_new (ctx, ZMQ_PUB);
     assert (zocket);
@@ -3072,64 +3073,6 @@ zsockopt_test (bool verbose)
     char *plain_password = zsocket_plain_password (zocket);
     assert (plain_password);
     free (plain_password);
-    zsocket_destroy (ctx, zocket);
-#     endif
-#     if defined (ZMQ_CURVE_SERVER)
-#       if defined (HAVE_LIBSODIUM)
-    zocket = zsocket_new (ctx, ZMQ_PUB);
-    assert (zocket);
-    zsocket_set_curve_server (zocket, 1);
-    assert (zsocket_curve_server (zocket) == 1);
-    zsocket_curve_server (zocket);
-    zsocket_destroy (ctx, zocket);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_PUBLICKEY)
-#       if defined (HAVE_LIBSODIUM)
-    zocket = zsocket_new (ctx, ZMQ_PUB);
-    assert (zocket);
-    zsocket_set_curve_publickey (zocket, "Yne@$w-vo<fVvi]a<NY6T1ed:M$fCG*[IaLV{hID");
-    char *curve_publickey = zsocket_curve_publickey (zocket);
-    assert (curve_publickey);
-    free (curve_publickey);
-    zsocket_destroy (ctx, zocket);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_SECRETKEY)
-#       if defined (HAVE_LIBSODIUM)
-    zocket = zsocket_new (ctx, ZMQ_PUB);
-    assert (zocket);
-    zsocket_set_curve_secretkey (zocket, "D:)Q[IlAW!ahhC2ac:9*A}h:p?([4%wOTJ%JR%cs");
-    char *curve_secretkey = zsocket_curve_secretkey (zocket);
-    assert (curve_secretkey);
-    free (curve_secretkey);
-    zsocket_destroy (ctx, zocket);
-#       endif
-#     endif
-#     if defined (ZMQ_CURVE_SERVERKEY)
-#       if defined (HAVE_LIBSODIUM)
-    zocket = zsocket_new (ctx, ZMQ_SUB);
-    assert (zocket);
-    zsocket_set_curve_serverkey (zocket, "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7");
-    char *curve_serverkey = zsocket_curve_serverkey (zocket);
-    assert (curve_serverkey);
-    free (curve_serverkey);
-    zsocket_destroy (ctx, zocket);
-#       endif
-#     endif
-#     if defined (ZMQ_ZAP_DOMAIN)
-    zocket = zsocket_new (ctx, ZMQ_SUB);
-    assert (zocket);
-    zsocket_set_zap_domain (zocket, "test");
-    char *zap_domain = zsocket_zap_domain (zocket);
-    assert (zap_domain);
-    free (zap_domain);
-    zsocket_destroy (ctx, zocket);
-#     endif
-#     if defined (ZMQ_MECHANISM)
-    zocket = zsocket_new (ctx, ZMQ_SUB);
-    assert (zocket);
-    zsocket_mechanism (zocket);
     zsocket_destroy (ctx, zocket);
 #     endif
 #     if defined (ZMQ_IPV6)

--- a/src/zsockopt.gsl
+++ b/src/zsockopt.gsl
@@ -126,9 +126,6 @@ zsocket_set_$(name) (void *zocket, $(ctype_const) $(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
-.       if defined (.ifdef)
-#     if defined ($(ifdef:))
-.       endif
 .           if count (restrict)
 .               for restrict
 .                   if first()
@@ -164,9 +161,6 @@ zsocket_set_$(name) (void *zocket, $(ctype_const) $(name))
     int rc = zmq_setsockopt (zocket, ZMQ_$(NAME), $(name), strlen ($(name)));
 .           endif
     assert (rc == 0 || zmq_errno () == ETERM);
-.       if defined (.ifdef)
-#     endif
-.       endif
 .       if style = "macro"
 #   endif
 .       endif
@@ -185,14 +179,8 @@ zsocket_set_$(name)_bin (void *zocket, const byte *$(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
-.       if defined (.ifdef)
-#     if defined ($(ifdef:))
-.       endif
     int rc = zmq_setsockopt (zocket, ZMQ_$(NAME), $(name), 32);
     assert (rc == 0 || zmq_errno () == ETERM);
-.       if defined (.ifdef)
-#     endif
-.       endif
 .       if style = "macro"
 #   endif
 .       endif
@@ -281,15 +269,12 @@ zsockopt_test (bool verbose)
     void *zocket;
 .for version
 #if (ZMQ_VERSION_MAJOR == $(major))
-.   for option
+.   for option where defined (test)
 .       if defined (.minor)
 #   if (ZMQ_VERSION_MINOR == $(minor))
 .       endif
 .       if style = "macro"
 #     if defined (ZMQ_$(NAME))
-.       endif
-.       if defined (.ifdef)
-#       if defined ($(ifdef:))
 .       endif
     zocket = zsocket_new (ctx, ZMQ_$(TEST));
     assert (zocket);
@@ -313,9 +298,6 @@ zsockopt_test (bool verbose)
 .           endif
 .       endif
     zsocket_destroy (ctx, zocket);
-.       if defined (.ifdef)
-#       endif
-.       endif
 .       if style = "macro"
 #     endif
 .       endif


### PR DESCRIPTION
CZMQ doesn't need libsodium, as all relevant calls are wrapped in the
zmq_util layer. Furthermore, detecting and using libsodium in CZMQ is
fragile as it is too easy to build libzmq and CZMQ inconsistently.

Additionally, the previous approach assumed CZMQ would be rebuilt if
there was a change to libzmq.

Solution: remove all dependencies on libsodium. Use zsys_has_curve()
to detect and report whether libzmq was built with libsodium or not.
This lets us switch CURVE on/off dynamically by installing different
builds of libzmq.
