### PR TITLE
Add -Wc++-compat when gcc is used for better compatibility with MSVC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ AC_C_VOLATILE
 
 # These options are GNU compiler specific.
 if test "x$GCC" = "xyes"; then
-    CPPFLAGS="-pedantic -Werror -Wall ${CPPFLAGS}"
+    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
 fi
 
 AM_CONDITIONAL(ON_MINGW, test "x$czmq_on_mingw32" = "xyes")


### PR DESCRIPTION
Problem: Assigning a void \* to a different typed pointer works with gcc but fails with MSVC (C99 vs C++)
Solution: Add -Wc++-compat when gcc is used to generate a warning (and therefore fail) under gcc too
