### PR TITLE
Adds zinterface class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set (czmq_headers
     include/zframe.h
     include/zhash.h
     include/zgossip.h
+    include/zinterface.h
     include/zlist.h
     include/zloop.h
     include/zmsg.h
@@ -141,6 +142,7 @@ set (czmq_sources
     src/zframe.c
     src/zhash.c
     src/zgossip.c
+    src/zinterface.c
     src/zlist.c
     src/zloop.c
     src/zmsg.c

--- a/builds/android/Android.mk
+++ b/builds/android/Android.mk
@@ -20,7 +20,7 @@ include $(PREBUILT_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := czmq
 LOCAL_C_INCLUDES := ../../include $(LIBZMQ)/include
-LOCAL_SRC_FILES := zactor.c zauth.c zbeacon.c zcert.c zcertstore.c zchunk.c zclock.c zconfig.c zdigest.c zdir.c zdir_patch.c zfile.c zframe.c zhash.c zgossip.c zlist.c zloop.c zmsg.c zpoller.c zproxy.c zrex.c zsock.c zsock_monitor.c zsock_option.c zstr.c zsys.c zuuid.c zgossip_msg.c zctx.c zmonitor.c zmutex.c zsocket.c zsockopt.c zthread.c
+LOCAL_SRC_FILES := zactor.c zauth.c zbeacon.c zcert.c zcertstore.c zchunk.c zclock.c zconfig.c zdigest.c zdir.c zdir_patch.c zfile.c zframe.c zhash.c zgossip.c zinterface.c zlist.c zloop.c zmsg.c zpoller.c zproxy.c zrex.c zsock.c zsock_monitor.c zsock_option.c zstr.c zsys.c zuuid.c zgossip_msg.c zctx.c zmonitor.c zmutex.c zsocket.c zsockopt.c zthread.c
 LOCAL_SHARED_LIBRARIES := zmq
 include $(BUILD_SHARED_LIBRARY)
 

--- a/builds/mingw32/Makefile.mingw32
+++ b/builds/mingw32/Makefile.mingw32
@@ -10,7 +10,7 @@ INCDIR=-I$(PREFIX)/include -I.
 LIBDIR=-L$(PREFIX)/lib
 CFLAGS=-Wall -Os -g -DDLL_EXPORT $(INCDIR)
 
-OBJS = zactor.o zauth.o zbeacon.o zcert.o zcertstore.o zchunk.o zclock.o zconfig.o zdigest.o zdir.o zdir_patch.o zfile.o zframe.o zhash.o zgossip.o zlist.o zloop.o zmsg.o zpoller.o zproxy.o zrex.o zsock.o zsock_monitor.o zsock_option.o zstr.o zsys.o zuuid.o zgossip_msg.o zctx.o zmonitor.o zmutex.o zsocket.o zsockopt.o zthread.o
+OBJS = zactor.o zauth.o zbeacon.o zcert.o zcertstore.o zchunk.o zclock.o zconfig.o zdigest.o zdir.o zdir_patch.o zfile.o zframe.o zhash.o zgossip.o zinterface.o zlist.o zloop.o zmsg.o zpoller.o zproxy.o zrex.o zsock.o zsock_monitor.o zsock_option.o zstr.o zsys.o zuuid.o zgossip_msg.o zctx.o zmonitor.o zmutex.o zsocket.o zsockopt.o zthread.o
 
 %.o: ../../src/%.c
     $(CC) -c -o $@ $< $(CFLAGS)

--- a/builds/msvc/vs2008/czmq/czmq.vcproj
+++ b/builds/msvc/vs2008/czmq/czmq.vcproj
@@ -678,6 +678,38 @@
           <Tool Name="VCCLCompilerTool" CompileAs="2" />
         </FileConfiguration>
       </File>
+      <File RelativePath="..\..\..\..\src\zinterface.c">
+        <FileConfiguration Name="Release|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Release|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+      </File>
       <File RelativePath="..\..\..\..\src\zlist.c">
         <FileConfiguration Name="Release|Win32">
           <Tool Name="VCCLCompilerTool" CompileAs="2" />
@@ -1306,6 +1338,7 @@
       <File RelativePath="..\..\..\..\include\zframe.h" />
       <File RelativePath="..\..\..\..\include\zhash.h" />
       <File RelativePath="..\..\..\..\include\zgossip.h" />
+      <File RelativePath="..\..\..\..\include\zinterface.h" />
       <File RelativePath="..\..\..\..\include\zlist.h" />
       <File RelativePath="..\..\..\..\include\zloop.h" />
       <File RelativePath="..\..\..\..\include\zmsg.h" />

--- a/builds/msvc/vs2010/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2010/czmq/czmq.vcxproj
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>

--- a/builds/msvc/vs2010/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2010/czmq/czmq.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <Filter>src</Filter>
     </ClCompile>

--- a/builds/msvc/vs2012/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2012/czmq/czmq.vcxproj
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>

--- a/builds/msvc/vs2012/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2012/czmq/czmq.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <Filter>src</Filter>
     </ClCompile>

--- a/builds/msvc/vs2013/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2013/czmq/czmq.vcxproj
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>

--- a/builds/msvc/vs2013/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2013/czmq/czmq.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\..\..\src\zgossip.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\zinterface.c">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zlist.c">
       <Filter>src</Filter>
     </ClCompile>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,7 @@
 #   Please read the README.txt file in the model directory.     #
 #################################################################
 MAN1 =
-MAN3 = zactor.3 zauth.3 zbeacon.3 zcert.3 zcertstore.3 zchunk.3 zclock.3 zconfig.3 zdigest.3 zdir.3 zdir_patch.3 zfile.3 zframe.3 zhash.3 zgossip.3 zlist.3 zloop.3 zmsg.3 zpoller.3 zproxy.3 zrex.3 zsock.3 zsock_monitor.3 zsock_option.3 zstr.3 zsys.3 zuuid.3 zctx.3 zmonitor.3 zmutex.3 zsocket.3 zsockopt.3 zthread.3
+MAN3 = zactor.3 zauth.3 zbeacon.3 zcert.3 zcertstore.3 zchunk.3 zclock.3 zconfig.3 zdigest.3 zdir.3 zdir_patch.3 zfile.3 zframe.3 zhash.3 zgossip.3 zinterface.3 zlist.3 zloop.3 zmsg.3 zpoller.3 zproxy.3 zrex.3 zsock.3 zsock_monitor.3 zsock_option.3 zstr.3 zsys.3 zuuid.3 zctx.3 zmonitor.3 zmutex.3 zsocket.3 zsockopt.3 zthread.3
 MAN7 = czmq.7
 MAN_DOC = $(MAN1) $(MAN3) $(MAN7)
 

--- a/include/czmq.h
+++ b/include/czmq.h
@@ -44,6 +44,7 @@ typedef struct _zdir_patch_t zdir_patch_t;
 typedef struct _zfile_t zfile_t;
 typedef struct _zframe_t zframe_t;
 typedef struct _zhash_t zhash_t;
+typedef struct _zinterface_t zinterface_t;
 typedef struct _zlist_t zlist_t;
 typedef struct _zloop_t zloop_t;
 typedef struct _zmonitor_t zmonitor_t;
@@ -72,6 +73,7 @@ typedef struct _zuuid_t zuuid_t;
 #include "zframe.h"
 #include "zgossip.h"
 #include "zhash.h"
+#include "zinterface.h"
 #include "zlist.h"
 #include "zloop.h"
 #include "zmsg.h"

--- a/include/zinterface.h
+++ b/include/zinterface.h
@@ -1,0 +1,61 @@
+/*  =========================================================================
+    zinterface - Information about network interfaces
+    
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+#ifndef __ZINTERFACE_H_INCLUDED__
+#define __ZINTERFACE_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  @interface
+//  Return a list of available network interfaces. The interfaces remain
+//  valid while the list is not destroyed. If one interface is to be valid
+//  after destroyed, it must be duplicated, and then destroyed.
+CZMQ_EXPORT zlist_t *
+    zinterface_list ();
+
+//  Duplicate an interface
+CZMQ_EXPORT zinterface_t *
+    zinterface_dup (zinterface_t *self);
+
+//  Destroy an interface
+CZMQ_EXPORT void
+    zinterface_destroy (zinterface_t **self_p);
+
+//  Return the interface's name as a printable string
+CZMQ_EXPORT char *
+    zinterface_name (zinterface_t *self);
+
+//  Return the interface's IP address as a printable string
+CZMQ_EXPORT char *
+    zinterface_address (zinterface_t *self);
+
+//  Return the interface's broadcast address as a printable string
+CZMQ_EXPORT char *
+    zinterface_broadcast (zinterface_t *self);
+
+//  Return the interface's network mask as a printable string
+CZMQ_EXPORT char *
+    zinterface_netmask (zinterface_t *self);
+
+// Prints all detected interfaces on the screen
+CZMQ_EXPORT void
+    zinterface_test(bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/model/project.xml
+++ b/model/project.xml
@@ -20,6 +20,7 @@
     <class name = "zframe" />
     <class name = "zhash" />
     <class name = "zgossip" />
+    <class name = "zinterface" />
     <class name = "zlist" />
     <class name = "zloop" />
     <class name = "zmsg" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ include_HEADERS = \
     ../include/zframe.h \
     ../include/zhash.h \
     ../include/zgossip.h \
+    ../include/zinterface.h \
     ../include/zlist.h \
     ../include/zloop.h \
     ../include/zmsg.h \
@@ -62,6 +63,7 @@ libczmq_la_SOURCES = \
     zframe.c \
     zhash.c \
     zgossip.c \
+    zinterface.c \
     zlist.c \
     zloop.c \
     zmsg.c \

--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -71,6 +71,7 @@ int main (int argc, char *argv [])
     zcert_test (verbose);
     zcertstore_test (verbose);
     zauth_test (verbose);
+    zinterface_test (verbose);
     printf ("Tests passed OK\n");
     return 0;
 }

--- a/src/zinterface.c
+++ b/src/zinterface.c
@@ -1,0 +1,323 @@
+/*  =========================================================================
+    zinterface - Information about network interfaces
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+/*
+@header
+    The zinterface class contains information about a network interface, 
+    namely the IP address, network mask and broadcast address. A list of
+    all interfaces present in the system is obtained by the zinterface_list
+    function. This list "owns" all the interfaces contained in it, so it is
+    only necessary to destroy the list, not every listed interface.
+@discuss
+@end
+*/
+
+#include "platform.h"
+#include "czmq.h"
+
+#ifdef __UNIX__
+//  --------------------------------------------------------------------------
+//  Helper function to verify if one interface's flags are what we want.
+static bool s_check_flags(short flags)
+{
+    return (flags & IFF_UP)             //  Only use interfaces that are running
+       && !(flags & IFF_LOOPBACK)       //  Ignore loopback interface
+       &&  (flags & IFF_BROADCAST)      //  Only use interfaces that have BROADCAST
+    #if defined(IFF_SLAVE)
+       && !(flags & IFF_SLAVE)          //  Ignore devices that are bonding slaves.
+    #endif
+       && !(flags & IFF_POINTOPOINT);   //  Ignore point to point interfaces.
+}
+#endif
+
+struct _zinterface_t {
+    char *name;
+    char *address;
+    char *netmask;
+    char *broadcast;
+};
+
+static zinterface_t *
+    s_zinterface_new(char *name, inaddr_t address, inaddr_t netmask, inaddr_t broadcast);
+static void s_freefn(void *ptr);
+
+//  --------------------------------------------------------------------------
+//  Builds a list of available interfaces.
+//  Currently implemented for POSIX and Windows
+
+zlist_t *
+zinterface_list ()
+{
+    zlist_t *ifaces = zlist_new();
+    assert(ifaces);
+#if defined (HAVE_GETIFADDRS)
+    struct ifaddrs *interfaces;
+    if (getifaddrs (&interfaces) == 0) {
+        struct ifaddrs *interface = interfaces;
+        while (interface) {
+            //  On Solaris, loopback interfaces have a NULL in ifa_broadaddr
+            if  (interface->ifa_broadaddr
+            &&   s_check_flags(interface->ifa_flags)
+            &&   interface->ifa_addr
+            &&  (interface->ifa_addr->sa_family == AF_INET)) {
+                inaddr_t address   = *(inaddr_t*) interface->ifa_addr;
+                inaddr_t netmask   = *(inaddr_t*) interface->ifa_netmask;
+                inaddr_t broadcast = *(inaddr_t*) interface->ifa_broadaddr;
+
+                //  If the returned broadcast address is the same as source
+                //  address, build the broadcast address from the source
+                //  address and netmask.
+                if (address.sin_addr.s_addr == broadcast.sin_addr.s_addr)
+                    broadcast.sin_addr.s_addr |= ~(netmask.sin_addr.s_addr);
+
+                zinterface_t* ziface = s_zinterface_new(interface->ifa_name,
+                    address, netmask, broadcast);
+                zlist_append(ifaces, ziface);
+                zlist_freefn(ifaces, ziface, s_freefn, true);
+            }
+            interface = interface->ifa_next;
+        }
+    }
+    freeifaddrs (interfaces);
+
+#   elif defined (__UNIX__)
+    int sock = socket (AF_INET, SOCK_DGRAM, 0);
+    if (sock != -1) {
+        int rc;
+        int num_interfaces = 0;
+        struct ifconf ifconfig;
+        ifconfig.ifc_len = 0;
+        ifconfig.ifc_req = NULL;
+
+        rc = ioctl (sock, SIOCGIFCONF, (caddr_t) &ifconfig, sizeof (struct ifconf));
+        if (rc != -1) {
+            ifconfig.ifc_buf = calloc(1, ifconfig.ifc_len);
+            rc = ioctl (sock, SIOCGIFCONF, (caddr_t) &ifconfig, sizeof (struct ifconf));
+            if (rc != -1) {
+                num_interfaces = ifconfig.ifc_len / sizeof (struct ifreq);
+            }
+        }
+
+        for (int i=0; i<num_interfaces; i++) {
+            struct ifreq* ifr = &ifconfig.ifc_req[i];
+            rc = ioctl (sock, SIOCGIFFLAGS, (caddr_t) ifr, sizeof (struct ifreq));
+            if  (rc == -1) continue;
+            if  (!s_check_flags(ifr->ifr_flags)) continue;
+
+            ifr->ifr_addr.sa_family = AF_INET;
+
+            //  Get interface address
+            rc = ioctl (sock, SIOCGIFADDR, (caddr_t) ifr, sizeof (struct ifreq));
+            if (rc == -1) continue;
+            inaddr_t address   = *((inaddr_t*) &ifr->ifr_addr);
+
+            //  Get interface netmask
+            rc = ioctl (sock, SIOCGIFBRDADDR, (caddr_t) ifr, sizeof (struct ifreq));
+            if (rc == -1) continue;
+            inaddr_t broadcast = *((inaddr_t*) &ifr->ifr_addr);
+
+            //  Get interface broadcast address
+            rc = ioctl (sock, SIOCGIFNETMASK, (caddr_t) ifr, sizeof (struct ifreq));
+            if (rc == -1) continue;
+            inaddr_t netmask = *((inaddr_t*) &ifr->ifr_addr);
+
+            zinterface_t* ziface = s_zinterface_new(ifr->ifr_name,
+                address, netmask, broadcast);
+            zlist_append(ifaces, ziface);
+            zlist_freefn(ifaces, ziface, s_freefn, true);
+        }
+
+        close(sock);
+    }
+
+#   elif defined (__WINDOWS__)
+    ULONG addr_size = 0;
+    DWORD rc = GetAdaptersAddresses (AF_INET, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &addr_size);
+    assert (rc == ERROR_BUFFER_OVERFLOW);
+
+    PIP_ADAPTER_ADDRESSES pip_addresses = (PIP_ADAPTER_ADDRESSES) malloc (addr_size);
+    rc = GetAdaptersAddresses (AF_INET,
+        GAA_FLAG_INCLUDE_PREFIX, NULL, pip_addresses, &addr_size);
+    assert (rc == NO_ERROR);
+
+    PIP_ADAPTER_ADDRESSES cur_address = pip_addresses;
+    while (cur_address) {
+        PIP_ADAPTER_UNICAST_ADDRESS pUnicast = cur_address->FirstUnicastAddress;
+        PIP_ADAPTER_PREFIX pPrefix = cur_address->FirstPrefix;
+
+        PWCHAR friendlyName = cur_address->FriendlyName;
+        size_t friendlyLength = 0;
+        size_t asciiSize = wcstombs(0, friendlyName, 0) + 1;
+        char *asciiFriendlyName = (char*) zmalloc(asciiSize);
+        friendlyLength = wcstombs(asciiFriendlyName, friendlyName, asciiSize);
+
+        int valid = cur_address->OperStatus == IfOperStatusUp;
+        
+        if (valid && pUnicast && pPrefix) {
+            if (pUnicast->Address.lpSockaddr->sa_family != AF_INET) continue;
+        
+            inaddr_t address   = *(inaddr_t*) pUnicast->Address.lpSockaddr;
+            inaddr_t netmask;
+            
+            if (pPrefix->PrefixLength > 32) continue;
+            netmask.sin_addr.s_addr = htonl((0xffffffffU) << (32 - pPrefix->PrefixLength));
+            
+            inaddr_t broadcast = address;
+            broadcast.sin_addr.s_addr |= ~(netmask.sin_addr.s_addr);
+                        
+            zinterface_t* ziface = s_zinterface_new(asciiFriendlyName,
+                address, netmask, broadcast);
+            zlist_append(ifaces, ziface);
+            zlist_freefn(ifaces, ziface, s_freefn, true);
+        }
+        free(asciiFriendlyName);
+        cur_address = cur_address->Next;
+    }
+    free (pip_addresses);
+
+#   else
+#       error "Interface detection TBD on this operating system"
+#   endif
+
+    return ifaces;
+}
+
+//  --------------------------------------------------------------------------
+//  Private constructor
+
+zinterface_t *
+s_zinterface_new(char *name, inaddr_t address, inaddr_t netmask, inaddr_t broadcast)
+{
+    assert(name);
+    zinterface_t *self = malloc(sizeof(struct _zinterface_t));
+    assert(self);
+    self->name      = strdup(name);
+    self->address   = strdup(inet_ntoa(address.sin_addr));
+    self->netmask   = strdup(inet_ntoa(netmask.sin_addr));
+    self->broadcast = strdup(inet_ntoa(broadcast.sin_addr));
+
+    assert(self->name);
+    assert(self->address);
+    assert(self->netmask);
+    assert(self->broadcast);
+    return self;
+}
+
+//  --------------------------------------------------------------------------
+//  Copy constructor
+
+zinterface_t *
+zinterface_dup (zinterface_t *self)
+{
+    assert(self);
+
+    zinterface_t *copy = malloc(sizeof(struct _zinterface_t));
+    assert(copy);
+    copy->name      = strdup(self->name);
+    copy->address   = strdup(self->address);
+    copy->netmask   = strdup(self->netmask);
+    copy->broadcast = strdup(self->broadcast);
+
+    assert(copy->name);
+    assert(copy->address);
+    assert(copy->netmask);
+    assert(copy->broadcast);
+
+    return copy;
+}
+
+//  --------------------------------------------------------------------------
+//  Destructor
+
+void
+s_freefn(void *ptr)
+{
+    zinterface_t *self = ptr;
+    zinterface_destroy(&self);
+}
+
+//  --------------------------------------------------------------------------
+//  Destructor
+
+void
+zinterface_destroy (zinterface_t **self_p)
+{
+    assert(self_p);
+    if (*self_p) {
+        zinterface_t *self = *self_p;
+        free (self->address);
+        free (self->netmask);
+        free (self->broadcast);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  --------------------------------------------------------------------------
+
+char *
+zinterface_name (zinterface_t *self)
+{
+    assert(self);
+    return self->name;
+}
+
+//  --------------------------------------------------------------------------
+
+char *
+zinterface_address (zinterface_t *self)
+{
+    assert(self);
+    return self->address;
+}
+
+//  --------------------------------------------------------------------------
+
+char *
+zinterface_broadcast (zinterface_t *self)
+{
+    assert(self);
+    return self->broadcast;
+}
+
+//  --------------------------------------------------------------------------
+
+char *
+zinterface_netmask (zinterface_t *self)
+{
+    assert(self);
+    return self->netmask;
+}
+
+//  --------------------------------------------------------------------------
+
+void
+zinterface_test(bool verbose)
+{
+    printf(" * zinterface: ");
+    zlist_t *interfaces = zinterface_list();
+    assert(interfaces);
+
+    if (verbose) {
+        printf("Len: %zu\n", zlist_size(interfaces));
+        zinterface_t *iface = zlist_first(interfaces);
+        while (iface) {
+            printf ("%s\t%s\t%s\t%s\n", zinterface_name(iface), zinterface_address(iface),
+                zinterface_netmask(iface), zinterface_broadcast(iface));
+            iface = zlist_next(interfaces);
+        }
+    }
+
+    zlist_destroy(&interfaces);
+    printf("OK\n");
+}


### PR DESCRIPTION
I needed to get a list of network interfaces for a given host, so I made this class.

The code is basically a copy from the function s_get_interface() in zbeacon.c. If this patch is accepted, I'll update zbeacon to use this funcion and remove the duplicate code.

The code has been tested on linux, Mac OSX and Windows.

Any suggestions are welcome.
