### PR TITLE
Fix zbeabon s_get_interface() for when zsys_interface() returns "".

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -474,7 +474,7 @@ s_get_interface (agent_t *self)
             } while (zinterface_next (interfaces));
         }
         else
-            found = zinterface_count (interfaces) > 0;
+            found = zinterface_first (interfaces);
 
         if (found) {
             // Using inet_addr instead of inet_aton or inet_atop because these are


### PR DESCRIPTION
```
        self->broadcast.sin_addr.s_addr = inet_addr (zinterface_broadcast (interfaces));
```

segfauilts because zinterface_broadcast() returns NULL if current_interface is not set. zinterface_first() sets this.
