### PR TITLE
Adds monotonic clock implementation for OSX

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -290,6 +290,8 @@
 #   endif
 #   if (defined (__UTYPE_OSX))
 #       include <crt_externs.h>         //  For _NSGetEnviron()
+#       include <mach/clock.h>
+#       include <mach/mach.h>           //  For monotonic clocks
 #   endif
 #endif
 

--- a/src/zclock.c
+++ b/src/zclock.c
@@ -123,10 +123,21 @@ int64_t
 zclock_mono (void)
 {
 #if defined (__UNIX__)
+#if defined (__UTYPE_OSX)
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+
+    return (int64_t) ((int64_t) mts.tv_sec * 1000 + (int64_t) mts.tv_nsec / 1000000);
+#else
     struct timespec ts;
     clock_gettime (CLOCK_MONOTONIC, &ts);
 
     return (int64_t) ((int64_t) ts.tv_sec * 1000 + (int64_t) ts.tv_nsec / 1000000);
+#endif
 #elif (defined (__WINDOWS__))
     LARGE_INTEGER count;
     QueryPerformanceCounter(&count);


### PR DESCRIPTION
The current implementation for zclock_mono() does not compile on OSX. This adds an implementation.
