### PR TITLE
Problem: Can't install due to missing czmq.7

### DIFF
--- a/doc/czmq.txt
+++ b/doc/czmq.txt
@@ -4,7 +4,7 @@ czmq(7)
 
 NAME
 ----
-CZMQ - high-level C binding for ZeroMQ
+czmq - high-level C binding for ZeroMQ
 
 
 SYNOPSIS


### PR DESCRIPTION
Solution: Changing name part in docs/czmq.txt from CZMQ back to czmq.
Currently asciidoc thinks that man page should be named CZMQ.7 and
installer searches for czmq.7. Options are either rename the man page
back or change makefile to expect CZMQ.7. Personally I would expect
lowercase names for man page (and it is referenced like that several
times), so changing to lowercase.
