### PR TITLE
Fix mingw makefile

### DIFF
--- a/builds/mingw32/Makefile.mingw32
+++ b/builds/mingw32/Makefile.mingw32
@@ -12,19 +12,19 @@ CFLAGS=-Wall -Os -g -DLIBCZMQ_EXPORTS $(INCDIR)
 
 OBJS = zactor.o zauth.o zbeacon.o zcert.o zcertstore.o zchunk.o zclock.o zconfig.o zdigest.o zdir.o zdir_patch.o zfile.o zframe.o zhash.o zgossip.o ziflist.o zlist.o zloop.o zmonitor.o zmsg.o zpoller.o zproxy.o zrex.o zring.o zsock.o zsock_option.o zstr.o zsys.o zuuid.o zgossip_msg.o zauth_v2.o zbeacon_v2.o zctx.o zmonitor_v2.o zmutex.o zproxy_v2.o zsocket.o zsockopt.o zthread.o
 %.o: ../../src/%.c
-    $(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(CFLAGS)
 
 all: libczmq.dll czmq_selftest.exe
 
 libczmq.dll: $(OBJS)
-    gcc -shared -o $@ $(OBJS) -Wl,--out-implib,$@.a $(LIBDIR) -lzmq -lws2_32 -liphlpapi
+	$(CC) -shared -o $@ $(OBJS) -Wl,--out-implib,$@.a $(LIBDIR) -lzmq -lws2_32 -liphlpapi -lrpcrt4
 
 # the test functions are not exported into the DLL
 czmq_selftest.exe: czmq_selftest.o $(OBJS)
-    gcc -o $@ $^ $(LIBDIR) -lzmq -lws2_32 -liphlpapi
+	$(CC) -o $@ $^ $(LIBDIR) -lzmq -lws2_32 -liphlpapi -lrpcrt4
 
 clean:
-    del *.o *.a *.dll *.exe
+	del *.o *.a *.dll *.exe
 
 #################################################################
 #   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #

--- a/model/build-mingw32.gsl
+++ b/model/build-mingw32.gsl
@@ -24,19 +24,19 @@ OBJS =\
 .endfor
 
 %.o: ../../src/%.c
-    $\(CC) -c -o $@ $< $\(CFLAGS)
+	$\(CC) -c -o $@ $< $\(CFLAGS)
 
 all: lib$(project.name).dll $(project.name)_selftest.exe
 
 lib$(project.name).dll: $\(OBJS)
-    gcc -shared -o $@ $\(OBJS) -Wl,--out-implib,$@.a $\(LIBDIR) -lzmq -lws2_32 -liphlpapi
+	$\(CC) -shared -o $@ $\(OBJS) -Wl,--out-implib,$@.a $\(LIBDIR) -lzmq -lws2_32 -liphlpapi -lrpcrt4
 
 # the test functions are not exported into the DLL
 $(project.name)_selftest.exe: $(project.name)_selftest.o $\(OBJS)
-    gcc -o $@ $^ $\(LIBDIR) -lzmq -lws2_32 -liphlpapi
+	$\(CC) -o $@ $^ $\(LIBDIR) -lzmq -lws2_32 -liphlpapi -lrpcrt4
 
 clean:
-    del *.o *.a *.dll *.exe
+	del *.o *.a *.dll *.exe
 
 #################################################################
 #   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #


### PR DESCRIPTION
Replace spaces with tabs to ensure make doesn't refuse our file, add -lrpcrt4 flag to expose the CreateUuid funtion to the linker, use $(CC) instead of hardcoded gcc command
