### PR TITLE
Remove deprecated header.

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -545,7 +545,6 @@ typedef int SOCKET;
 //- Always include ZeroMQ header file ---------------------------------------
 
 #include "zmq.h"
-#include "zmq_utils.h"
 
 #if ZMQ_VERSION_MAJOR == 4
 #   define ZMQ_POLL_MSEC    1           //  zmq_poll is msec


### PR DESCRIPTION
The header has a missing EOL at the end, causing MacOS to fail to compile it
