### PR TITLE
Add _TRUNCATE define on zbeacon.c for some mingw compilers

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -30,6 +30,12 @@
 #include "platform.h"
 #include "../include/czmq.h"
 
+#ifdef __WINDOWS__
+#ifndef _TRUNCATE
+#define _TRUNCATE ((size_t)-1)
+#endif
+#endif
+
 //  Constants
 #define INTERVAL_DFLT  1000         //  Default interval = 1 second
 


### PR DESCRIPTION
In some mingw compilers, the '_TRUNCATE' (used in s_get_interface function) is not defined and, thus it generates a compiler error.
