### PR TITLE
Problem: new methods added complexity with no functionality gain

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -221,16 +221,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsock_recv (void *self, const char *picture, ...);
 
-//  Check whether a zsock_t has a waiting incoming message. This checks for
-//  a POLLIN event on the socket. Returns true or false.
-CZMQ_EXPORT bool
-    zsock_pollin (zsock_t *self);
-
-//  Check whether a zsock_t is ready to write to. This checks for a POLLOUT
-//  event on the socket. Returns true or false.
-CZMQ_EXPORT bool
-    zsock_pollout (zsock_t *self);
-
 //  Set socket to use unbounded pipes (HWM=0); use this in cases when you are
 //  totally certain the message volume can fit in memory. This method works
 //  across all versions of ZeroMQ. Takes a polymorphic socket reference.

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -759,28 +759,6 @@ zsock_set_unbounded (void *self)
 }
 
 //  --------------------------------------------------------------------------
-//  Check whether a zsock_t has a waiting incoming message. This checks for
-//  a POLLIN event on the socket. Returns true or false.
-
-bool
-zsock_pollin (zsock_t *self)
-{
-    assert (zsock_is (self));
-    return (zsock_events (self) & ZMQ_POLLIN);
-}
-
-//  --------------------------------------------------------------------------
-//  Check whether a zsock_t is ready to write to. This checks for a POLLOUT
-//  event on the socket. Returns true or false.
-
-bool
-zsock_pollout  (zsock_t *self)
-{
-    assert (zsock_is (self));
-    return (zsock_events (self) & ZMQ_POLLOUT);
-}
-
-//  --------------------------------------------------------------------------
 //  Send a signal over a socket. A signal is a short message carrying a
 //  success/failure code (by convention, 0 means OK). Signals are encoded
 //  to be distinguishable from "normal" messages. Accepts a zock_t or a
@@ -1041,35 +1019,6 @@ zsock_test (bool verbose)
     rc = zsock_attach (server, ">a,@b, c,, ", false);
     assert (rc == -1);
     zsock_destroy (&server);
-
-    // Test zsock_pollin method
-    zsock_t *sender = zsock_new (ZMQ_PUSH);
-    assert (sender);
-    rc = zsock_bind (sender, "inproc://test-waiting");
-    assert (rc == 0);
-    zsock_t *receiver = zsock_new (ZMQ_PULL);
-    assert (receiver);
-    rc = zsock_connect (receiver, "inproc://test-waiting");
-    assert (rc == 0);
-    assert (!zsock_pollin (receiver));
-    zstr_send (sender, "HELLO");
-    assert (zsock_pollin (receiver));
-    zsock_destroy (&sender);
-    zsock_destroy (&receiver);
-
-    //  Test zsock_pollout method
-    sender = zsock_new (ZMQ_PUSH);
-    assert (sender);
-    rc = zsock_bind (sender, "inproc://test-ready");
-    assert (rc == 0);
-    assert (!zsock_pollout (sender));
-    receiver = zsock_new (ZMQ_PULL);
-    assert (receiver);
-    rc = zsock_connect (receiver, "inproc://test-ready");
-    assert (rc == 0);
-    assert (zsock_pollout (sender));
-    zsock_destroy (&sender);
-    zsock_destroy (&receiver);
 
     //  @end
     


### PR DESCRIPTION
- removed zsock_pollin
- removed zsock_pollout

I wrote these functions because I was not aware of zsock_events!  I've moved my go binding to use zsock_events directly.  Since currently I was the only user of these two functions, they don't provide additional functionality, I suggest we remove them.
