### PR TITLE
zhash: Add support for custom hash function and arbitrary key type

### DIFF
--- a/include/zhash.h
+++ b/include/zhash.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef void (zhash_free_fn) (void *data);
 
 //  Callback function for hashing keys
-typedef size_t (zhash_hash_fn) (const char *key);
+typedef size_t (zhash_hash_fn) (const void *key);
 
 //  Create a new, empty hash container
 CZMQ_EXPORT zhash_t *
@@ -37,7 +37,7 @@ CZMQ_EXPORT void
 //  If key is already present returns -1 and leaves existing item unchanged
 //  Returns 0 on success.
 CZMQ_EXPORT int
-    zhash_insert (zhash_t *self, const char *key, void *item);
+    zhash_insert (zhash_t *self, void *key, void *item);
 
 //  Update or insert item into hash table with specified key and item. If the
 //  key is already present, destroys old item and inserts new one. If you set
@@ -45,21 +45,21 @@ CZMQ_EXPORT int
 //  was not already present, inserts a new item. Sets the hash cursor to the
 //  new item.
 CZMQ_EXPORT void
-    zhash_update (zhash_t *self, const char *key, void *item);
+    zhash_update (zhash_t *self, void *key, void *item);
 
 //  Remove an item specified by key from the hash table. If there was no such
 //  item, this function does nothing.
 CZMQ_EXPORT void
-    zhash_delete (zhash_t *self, const char *key);
+    zhash_delete (zhash_t *self, void *key);
 
 //  Return the item at the specified key, or null
 CZMQ_EXPORT void *
-    zhash_lookup (zhash_t *self, const char *key);
+    zhash_lookup (zhash_t *self, void *key);
 
 //  Reindexes an item from an old key to a new key. If there was no such
 //  item, does nothing. Returns 0 if successful, else -1.
 CZMQ_EXPORT int
-    zhash_rename (zhash_t *self, const char *old_key, const char *new_key);
+    zhash_rename (zhash_t *self, void *old_key, void *new_key);
 
 //  Set a free function for the specified hash table item. When the item is
 //  destroyed, the free function, if any, is called on that item.
@@ -67,14 +67,15 @@ CZMQ_EXPORT int
 //  you don't have memory leaks. You can pass 'free' or NULL as a free_fn.
 //  Returns the item, or NULL if there is no such item.
 CZMQ_EXPORT void *
-    zhash_freefn (zhash_t *self, const char *key, zhash_free_fn *free_fn);
+    zhash_freefn (zhash_t *self, void *key, zhash_free_fn *free_fn);
 
 //  Return the number of keys/items in the hash table
 CZMQ_EXPORT size_t
     zhash_size (zhash_t *self);
 
-//  Return a zlist_t containing the keys for the items in the table. It is
-//  safe to use this list after destroying the hash table or items in it.
+//  Return a zlist_t containing the keys for the items in the
+//  table. Uses the key_duplicator to duplicate all keys and sets the
+//  key_destructor as destructor for the list.
 CZMQ_EXPORT zlist_t *
     zhash_keys (zhash_t *self);
     
@@ -98,7 +99,7 @@ CZMQ_EXPORT void *
 //  for the item that was returned. This is a constant string that you may
 //  not modify or deallocate, and which lasts as long as the item in the hash.
 //  After an unsuccessful first/next, returns NULL.
-CZMQ_EXPORT const char *
+CZMQ_EXPORT void *
     zhash_cursor (zhash_t *self);
 
 //  Add a comment to hash table before saving to disk. You can add as many
@@ -163,15 +164,30 @@ CZMQ_EXPORT zhash_t *
 CZMQ_EXPORT zhash_t *
     zhash_dup (zhash_t *self);
 
