### PR TITLE
Issue #743 fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,5 +263,5 @@ AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
 AC_SUBST([pkgconfigdir])
 
 # Specify output files
-AC_CONFIG_FILES([Makefile src/libczmq.pc labs/libczmq_labs.pc ])
+AC_CONFIG_FILES([Makefile src/Makefile src/libczmq.pc labs/libczmq_labs.pc ])
 AC_OUTPUT

--- a/model/build-autoconf.gsl
+++ b/model/build-autoconf.gsl
@@ -65,10 +65,21 @@ TESTS = $(project.name)_selftest
 .for model
 .   if first ()
 
+#################################################################
+#   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
+#   Please read the README.txt file in the model directory.     #
+#################################################################
+.echo "Generating src/Makefile.am..."
+.output "../src/Makefile.am"
+#################################################################
+#   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
+#   Please read the README.txt file in the model directory.     #
+#################################################################
+
 # Produce generated models; do this manually in src directory
 code:
 .   endif
-\tgsl -q src/$(name).xml
+\tgsl -q $(name).xml
 .endfor
 
 #################################################################

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,0 +1,15 @@
+#################################################################
+#   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
+#   Please read the README.txt file in the model directory.     #
+#################################################################
+
+# Produce generated models; do this manually in src directory
+code:
+	gsl -q sockopts.xml
+	gsl -q zgossip.xml
+	gsl -q zgossip_msg.xml
+
+#################################################################
+#   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
+#   Please read the README.txt file in the model directory.     #
+#################################################################

--- a/src/Makefile.am.supplement
+++ b/src/Makefile.am.supplement
@@ -112,12 +112,6 @@ endif
 
 TESTS = czmq_selftest
 
-# Produce generated models; do this manually in src directory
-code:
-	gsl -q src/sockopts.xml
-	gsl -q src/zgossip.xml
-	gsl -q src/zgossip_msg.xml
-
 #################################################################
 #   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
 #   Please read the README.txt file in the model directory.     #


### PR DESCRIPTION
Restores the custom make target in src with an independent makefile (not part of the nonrecursive root make call).  Note that this does not correct the gsl execution issue 'File: zproto_server_c not found'
