### PR TITLE
Problem: we can easily check for POLLIN on a zsock but not POLLOUT

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -222,9 +222,16 @@ CZMQ_EXPORT int
     zsock_recv (void *self, const char *picture, ...);
 
 // Check whether a zsock_t has a waiting incoming message.
+// This checks for a POLLIN event on the socket.
 // Returns true or false.
 CZMQ_EXPORT bool
     zsock_waiting (zsock_t *self);
+
+// Check whether a zsock_t is ready to write to.
+// This checks for a POLLOUT event on the socket.
+// Returns true or false.
+CZMQ_EXPORT bool
+    zsock_ready (zsock_t *self);
 
 //  Set socket to use unbounded pipes (HWM=0); use this in cases when you are
 //  totally certain the message volume can fit in memory. This method works

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -777,6 +777,25 @@ zsock_waiting (zsock_t *self)
     return false;
 }
 
+//  ------------------------------------------------
+// Check whether a zsock_t is ready to write to.
+// Returns true or false.
+bool
+zsock_ready (zsock_t *self)
+{
+    assert (zsock_is (self));
+    zmq_pollitem_t items[1];
+    items[0].socket = self->handle;
+    items[0].events = ZMQ_POLLOUT;
+    items[0].revents = 0;
+
+    zmq_poll (items, 1, 0);
+    if (items[0].revents & ZMQ_POLLIN) {
+        return true;
+    }
+    return false;
+}
+
 //  --------------------------------------------------------------------------
 //  Send a signal over a socket. A signal is a short message carrying a
 //  success/failure code (by convention, 0 means OK). Signals are encoded
@@ -1050,12 +1069,36 @@ zsock_test (bool verbose)
     rc = zsock_connect (receiver, "inproc://incoming");
     assert (rc == 0);
 
+    bool waiting = zsock_waiting (receiver);
+    assert (waiting == false);
+
     zstr_send (sender, "HELLO");
-    bool inc = zsock_waiting (receiver);
-    assert (inc == true);
+    waiting = zsock_waiting (receiver);
+    assert (waiting == true);
 
     zsock_destroy (&sender);
     zsock_destroy (&receiver);
+
+    // Test zsock_ready method
+    sender = zsock_new (ZMQ_PUSH);
+    assert (sender);
+    rc = zsock_bind (sender, "inproc://incoming");
+    assert (rc == 0);
+
+    bool ready = zsock_ready (sender);
+    assert (ready == false);
+
+    receiver = zsock_new (ZMQ_PULL);
+    assert (receiver);
+    rc = zsock_connect (receiver, "inproc://incoming");
+    assert (rc == 0);
+
+    ready = zsock_ready (sender);
+    assert (ready == false);
+
+    zsock_destroy (&sender);
+    zsock_destroy (&receiver);
+
     //  @end
     
     printf ("OK\n");


### PR DESCRIPTION
- added zsock_ready which checks for a POLLOUT and returns a boolean to compliment zsock_waiting.
