### PR TITLE
Problem: zctx_new always catching interrupt signals

### DIFF
--- a/src/zctx.c
+++ b/src/zctx.c
@@ -79,7 +79,12 @@ zctx_new (void)
     self->pipehwm = 1000;   
     self->sndhwm = 1000;
     self->rcvhwm = 1000;
-    zsys_catch_interrupts ();
+
+    //  Catch SIGINT and SIGTERM unless ZSYS_SIGHANDLER=false
+    if (getenv ("ZSYS_SIGHANDLER") == NULL
+    || strneq (getenv ("ZSYS_SIGHANDLER"), "true"))
+        zsys_catch_interrupts ();
+    
     return self;
 }
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -219,9 +219,10 @@ s_initialize_process (void)
         if (streq (getenv ("ZSYS_LOGSYSTEM"), "false"))
             s_logsystem = false;
     }
-    bool handle_signals = true;
-    if (getenv ("ZSYS_SIGHANDLER"))
-        handle_signals = streq (getenv ("ZSYS_SIGHANDLER"), "true");
+    //  Catch SIGINT and SIGTERM unless ZSYS_SIGHANDLER=false
+    if (getenv ("ZSYS_SIGHANDLER") == NULL
+    || strneq (getenv ("ZSYS_SIGHANDLER"), "true"))
+        zsys_catch_interrupts ();
 
     //  This call keeps compatibility back to ZMQ v2
     process_ctx = zmq_init ((int) s_io_threads);
@@ -232,8 +233,6 @@ s_initialize_process (void)
 #endif
     ZMUTEX_INIT (s_mutex);
     s_sockref_list = zlist_new ();
-    if (handle_signals)
-        zsys_catch_interrupts ();
     srandom ((unsigned) time (NULL));
     atexit (s_terminate_process);
 }


### PR DESCRIPTION
Solution: make conditional on ZSYS_SIGHANDLER environment variable
as done in zsys.
