### PR TITLE
mingw fix: DLL_EXPORT -> LIBCZMQ_EXPORTS

### DIFF
--- a/model/build-mingw32.gsl
+++ b/model/build-mingw32.gsl
@@ -16,7 +16,7 @@ CC=gcc
 PREFIX=c:/mingw/msys/1.0/local
 INCDIR=-I$\(PREFIX)/include -I.
 LIBDIR=-L$\(PREFIX)/lib
-CFLAGS=-Wall -Os -g -DDLL_EXPORT $\(INCDIR)
+CFLAGS=-Wall -Os -g -DLIBCZMQ_EXPORTS $\(INCDIR)
 
 OBJS =\
 .for class


### PR DESCRIPTION
since commit 5dc41fe9a16d722fb675bbd3abe4c9f59c74d0e6,
DLL_EXPORT was renamed to LIBCZMQ_EXPORTS.
