### PR TITLE
Use _DEFAULT_SOURCE instead of _BSD_SOURCE

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -153,8 +153,8 @@
 #   ifndef __NO_CTYPE
 #   define __NO_CTYPE                   //  Suppress warnings on tolower()
 #   endif
-#   ifndef _BSD_SOURCE
-#   define _BSD_SOURCE                  //  Include stuff from 4.3 BSD Unix
+#   ifndef _DEFAULT_SOURCE
+#   define _DEFAULT_SOURCE                  //  Include stuff from 4.3 BSD Unix
 #   endif
 #elif (defined (Mips))
 #   define __UTYPE_MIPS


### PR DESCRIPTION
Since glibc 2.20, using _BSD_SOURCE triggers a warning, and since czmq
uses -Werror, it aborts the build:

  CC       zchunk.lo
In file included from /home/thomas/projets/buildroot/output/host/usr/nios2-buildroot-linux-gnu/sysroot/usr/include/ctype.h:25:0,
                 from ../include/czmq_prelude.h:203,
                 from ../include/czmq.h:19,
                 from zauth.c:25:
/home/thomas/projets/buildroot/output/host/usr/nios2-buildroot-linux-gnu/sysroot/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^

See the glibc 2.20 release notes, https://lwn.net/Articles/611162/,
explaining the change about _BSD_SOURCE:
- The _BSD_SOURCE and _SVID_SOURCE feature test macros are no longer
  supported; they now act the same as _DEFAULT_SOURCE (but generate a
  warning).  Except for cases where _BSD_SOURCE enabled BSD interfaces that
  conflicted with POSIX (support for which was removed in 2.19), the
  interfaces those macros enabled remain available when compiling with
  _GNU_SOURCE defined, with _DEFAULT_SOURCE defined, or without any feature
  test macros defined.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
