### PR TITLE
Problem: creating pollers in language bindings for CZMQ is difficult

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -224,7 +224,7 @@ CZMQ_EXPORT int
 // Check whether a zsock_t has a waiting incoming message.
 // Returns true or false.
 CZMQ_EXPORT bool
-    zsock_pollin (zsock_t *self);
+    zsock_waiting (zsock_t *self);
 
 //  Set socket to use unbounded pipes (HWM=0); use this in cases when you are
 //  totally certain the message volume can fit in memory. This method works

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -762,7 +762,7 @@ zsock_set_unbounded (void *self)
 //  Check whether a zsock_t has a waiting incoming message.
 //  Returns true or false.
 bool
-zsock_pollin (zsock_t *self)
+zsock_waiting (zsock_t *self)
 {
     assert (zsock_is (self));
     zmq_pollitem_t items[1];
@@ -1039,7 +1039,7 @@ zsock_test (bool verbose)
     assert (rc == -1);
     zsock_destroy (&server);
 
-    // Test zsock_pollin method
+    // Test zsock_waiting method
     zsock_t *sender = zsock_new (ZMQ_PUSH);
     assert (sender);
     rc = zsock_bind (sender, "inproc://incoming");
@@ -1051,7 +1051,7 @@ zsock_test (bool verbose)
     assert (rc == 0);
 
     zstr_send (sender, "HELLO");
-    bool inc = zsock_pollin (receiver);
+    bool inc = zsock_waiting (receiver);
     assert (inc == true);
 
     zsock_destroy (&sender);


### PR DESCRIPTION
Adding zsock_pollin to zsock.  This method simply returns true if the zsock has a waiting incoming event on the socket handle in zsock_t.  This allows for simple creation of "higher level" poll loops in language bindings for CZMQ.
