### PR TITLE
zdir: use S_ISDIR macro instead of masking yourself

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -87,7 +87,7 @@ s_posix_populate_entry (zdir_t *self, struct dirent *entry)
         ; //  Skip hidden files
     else
     //  If we have a subdirectory, go load that
-    if (stat_buf.st_mode & S_IFDIR) {
+    if (S_ISDIR(stat_buf.st_mode)) {
         if (!self->trimmed) {
             zdir_t *subdir = zdir_new (entry->d_name, self->path);
             assert (subdir);


### PR DESCRIPTION
For some reason zdir_test fails for me if run in gdb because it mistakenly recognizes a file as dir. Using the macro to test for dir fixes this. Don't ask me what is going wrong there but it makes sense to me to use the macro anyway.
