### PR TITLE
zbeacon: uses only interfaces that are running

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -462,6 +462,9 @@ s_get_interface (agent_t *self)
             && !(interface->ifa_flags & IFF_LOOPBACK)       //  Ignore loopback interface
             &&  (interface->ifa_flags & IFF_BROADCAST)      //  Only use interfaces that have BROADCAST
             && !(interface->ifa_flags & IFF_POINTOPOINT)    //  Ignore point to point interfaces.
+#if defined(IFF_SLAVE)
+            && !(interface->ifa_flags & IFF_SLAVE)          //  Ignore devices that are bonding slaves.
+#endif
             &&   interface->ifa_addr
             &&  (interface->ifa_addr->sa_family == AF_INET)) {
                 self->address = *(inaddr_t *) interface->ifa_addr;


### PR DESCRIPTION
Adds a check in s_get_interface to ignore the interfaces that do not
have the IFF_UP flag set.
