### PR TITLE
Problem: selftest failing on libzmq 4.0.x without libsodium

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -993,7 +993,7 @@ zsys_has_curve (void)
     int rc = zmq_setsockopt (pub, ZMQ_CURVE_SERVER, &as_server, sizeof (int));
     zmq_close (pub);
     zmq_ctx_term (ctx);
-    return rc != EINVAL;
+    return rc != -1;
 #   endif
 #else
     return false;


### PR DESCRIPTION
One assertion failure in zcert.c:68, and a bug in zsys_has_curve
which checked 'rc != EINVAL' instead of 'rc != -1'

Solution: fixed these issues.
