### PR TITLE
Fix compilation error in OSX.

### DIFF
--- a/src/zhash_primes.h
+++ b/src/zhash_primes.h
@@ -326,3 +326,4 @@ static size_t primes [] = {
 };
 
 #endif
+


### PR DESCRIPTION
Due to -Wall -Werror, the compiler complains about lack of newline at
the end of file.
