### PR TITLE
Windows zbeacon ZSYS_INTERFACE support and correct default adapter

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -566,7 +566,7 @@ s_get_interface (agent_t *self)
         char *asciiFriendlyName = (char*) zmalloc(asciiSize);
         wcstombs_s (&friendlyLength, asciiFriendlyName, asciiSize, friendlyName, _TRUNCATE);
 
-        int filter = any_interface || (strcmp (zsys_interface (), asciiFriendlyName));
+        int filter = any_interface || (strcmp (zsys_interface (), asciiFriendlyName) == 0);
         int valid = cur_address->OperStatus == IfOperStatusUp;
 
         if (filter && valid && pUnicast && pPrefix) {


### PR DESCRIPTION
Default adapter was set to INADDR_ANY, which does not work on Windows when calling getnameinfo.
