### PR TITLE
Problem: Cumbersome to compile z* files in labs folder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = src model doc addons 
+SUBDIRS = src model doc addons labs
 
 DIST_SUBDIRS = src model doc addons
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,12 @@ AC_PROG_LIBTOOL
 AC_PROG_SED
 AC_PROG_AWK
 
+# 
+AC_ARG_ENABLE([labs],
+    [AS_HELP_STRING([--disable-labs], [Enable Lbas support @<:@check@:>@])],
+    [:],
+    [enable_labs=check])
+
 # Checks for libraries
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([uuid], [uuid_generate])
@@ -111,6 +117,16 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <zmq.h>],
                ],
                [AC_MSG_RESULT([yes])],
                [AC_MSG_ERROR([no. Please specify libzmq installation prefix using --with-libzmq])])
+
+# When building labs, check for czmq
+AS_IF([test "$enable_labs" != "no"],
+    [PKG_CHECK_MODULES([CZMQ], [libczmq], [enable_labs=yes],
+        [AS_IF([test "$enable_labs" = "yes"],
+        [AC_MSG_ERROR([czmq required for building labs, but not found.])],
+        [enable_labs=no])
+        ]
+    )]
+)
 
 # Platform specific checks
 czmq_on_mingw32="no"
@@ -243,6 +259,7 @@ AM_CONDITIONAL(ON_MINGW, test "x$czmq_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$czmq_on_android" = "xyes")
 AM_CONDITIONAL(INSTALL_MAN, test "x$czmq_install_man" = "xyes")
 AM_CONDITIONAL(BUILD_DOC, test "x$czmq_build_doc" = "xyes")
+AM_CONDITIONAL([ENABLE_LABS], [test "x$enable_labs" = "xyes"])
 
 # Checks for library functions.
 AC_TYPE_SIGNAL
@@ -254,5 +271,7 @@ AC_CONFIG_FILES([Makefile \
                 src/libczmq.pc \
                 doc/Makefile \
                 addons/Makefile \
+                labs/Makefile \
+                labs/libczmq_labs.pc \
                 model/Makefile])
 AC_OUTPUT

--- a/labs/Makefile.am
+++ b/labs/Makefile.am
@@ -1,0 +1,31 @@
+if ENABLE_LABS
+lib_LTLIBRARIES = libczmq_labs.la
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libczmq_labs.pc
+
+include_HEADERS = \
+    zpubsub.h \
+	zpubsub_filter.h \
+	zpubsub_option.h 
+
+libczmq_labs_la_SOURCES = \
+    zpubsub.c \
+	zpubsub_filter.c \
+	zpubsub_option.c 
+
+
+AM_CFLAGS = -g
+AM_CPPFLAGS = -I.
+#bin_PROGRAMS = czmq_labs_selftest
+#czmq_labs_selftest_LDADD = libczmq_labs.la
+#czmq_labs_selftest_SOURCES = czmq_labs_selftest.c
+
+if ON_MINGW
+libczmq_labs_la_LDFLAGS = -no-undefined -avoid-version -version-info @LTVER@
+else
+libczmq_labs_la_LDFLAGS = -version-info @LTVER@
+endif
+
+#TESTS = czmq_labs_selftest
+endif

--- a/labs/czmq_labs_selftest.c
+++ b/labs/czmq_labs_selftest.c
@@ -1,0 +1,51 @@
+/*  =========================================================================
+    czmq_labs_tests.c - run selftests
+
+    Runs all selftests.
+
+    -------------------------------------------------------------------------
+    Copyright (c) 1991-2014 iMatix Corporation <www.imatix.com>
+    Copyright other contributors as noted in the AUTHORS file.
+
+    This file is part of czmq, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This software is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this program. If not, see
+    <http://www.gnu.org/licenses/>.
+    =========================================================================
+*/
+
+#include "zpubsub.h"
+#include "zpubsub_filter.h"
+#include "zpubsub_option.h"
+
+int main (int argc, char *argv [])
+{
+    bool verbose;
+    if (argc == 2 && streq (argv [1], "-v"))
+        verbose = true;
+    else
+        verbose = false;
+
+    printf ("Running CZMQ (LABS) selftests...\n");
+
+    zpubsub_test (verbose)
+    zpubsub_filter_test (verbose);
+    zpubsub_option_test (verbose);
+
+    zsys_shutdown ();
+
+    printf ("Tests passed OK\n");
+    return 0;
+}

--- a/labs/libczmq_labs.pc.in
+++ b/labs/libczmq_labs.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libczmq_labs
+Description: High-level C binding for 0MQ (LABS)
+Version: @VERSION@
+Requires: libczmq
+Libs: -L${libdir} -lczmq_labs
+Cflags: -I${includedir}


### PR DESCRIPTION
Solution: Changed the autotools configuration

Prerequisites: libczmq is installed

Step 1: ./configure --enable-labs=yes
Step 2: make
Step 3: make install

Now you've got a library libczmq_labs installed on your system which
can be used in third party projects.

Known issues: Couln't get czmq_labs_selftest to compile, thus those 
parts are commented in the labs/Makefile.am
- Let's try this again, thanks to git cherry-pick :)