+//  Set a user-defined deallocator for keys; by default keys are freed
+//  when the hash is destroyed using free().
+CZMQ_EXPORT void
+    zhash_set_key_destructor (zhash_t *self, czmq_destructor destructor);
+
+//  Set a user-defined duplicator for keys; by default keys are duplicated
+//  using strdup.
+CZMQ_EXPORT void
+    zhash_set_key_duplicator (zhash_t *self, czmq_duplicator duplicator);
+
+//  Set a user-defined comparator for keys; by default keys are
+//  compared using strcmp.
+CZMQ_EXPORT void
+    zhash_set_key_comparator (zhash_t *self, czmq_comparator comparator);
+
 //  Set a user-defined deallocator for hash items; by default items are not
 //  freed when the hash is destroyed.
 CZMQ_EXPORT void
-    zhash_set_destructor (zhash_t *self, czmq_destructor destructor);
+    zhash_set_item_destructor (zhash_t *self, czmq_destructor destructor);
 
 //  Set a user-defined duplicator for hash items; by default items are not
 //  copied when the hash is duplicated.
 CZMQ_EXPORT void
-    zhash_set_duplicator (zhash_t *self, czmq_duplicator duplicator);
+    zhash_set_item_duplicator (zhash_t *self, czmq_duplicator duplicator);
 
 //  Set a user-defined hash function for keys; by default keys are
 //  hashed by a modified Bernstein hashing function.
@@ -192,7 +208,7 @@ CZMQ_EXPORT void
     zhash_autofree (zhash_t *self);
 
 //  DEPRECATED as clumsy -- use zhash_first/_next instead
-typedef int (zhash_foreach_fn) (const char *key, void *item, void *argument);
+typedef int (zhash_foreach_fn) (const void *key, void *item, void *argument);
 
 //  DEPRECATED as clumsy -- use zhash_first/_next instead
 //  Apply function to each item in the hash table. Items are iterated in no

--- a/include/zlist.h
+++ b/include/zlist.h
@@ -99,6 +99,17 @@ CZMQ_EXPORT size_t
 CZMQ_EXPORT void
     zring_sort (zring_t *self);
 
+//  Set a user-defined destructor for items; by default items are not
+//  freed when the list is destroyed.
+CZMQ_EXPORT void
+    zlist_set_destructor (zlist_t *self, czmq_destructor destructor);
+
+//  Set a user-defined duplicator for items; by default items are not
+//  copied when the list is duplicated.
+CZMQ_EXPORT void
+    zlist_set_duplicator (zlist_t *self, czmq_duplicator duplicator);
+
+//  DEPRECATED by zlist_set_duplicator/zlist_set_destructor
 //  Set list for automatic item destruction; item values MUST be strings.
 //  By default a list item refers to a value held elsewhere. When you set
 //  this, each time you append or push a list item, zlist will take a copy

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -59,8 +59,8 @@ zcert_new (void)
 
     //  Initialize metadata, even if keys aren't working
     self->metadata = zhash_new ();
-    zhash_set_destructor (self->metadata, (czmq_destructor *) zstr_free);
-    zhash_set_duplicator (self->metadata, (czmq_duplicator *) strdup);
+    zhash_set_item_destructor (self->metadata, (czmq_destructor *) zstr_free);
+    zhash_set_item_duplicator (self->metadata, (czmq_duplicator *) strdup);
     
 #if (ZMQ_VERSION_MAJOR == 4)
     if (zsys_has_curve ()) {
@@ -93,8 +93,8 @@ zcert_new_from (byte *public_key, byte *secret_key)
     assert (secret_key);
 
     self->metadata = zhash_new ();
-    zhash_set_destructor (self->metadata, (czmq_destructor *) zstr_free);
-    zhash_set_duplicator (self->metadata, (czmq_duplicator *) strdup);
+    zhash_set_item_destructor (self->metadata, (czmq_destructor *) zstr_free);
+    zhash_set_item_duplicator (self->metadata, (czmq_duplicator *) strdup);
     
     memcpy (self->public_key, public_key, 32);
     memcpy (self->secret_key, secret_key, 32);
@@ -181,7 +181,7 @@ zcert_set_meta (zcert_t *self, const char *name, const char *format, ...)
     va_start (argptr, format);
     char *value = zsys_vprintf (format, argptr);
     va_end (argptr);
-    zhash_insert (self->metadata, name, value);
+    zhash_insert (self->metadata, (void *)name, value);
 }
 
 
