### PR TITLE
Problem: zsock_option.c:78 fails on MSVC

### DIFF
--- a/doc/zsock.doc
+++ b/doc/zsock.doc
@@ -160,9 +160,10 @@ This is the class interface:
     CZMQ_EXPORT int
         zsock_attach (zsock_t *self, const char *endpoints, bool serverish);
     
-    //  Returns socket type as printable constant string
+    //  Returns socket type as printable constant string. Takes a polymorphic
+    //  socket reference.
     CZMQ_EXPORT const char *
-        zsock_type_str (zsock_t *self);
+        zsock_type_str (void *self);
     
     //  Send a 'picture' message to the socket (or actor). The picture is a
     //  string that defines the type of each frame. This makes it easy to send

--- a/doc/zsock.txt
+++ b/doc/zsock.txt
@@ -160,9 +160,10 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsock_attach (zsock_t *self, const char *endpoints, bool serverish);
 
-//  Returns socket type as printable constant string
+//  Returns socket type as printable constant string. Takes a polymorphic
+//  socket reference.
 CZMQ_EXPORT const char *
-    zsock_type_str (zsock_t *self);
+    zsock_type_str (void *self);
 
 //  Send a 'picture' message to the socket (or actor). The picture is a
 //  string that defines the type of each frame. This makes it easy to send

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -171,9 +171,10 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsock_attach (zsock_t *self, const char *endpoints, bool serverish);
 
-//  Returns socket type as printable constant string
+//  Returns socket type as printable constant string. Takes a polymorphic
+//  socket reference.
 CZMQ_EXPORT const char *
-    zsock_type_str (zsock_t *self);
+    zsock_type_str (void *self);
 
 //  Send a 'picture' message to the socket (or actor). The picture is a
 //  string that defines the type of each frame. This makes it easy to send


### PR DESCRIPTION
Some confusion in the code, passing a polymorphic socket reference to a
method that accepts only zsock_t *.

Solution: change zsock_type_str() to accept a polymorphic reference and
resolve properly to get the socket type.
