### PR TITLE
Problem: zcertstore uses clumsy mix of hash + list

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -473,8 +473,7 @@ zcert_test (bool verbose)
     shadow = zcert_load (TESTDIR "/mycert.txt");
     
     //  32-byte null key encodes as 40 '0' characters
-    assert (streq (zcert_secret_txt (shadow),
-                   FORTY_ZEROES));
+    assert (streq (zcert_secret_txt (shadow), FORTY_ZEROES));
     
     zcert_destroy (&shadow);
     zcert_destroy (&cert);

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -15,8 +15,8 @@
 @header
     To authenticate new clients using the ZeroMQ CURVE security mechanism,
     we have to check that the client's public key matches a key we know and
-    accept. There are numerous ways to store accepted client public keys. 
-    The mechanism CZMQ implements is "certificates" (plain text files) held 
+    accept. There are numerous ways to store accepted client public keys.
+    The mechanism CZMQ implements is "certificates" (plain text files) held
     in a "certificate store" (a disk directory). This class works with such
     certificate stores, and lets you easily load them from disk, and check
     if a given client public key is known or not. The zcert class does the
@@ -25,11 +25,11 @@
     The certificate store can be memory-only, in which case you can load it
     yourself by inserting certificate objects one by one, or it can be loaded
     from disk, in which case you can add, modify, or remove certificates on
-    disk at any time, and the store will detect such changes and refresh 
+    disk at any time, and the store will detect such changes and refresh
     itself automatically. In most applications you won't use this class
     directly but through the zauth class, which provides a high-level API for
     authentication (and manages certificate stores for you). To actually
-    create certificates on disk, use the zcert class in code, or the 
+    create certificates on disk, use the zcert class in code, or the
     tools/makecert.c command line tool, or any text editor. The format of a
     certificate file is defined in the zcert man page.
 @end
@@ -46,19 +46,18 @@ struct _zcertstore_t {
     time_t modified;            //  Modified time of directory
     size_t count;               //  Number of certificates
     size_t cursize;             //  Total size of certificates
-    zlist_t *cert_list;         //  List of loaded certificates
-    zhash_t *cert_hash;         //  Hash of loaded certificates
+    zring_t *certs;             //  Loaded certificates
 };
 
 
 //  --------------------------------------------------------------------------
 //  Constructor
 //
-//  Create a new certificate store from a disk directory, loading and 
+//  Create a new certificate store from a disk directory, loading and
 //  indexing all certificates in that location. The directory itself may be
-//  absent, and created later, or modified at any time. The certificate store 
-//  is automatically refreshed on any zcertstore_lookup() call. If the 
-//  location is specified as NULL, creates a pure-memory store, which you 
+//  absent, and created later, or modified at any time. The certificate store
+//  is automatically refreshed on any zcertstore_lookup() call. If the
+//  location is specified as NULL, creates a pure-memory store, which you
 //  can work with by inserting certificates at runtime.
 
 static void s_load_certs_from_disk (zcertstore_t *self);
