### PR TITLE
missing doc about zhash picture in zsock_send

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -186,6 +186,7 @@ CZMQ_EXPORT const char *
 //      b = byte *, size_t (2 arguments)
 //      c = zchunk_t *
 //      f = zframe_t *
+//      h = zhash_t *
 //      p = void * (sends the pointer value, only meaningful over inproc)
 //      z = sends zero-sized frame (0 arguments)
 //


### PR DESCRIPTION
The doc about zhash picture was missing,  it was added directly on .txt file.
