### PR TITLE
Pull prime table size

### DIFF
--- a/src/zhash.c
+++ b/src/zhash.c
@@ -18,6 +18,12 @@
     Note that it's relatively slow (~50k insertions/deletes per second), so
     don't do inserts/updates on the critical path for message I/O. It can
     do ~2.5M lookups per second for 16-char keys. Timed on a 1.6GHz CPU.
+    .
+    The hash table always has a size that is prime and roughly doubles it's
+    size when 75% full. In case of hash collisions items are chained in a
+    linked list. The hash table size is increased slightly (up to 5 times
+    before roughly doubling the size) when an overly long chain (between 1
+    and 63 items depending on table size) is detected.
 @end
 */
 


### PR DESCRIPTION
Use prime numbers for hash table size, double size when 75% full, slightly increase size when overly long chains are detected.
