### PR TITLE
Remove 'czmq' string from visual studio gsl templates.

### DIFF
--- a/model/build-vs2008.gsl
+++ b/model/build-vs2008.gsl
@@ -4,8 +4,8 @@
 .#  language. See https://github.com/imatix/gsl for details. This script
 .#  is licensed under MIT/X11.
 .#
-.echo "Generating builds/msvc/vs2008/czmq/$(project.name).vcproj..."
-.output "../builds/msvc/vs2008/czmq/$(project.name).vcproj"
+.echo "Generating builds/msvc/vs2008/$(project.name)/$(project.name).vcproj..."
+.output "../builds/msvc/vs2008/$(project.name)/$(project.name).vcproj"
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #################################################################
@@ -94,7 +94,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" Optimization="0" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;_WIN32;WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" MinimalRebuild="false" BasicRuntimeChecks="3" RuntimeLibrary="3" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" DebugInformationFormat="1" />
+      <Tool Name="VCCLCompilerTool" Optimization="0" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;_WIN32;WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" MinimalRebuild="false" BasicRuntimeChecks="3" RuntimeLibrary="3" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" DebugInformationFormat="1" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="_DEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />
@@ -113,7 +113,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" TargetEnvironment="3" />
-      <Tool Name="VCCLCompilerTool" Optimization="0" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;_WIN32;WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" MinimalRebuild="false" BasicRuntimeChecks="3" RuntimeLibrary="3" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" DebugInformationFormat="1" />
+      <Tool Name="VCCLCompilerTool" Optimization="0" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;_WIN32;WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" MinimalRebuild="false" BasicRuntimeChecks="3" RuntimeLibrary="3" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" DebugInformationFormat="1" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="_DEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />
@@ -132,7 +132,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
+      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="NDEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />
@@ -151,7 +151,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" TargetEnvironment="3" />
-      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
+      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="NDEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />
@@ -170,7 +170,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
+      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="NDEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />
@@ -189,7 +189,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" TargetEnvironment="3" />
-      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIBCZMQ_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
+      <Tool Name="VCCLCompilerTool" Optimization="2" InlineFunctionExpansion="1" AdditionalIncludeDirectories="..\\..\\..\\..\\include;..\\..\\..\\..\\..\\libzmq\\include" PreprocessorDefinitions="LIB$(PROJECT.NAME)_EXPORTS;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;BASE_THREADSAFE" StringPooling="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" PrecompiledHeaderFile="./$(project.name).pch" AssemblerListingLocation="./" ObjectFile="./" ProgramDataBaseFileName="./" WarningLevel="3" SuppressStartupBanner="true" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" PreprocessorDefinitions="NDEBUG" Culture="2060" />
       <Tool Name="VCPreLinkEventTool" />

--- a/model/build-vs2010.gsl
+++ b/model/build-vs2010.gsl
@@ -4,8 +4,8 @@
 .#  language. See https://github.com/imatix/gsl for details. This script
 .#  is licensed under MIT/X11.
 .#
-.echo "Generating builds/msvc/vs2010/czmq/$(project.name).vcxproj..."
-.output "../builds/msvc/vs2010/czmq/$(project.name).vcxproj"
+.echo "Generating builds/msvc/vs2010/$(project.name)/$(project.name).vcxproj..."
+.output "../builds/msvc/vs2010/$(project.name)/$(project.name).vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -100,7 +100,7 @@
 .endfor
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc" />
+    <ResourceCompile Include="..\\..\\$(project.name).rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\\..\\..\\..\\packaging\\nuget\\package.bat" />
@@ -118,8 +118,8 @@
   #################################################################
   -->
 </Project>
-.echo "Generating builds/msvc/vs2010/czmq/$(project.name).vcxproj.filters..."
-.output "../builds/msvc/vs2010/czmq/$(project.name).vcxproj.filters"
+.echo "Generating builds/msvc/vs2010/$(project.name)/$(project.name).vcxproj.filters..."
+.output "../builds/msvc/vs2010/$(project.name)/$(project.name).vcxproj.filters"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -158,7 +158,7 @@
     </ClInclude>
   </ItemGroup>  
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc">
+    <ResourceCompile Include="..\\..\\$(project.name).rc">
       <Filter>resource</Filter>
     </ResourceCompile>
   </ItemGroup>
@@ -206,8 +206,8 @@
 #################################################################
 -->  
 </Project>
