### PR TITLE
Fail if /dev/urandom could not be read

### DIFF
--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -60,8 +60,11 @@ zuuid_new (void)
             ssize_t bytes_read = read (fd, uuid, ZUUID_LEN);
             assert (bytes_read == ZUUID_LEN);
             close (fd);
-        }
-        zuuid_set (self, uuid);
+            zuuid_set (self, uuid);
+        } else
+            //  We couldn't read /dev/urandom and we have no alternative
+            //  strategy
+            assert (false);
 #endif
     }
     return self;


### PR DESCRIPTION
Make sure we do not succeed if /dev/urandom could not be read. Otherwise
we generate a uuid based on uninitialized data, which is not really
random.

Fixes #737.
