### PR TITLE
Only do a custom typedef of bool for MSVC

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -397,7 +397,7 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
 #endif
 
 // Windows MSVS doesn't have stdbool
-#if (defined (__WINDOWS__))
+#if (defined (_MSC_VER))
 #   if (!defined (__cplusplus) && (!defined (true)))
 #       define true 1
 #       define false 0


### PR DESCRIPTION
I changed the check for defining a non standard bool type to only be used with MSVC.
Doing so with mingw causes issues for the Go binding, as Go expects std bools to be used under mingw (As it is available)
