### PR TITLE
fix zeromq/czmq#609

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -560,7 +560,7 @@ zloop_start (zloop_t *self)
                     free (timer);
                 }
                 else
-                    timer->when = timer->delay + zclock_mono ();
+                    timer->when += timer->delay;
             }
             timer = (s_timer_t *) zlist_next (self->timers);
         }


### PR DESCRIPTION
Fix #609 Changed zloop timer to use fixed interval from start of loop instead of current time plus interval