@@ -193,7 +193,7 @@ char *
 zcert_meta (zcert_t *self, const char *name)
 {
     assert (self);
-    return (char *) zhash_lookup (self->metadata, name);
+    return (char *) zhash_lookup (self->metadata, (void *)name);
 }
 
 
@@ -429,7 +429,7 @@ zcert_fprint (zcert_t *self, FILE *file)
     char *value = (char *) zhash_first (self->metadata);
     while (value) {
         fprintf (file, "    %s = \"%s\"\n",
-                 zhash_cursor (self->metadata), value);
+                 (char *)zhash_cursor (self->metadata), value);
         value = (char *) zhash_next (self->metadata);
     }
     fprintf (file, "curve\n");

--- a/src/zgossip.c
+++ b/src/zgossip.c
@@ -221,7 +221,7 @@ server_connect (server_t *self, const char *endpoint)
 static void
 server_accept (server_t *self, const char *key, const char *value)
 {
-    tuple_t *tuple = (tuple_t *) zhash_lookup (self->tuples, key);
+  tuple_t *tuple = (tuple_t *) zhash_lookup (self->tuples, (void *) key);
     if (tuple && streq (tuple->value, value))
         return;                 //  Duplicate tuple, do nothing
 
@@ -233,8 +233,8 @@ server_accept (server_t *self, const char *key, const char *value)
     tuple->value = strdup (value);
 
     //  Store new tuple
-    zhash_update (tuple->container, key, tuple);
-    zhash_freefn (tuple->container, key, tuple_free);
+    zhash_update (tuple->container, (void *) key, tuple);
+    zhash_freefn (tuple->container, (void *) key, tuple_free);
 
     //  Deliver to calling application
     zstr_sendx (self->pipe, "DELIVER", key, value, NULL);

--- a/src/zring.c
+++ b/src/zring.c
@@ -165,9 +165,9 @@ zring_insert (zring_t *self, const char *key, void *item)
 
     //  If item isn't already in dictionary, append to list and then
     //  store item node (which is in cursor) in dictionary
-    if (!zhash_lookup (self->hash, key)
+    if (!zhash_lookup (self->hash, (void *) key)
     &&  !zring_append (self, item)
-    &&  !zhash_insert (self->hash, key, self->cursor)) {
+	&&  !zhash_insert (self->hash, (void *) key, self->cursor)) {
         self->cursor->key = zhash_cursor (self->hash);
         return 0;
     }
@@ -230,7 +230,7 @@ zring_lookup (zring_t *self, const char *key)
     assert (key);
     
     if (self->hash) {
-        node_t *node = (node_t *) zhash_lookup (self->hash, key);
+      node_t *node = (node_t *) zhash_lookup (self->hash, (void *) key);
         if (node) {
             self->cursor = node;
             return node->item;
@@ -265,7 +265,7 @@ zring_detach (zring_t *self, void *item)
         self->cursor = found->next;
         self->size--;
         if (found->key)
-            zhash_delete (self->hash, found->key);
+	  zhash_delete (self->hash, (void *) found->key);
         free (found);
         return item;
     }


### PR DESCRIPTION
Make it possible to use arbitrary data for key and value in a zhash.
- Changes zhash_set_destructor to zhash_set_item_destructor and zhash_set_duplicator to zhash_set_item_duplicator.
- Adds zhash_set_hasher, zhash_set_key_destructor, zhash_set_key_duplicator, zhash_set_key_comparator, zlist_set_destructor and zlist_set_duplicator.
- Changes data type for keys from const char \* to void \* (ABI compatible but API break).
