### PR TITLE
zpubsub protobuf example is not built using czmq_labs library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,13 +84,16 @@ examples/security/woodhouse.o
 examples/zpubsub/simple/*.o
 examples/zpubsub/simple/test_publisher
 examples/zpubsub/simple/test_subscriber
-!examples/zpubsub/simple/Makefile
 examples/zpubsub/protobuf/*.o
 examples/zpubsub/protobuf/*.pb.*
 examples/zpubsub/protobuf/testPublisher
 examples/zpubsub/protobuf/testSubscriber
-!examples/zpubsub/protobuf/Makefile
 src/test_zgossip
+labs/.deps/
+labs/.libs/
+labs/*.o
+labs/*.lo
+labs/*.pc
 
 .cproject
 .project

--- a/examples/zpubsub/protobuf/Makefile
+++ b/examples/zpubsub/protobuf/Makefile
@@ -2,21 +2,16 @@ CC = g++
 PROTO = protoc
 CFLAGS = -g -pthread
 LDFLAGS = -g -pthread
-LDLIBS = -lzmq -lczmq -lprotobuf -lpthread
-ZPUBSUB_SRC=../../../labs/zpubsub.c ../../../labs/zpubsub_option.c ../../../labs/zpubsub_filter.c
-ZPUBSUB_OBJ=zpubsub.o zpubsub_option.o zpubsub_filter.o
+LDLIBS = -lzmq -lczmq_labs -lczmq -lprotobuf -lpthread
 LIB_SRC = topic.cc subscriber.cc participant.cc
 PUB_SRC = $(LIB_SRC) testMessage.pb.cc testPublisher.cc
-PUB_OBJ = $(ZPUBSUB_OBJ) $(PUB_SRC:.cc=.o)
+PUB_OBJ = $(PUB_SRC:.cc=.o)
 SUB_SRC = $(LIB_SRC) testMessage.pb.cc testSubscriber.cc
-SUB_OBJ = $(ZPUBSUB_OBJ) $(SUB_SRC:.cc=.o)
+SUB_OBJ = $(SUB_SRC:.cc=.o)
 TARGETS = testPublisher testSubscriber
 
-default: zpubsub
+default:
 	make $(TARGETS)
-
-zpubsub: $(ZPUBSUB_SRC)
-	$(CC) $(CFLAGS) -c $^
 
 testPublisher: $(PUB_OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(PUB_OBJ) $(LDLIBS)


### PR DESCRIPTION
Fixed Makefile for zpubsub protobuf example to use czmq_labs library.
Added some .gitignores for labs directory.
