### PR TITLE
zbeacon.c: Remove unused variable in s_get_interface (mingw)

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -575,10 +575,9 @@ s_get_interface (agent_t *self)
         PIP_ADAPTER_PREFIX pPrefix = cur_address->FirstPrefix;
 
         PWCHAR friendlyName = cur_address->FriendlyName;
-        size_t friendlyLength = 0;
-        size_t asciiSize = wcstombs(0, friendlyName, 0) + 1;
-        char *asciiFriendlyName = (char*) zmalloc(asciiSize);
-        friendlyLength = wcstombs(asciiFriendlyName, friendlyName, asciiSize);
+        size_t asciiFriendlyLength = wcstombs(0, friendlyName, 0) + 1;
+        char *asciiFriendlyName = (char*) zmalloc(asciiFriendlyLength);
+        wcstombs(asciiFriendlyName, friendlyName, asciiFriendlyLength);
 
         int filter = any_interface || (strcmp (zsys_interface (), asciiFriendlyName) == 0);
         int valid = cur_address->OperStatus == IfOperStatusUp;


### PR DESCRIPTION
Related issues: #564

```
zbeacon.c: In function 's_get_interface':
zbeacon.c:578:16: error: variable 'friendlyLength' set but not used [-Werror=unused-but-set-variable]
         size_t friendlyLength = 0;
                ^
```