-.echo "Generating builds/msvc/vs2010/czmq_selftest/$(project.name)_selftest.vcxproj..."
-.output "../builds/msvc/vs2010/czmq_selftest/$(project.name)_selftest.vcxproj"
+.echo "Generating builds/msvc/vs2010/$(project.name)_selftest/$(project.name)_selftest.vcxproj..."
+.output "../builds/msvc/vs2010/$(project.name)_selftest/$(project.name)_selftest.vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################

--- a/model/build-vs2012.gsl
+++ b/model/build-vs2012.gsl
@@ -4,8 +4,8 @@
 .#  language. See https://github.com/imatix/gsl for details. This script
 .#  is licensed under MIT/X11.
 .#
-.echo "Generating builds/msvc/vs2012/czmq/$(project.name).vcxproj..."
-.output "../builds/msvc/vs2012/czmq/$(project.name).vcxproj"
+.echo "Generating builds/msvc/vs2012/$(project.name)/$(project.name).vcxproj..."
+.output "../builds/msvc/vs2012/$(project.name)/$(project.name).vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -100,7 +100,7 @@
 .endfor
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc" />
+    <ResourceCompile Include="..\\..\\$(project.name).rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\\..\\..\\..\\packaging\\nuget\\package.bat" />
@@ -118,8 +118,8 @@
   #################################################################
   -->
 </Project>
-.echo "Generating builds/msvc/vs2012/czmq/$(project.name).vcxproj.filters..."
-.output "../builds/msvc/vs2012/czmq/$(project.name).vcxproj.filters"
+.echo "Generating builds/msvc/vs2012/$(project.name)/$(project.name).vcxproj.filters..."
+.output "../builds/msvc/vs2012/$(project.name)/$(project.name).vcxproj.filters"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -158,7 +158,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc">
+    <ResourceCompile Include="..\\..\\$(project.name).rc">
       <Filter>resource</Filter>
     </ResourceCompile>
   </ItemGroup>
@@ -206,8 +206,8 @@
 #################################################################
 -->
 </Project>
-.echo "Generating builds/msvc/vs2012/czmq_selftest/$(project.name)_selftest.vcxproj..."
-.output "../builds/msvc/vs2012/czmq_selftest/$(project.name)_selftest.vcxproj"
+.echo "Generating builds/msvc/vs2012/$(project.name)_selftest/$(project.name)_selftest.vcxproj..."
+.output "../builds/msvc/vs2012/$(project.name)_selftest/$(project.name)_selftest.vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################

--- a/model/build-vs2013.gsl
+++ b/model/build-vs2013.gsl
@@ -4,8 +4,8 @@
 .#  language. See https://github.com/imatix/gsl for details. This script
 .#  is licensed under MIT/X11.
 .#
-.echo "Generating builds/msvc/vs2013/czmq/$(project.name).vcxproj..."
-.output "../builds/msvc/vs2013/czmq/$(project.name).vcxproj"
+.echo "Generating builds/msvc/vs2013/$(project.name)/$(project.name).vcxproj..."
+.output "../builds/msvc/vs2013/$(project.name)/$(project.name).vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -100,7 +100,7 @@
 .endfor
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc" />
+    <ResourceCompile Include="..\\..\\$(project.name).rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\\..\\..\\..\\packaging\\nuget\\package.bat" />
@@ -118,8 +118,8 @@
   #################################################################
   -->
 </Project>
-.echo "Generating builds/msvc/vs2013/czmq/$(project.name).vcxproj.filters..."
-.output "../builds/msvc/vs2013/czmq/$(project.name).vcxproj.filters"
+.echo "Generating builds/msvc/vs2013/$(project.name)/$(project.name).vcxproj.filters..."
+.output "../builds/msvc/vs2013/$(project.name)/$(project.name).vcxproj.filters"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################
@@ -158,7 +158,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\\..\\czmq.rc">
+    <ResourceCompile Include="..\\..\\$(project.name).rc">
       <Filter>resource</Filter>
     </ResourceCompile>
   </ItemGroup>
@@ -206,8 +206,8 @@
 #################################################################
 -->
 </Project>
-.echo "Generating builds/msvc/vs2013/czmq_selftest/$(project.name)_selftest.vcxproj..."
-.output "../builds/msvc/vs2013/czmq_selftest/$(project.name)_selftest.vcxproj"
+.echo "Generating builds/msvc/vs2013/$(project.name)_selftest/$(project.name)_selftest.vcxproj..."
+.output "../builds/msvc/vs2013/$(project.name)_selftest/$(project.name)_selftest.vcxproj"
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 #################################################################


### PR DESCRIPTION
Use the project.name macro instead, to make the templates more portable.

Checked by re-generating and verifying there were no differences (there were - but just the newlines at the end of the files, which i think is acceptable)