@@ -68,9 +67,9 @@ zcertstore_new (const char *location)
 {
     zcertstore_t *self = (zcertstore_t *) zmalloc (sizeof (zcertstore_t));
     assert (self);
-    
-    self->cert_list = zlist_new ();
-    self->cert_hash = zhash_new ();
+
+    self->certs = zring_new ();
+    zring_set_destructor (self->certs, (czmq_destructor *) zcert_destroy);
     if (location) {
         self->location = strdup (location);
         s_load_certs_from_disk (self);
@@ -79,39 +78,26 @@ zcertstore_new (const char *location)
 }
 
 
-//  Get rid of any existing certificates in the store, but leave the
-//  store list and hash in place.
-
-static void 
-s_empty_store (zcertstore_t *self) 
-{
-    zcert_t *cert = (zcert_t *) zlist_pop (self->cert_list);
-    while (cert) {
-        zhash_delete (self->cert_hash, zcert_public_txt (cert));
-        zcert_destroy (&cert);
-        cert = (zcert_t *) zlist_pop (self->cert_list);
-    }
-    assert (zlist_size (self->cert_list) == 0);
-    assert (zhash_size (self->cert_hash) == 0);
-}
-
-
 //  Load certificates from directory location, if it exists
 
-static void 
+static void
 s_load_certs_from_disk (zcertstore_t *self)
 {
-    s_empty_store (self);
+    zring_purge (self->certs);
     zdir_t *dir = zdir_new (self->location, NULL);
     if (dir) {
         //  Load all certificates including those in subdirectories
         zfile_t **filelist = zdir_flatten (dir);
+        zrex_t *rex = zrex_new ("_secret$");
+        assert (rex);
+        
         uint index;
         for (index = 0;; index++) {
             zfile_t *file = filelist [index];
             if (!file)
                 break;      //  End of list
-            if (zfile_is_regular (file)) {
+            if (zfile_is_regular (file)
+            && !zrex_matches (rex, zfile_filename (file, NULL))) {
                 zcert_t *cert = zcert_load (zfile_filename (file, NULL));
                 if (cert)
                     zcertstore_insert (self, &cert);
@@ -122,6 +108,7 @@ s_load_certs_from_disk (zcertstore_t *self)
         self->count = zdir_count (dir);
         self->cursize = zdir_cursize (dir);
 
+        zrex_destroy (&rex);
         zdir_destroy (&dir);
     }
 }
@@ -129,7 +116,7 @@ s_load_certs_from_disk (zcertstore_t *self)
 
 //  --------------------------------------------------------------------------
 //  Destructor
-//  
+//
 //  Destroy a certificate store object in memory. Does not affect anything
 //  stored on disk.
 
@@ -139,9 +126,7 @@ zcertstore_destroy (zcertstore_t **self_p)
     assert (self_p);
     if (*self_p) {
         zcertstore_t *self = *self_p;
-        s_empty_store (self);
-        zlist_destroy (&self->cert_list);
-        zhash_destroy (&self->cert_hash);
+        zring_destroy (&self->certs);
         free (self->location);
         free (self);
         *self_p = NULL;
@@ -150,7 +135,7 @@ zcertstore_destroy (zcertstore_t **self_p)
 
 
 //  --------------------------------------------------------------------------
-//  Look up certificate by public key, returns zcert_t object if found, 
+//  Look up certificate by public key, returns zcert_t object if found,
 //  else returns NULL. The public key is provided in Z85 text format.
 
 zcert_t *
@@ -167,20 +152,20 @@ zcertstore_lookup (zcertstore_t *self, const char *public_key)
         }
         zdir_destroy (&dir);
     }
-    return (zcert_t *) zhash_lookup (self->cert_hash, public_key);
+    return (zcert_t *) zring_lookup (self->certs, public_key);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Insert certificate into certificate store in memory. Note that this 
+//  Insert certificate into certificate store in memory. Note that this
 //  does not save the certificate to disk. To do that, use zcert_save()
 //  directly on the certificate.
 
 void
 zcertstore_insert (zcertstore_t *self, zcert_t **cert_p)
 {
-    zlist_append (self->cert_list, *cert_p);
-    zhash_insert (self->cert_hash, zcert_public_txt (*cert_p), *cert_p);
+    int rc = zring_insert (self->certs, zcert_public_txt (*cert_p), *cert_p);
+    assert (rc == 0);
     *cert_p = NULL;             //  We own this now
 }
 
@@ -196,10 +181,10 @@ zcertstore_print (zcertstore_t *self)
     else
         zsys_info ("zcertstore: certificates in memory");
 
-    zcert_t *cert = (zcert_t *) zlist_first (self->cert_list);
+    zcert_t *cert = (zcert_t *) zring_first (self->certs);
     while (cert) {
         zcert_print (cert);
-        cert = (zcert_t *) (zcert_t *) zlist_next (self->cert_list);
+        cert = (zcert_t *) (zcert_t *) zring_next (self->certs);
     }
 }
 
@@ -216,10 +201,10 @@ zcertstore_fprint (zcertstore_t *self, FILE *file)
     else
         fprintf (file, "Certificate store\n");
 
-    zcert_t *cert = (zcert_t *) zlist_first (self->cert_list);
+    zcert_t *cert = (zcert_t *) zring_first (self->certs);
     while (cert) {
         zcert_fprint (cert, file);
-        cert = (zcert_t *) (zcert_t *) zlist_next (self->cert_list);
+        cert = (zcert_t *) (zcert_t *) zring_next (self->certs);
     }
 }
 
@@ -233,28 +218,28 @@ zcertstore_test (bool verbose)
     printf (" * zcertstore: ");
     if (verbose)
         printf ("\n");
-    
+
     //  @selftest
     //  Create temporary directory for test files
 #   define TESTDIR ".test_zcertstore"
     zsys_dir_create (TESTDIR);
-    
+
     //  Load certificate store from disk; it will be empty
     zcertstore_t *certstore = zcertstore_new (TESTDIR);
-    
+
     //  Create a single new certificate and save to disk
     zcert_t *cert = zcert_new ();
     char *client_key = strdup (zcert_public_txt (cert));
     zcert_set_meta (cert, "name", "John Doe");
     zcert_save (cert, TESTDIR "/mycert.txt");
     zcert_destroy (&cert);
-    
+
     //  Check that certificate store refreshes as expected
     cert = zcertstore_lookup (certstore, client_key);
     assert (cert);
     assert (streq (zcert_meta (cert, "name"), "John Doe"));
     free (client_key);
-    
+
     if (verbose)
         zcertstore_print (certstore);
     zcertstore_destroy (&certstore);


### PR DESCRIPTION
Solution: move to nice elegant zring hybrid.

This also exposed a proto-bug in zcertstore which would load
certificates from disk without filtering out _secret files. So
depending on the order of filenames after sorting, the secret
certificate would override the normal one, or not. It worked
by accident because _secret came after the normal filename.
