### PR TITLE
zsys: don't leak string when realloc fails

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -663,7 +663,8 @@ zsys_vprintf (const char *format, va_list argptr)
     //  larger buffer for it.
     if (required >= size) {
         size = required + 1;
-        string = (char *) realloc (string, size);
+        free (string);
+        string = (char *) malloc (size);
         if (string) {
             va_copy (my_argptr, argptr);
             vsnprintf (string, size, format, my_argptr);


### PR DESCRIPTION
We are not interested in realloc since the string is rewritten
in full anyway.  Switch to a more explicit free/malloc style.
