### PR TITLE
Problem: zsock_recv 'm' assumes initialized message

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -738,8 +738,7 @@ zsock_recv (void *self, const char *picture, ...)
         if (*picture == 'm') {
             zmsg_t **zmsg_p = va_arg (argptr, zmsg_t **);
             if (zmsg_p) {
-                if (!*zmsg_p)
-                    *zmsg_p = zmsg_new ();
+                *zmsg_p = zmsg_new ();
                 zframe_t *frame;
                 while ((frame = zmsg_pop (msg)))
                     zmsg_append (*zmsg_p, &frame);


### PR DESCRIPTION
This is inconsistent with all other picture formats and leads to
surprising code.

Solution: always initialize message before reading off socket.

If we need an "append to message" picture that should be a special
case, e.g. using 'M' as picture.
