### PR TITLE
Create a monotonic clock function, use where time offsets are computed

### DIFF
--- a/include/zclock.h
+++ b/include/zclock.h
@@ -27,6 +27,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int64_t
     zclock_time (void);
 
+//  Return current monotonic clock in milliseconds
+CZMQ_EXPORT int64_t
+    zclock_mono (void);
+
 //  Return formatted date/time as fresh string. Free using zstr_free().
 CZMQ_EXPORT char *
     zclock_timestr (void);

--- a/src/test_zgossip.c
+++ b/src/test_zgossip.c
@@ -150,7 +150,7 @@ int main (int argn, char *argv [])
     //  Each actor will deliver us tuples; count these until we're done
     int total = set_size * swarm_size;
     int pending = total;
-    int64_t ticker = zclock_time () + 2000;
+    int64_t ticker = zclock_mono () + 2000;
     while (pending) {
         zsock_t *which = (zsock_t *) zpoller_wait (poller, 100);
         if (!which) {
@@ -162,10 +162,10 @@ int main (int argn, char *argv [])
         assert (streq (command, "DELIVER"));
         pending--;
         free (command);
-        if (zclock_time () > ticker) {
+        if (zclock_mono () > ticker) {
             printf ("(%d%%)", (int) ((100 * (total - pending)) / total));
             fflush (stdout);
-            ticker = zclock_time () + 2000;
+            ticker = zclock_mono () + 2000;
         }
     }
     //  Destroy swarm

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -271,9 +271,9 @@ zbeacon_test (bool verbose)
         zbeacon_socket (node2), 
         zbeacon_socket (node3), NULL);
         
-    int64_t stop_at = zclock_time () + 1000;
-    while (zclock_time () < stop_at) {
-        long timeout = (long) (stop_at - zclock_time ());
+    int64_t stop_at = zclock_mono () + 1000;
+    while (zclock_mono () < stop_at) {
+        long timeout = (long) (stop_at - zclock_mono ());
         if (timeout < 0)
             timeout = 0;
         void *which = zpoller_wait (poller, timeout * ZMQ_POLL_MSEC);
@@ -364,7 +364,7 @@ s_agent_task (void *args, zctx_t *ctx, void *pipe)
         };
         long timeout = -1;
         if (self->transmit) {
-            timeout = (long) (self->ping_at - zclock_time ());
+            timeout = (long) (self->ping_at - zclock_mono ());
             if (timeout < 0)
                 timeout = 0;
         }
@@ -377,10 +377,10 @@ s_agent_task (void *args, zctx_t *ctx, void *pipe)
             s_beacon_recv (self);
 
         if (self->transmit
-        &&  zclock_time () >= self->ping_at) {
+        &&  zclock_mono () >= self->ping_at) {
             //  Send beacon to any listening peers
             zsys_udp_send (self->udpsock, self->transmit, &self->broadcast);
-            self->ping_at = zclock_time () + self->interval;
+            self->ping_at = zclock_mono () + self->interval;
         }
     }
     s_agent_destroy (&self);
@@ -627,7 +627,7 @@ s_api_command (agent_t *self)
         self->transmit = zframe_recv (self->pipe);
         assert (self->transmit);
         //  Start broadcasting immediately
-        self->ping_at = zclock_time ();
+        self->ping_at = zclock_mono ();
     }
     else
     if (streq (command, "SILENCE"))

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -186,17 +186,17 @@ static long
 s_tickless_timer (zloop_t *self)
 {
     //  Calculate tickless timer, up to 1 hour
-    int64_t tickless = zclock_time () + 1000 * 3600;
+    int64_t tickless = zclock_mono () + 1000 * 3600;
     s_timer_t *timer = (s_timer_t *) zlist_first (self->timers);
     while (timer) {
         //  Find earliest timer
         if (timer->when == -1)
-            timer->when = timer->delay + zclock_time ();
+            timer->when = timer->delay + zclock_mono ();
         if (tickless > timer->when)
             tickless = timer->when;
         timer = (s_timer_t *) zlist_next (self->timers);
     }
-    long timeout = (long) (tickless - zclock_time ());
+    long timeout = (long) (tickless - zclock_mono ());
     if (timeout < 0)
         timeout = 0;
     if (self->verbose)
@@ -512,7 +512,7 @@ zloop_start (zloop_t *self)
     //  Recalculate all timers now
     s_timer_t *timer = (s_timer_t *) zlist_first (self->timers);
     while (timer) {
-        timer->when = timer->delay + zclock_time ();
+        timer->when = timer->delay + zclock_mono ();
         timer = (s_timer_t *) zlist_next (self->timers);
     }
     //  Main reactor loop
@@ -536,7 +536,7 @@ zloop_start (zloop_t *self)
         //  Handle any timers that have now expired
         timer = (s_timer_t *) zlist_first (self->timers);
         while (timer) {
-            if (zclock_time () >= timer->when && timer->when != -1) {
+            if (zclock_mono () >= timer->when && timer->when != -1) {
                 if (self->verbose)
                     zsys_debug ("zloop: call timer id=%d handler", timer->timer_id);
                 rc = timer->handler (self, timer->timer_id, timer->arg);
@@ -547,7 +547,7 @@ zloop_start (zloop_t *self)
                     free (timer);
                 }
                 else
-                    timer->when = timer->delay + zclock_time ();
+                    timer->when = timer->delay + zclock_mono ();
             }
             timer = (s_timer_t *) zlist_next (self->timers);
         }


### PR DESCRIPTION
Problem:  If the system time is set backwards while a czmq application is
          running that has timers set on a zloop, those timers will stop
          until the system time reaches its previous value.

Solution: Introduce a monotonic clock that is not affected by system time
          changes.  Use this clock where time offsets are computed.

I've added a simple test to the self test.  I built and ran on both Ubuntu 14.04 and Windows 7.
