### PR TITLE
Fix ZSYS_SIGHANDLER env check

### DIFF
--- a/src/zctx.c
+++ b/src/zctx.c
@@ -84,7 +84,7 @@ zctx_new (void)
 
     //  Catch SIGINT and SIGTERM unless ZSYS_SIGHANDLER=false
     if (  getenv ("ZSYS_SIGHANDLER") == NULL
-       || strneq (getenv ("ZSYS_SIGHANDLER"), "true"))
+       || strneq (getenv ("ZSYS_SIGHANDLER"), "false"))
         zsys_catch_interrupts ();
 
     return self;

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -164,7 +164,7 @@ zsys_init (void)
     }
     //  Catch SIGINT and SIGTERM unless ZSYS_SIGHANDLER=false
     if (  getenv ("ZSYS_SIGHANDLER") == NULL
-       || strneq (getenv ("ZSYS_SIGHANDLER"), "true"))
+       || strneq (getenv ("ZSYS_SIGHANDLER"), "false"))
         zsys_catch_interrupts ();
 
     ZMUTEX_INIT (s_mutex);


### PR DESCRIPTION
Error in commit 2cc90cd1a7bce217e77a86a1cc1412294d3cd2bc
Signal handlers should be enabled if ZSYS_SIGHANDLER env is not false
