### PR TITLE
Moved zclass packaging to non-generated files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ set (czmq_headers
     include/zthread.h
     src/zgossip_engine.inc
     src/zhash_primes.inc
+    src/zclass_example.xml
 )
 source_group ("Header Files" FILES ${czmq_headers})
 install(FILES ${czmq_headers} DESTINATION include)

--- a/builds/msvc/vs2008/czmq/czmq.vcproj
+++ b/builds/msvc/vs2008/czmq/czmq.vcproj
@@ -1525,6 +1525,7 @@
       <File RelativePath="..\..\..\..\include\czmq_prelude.h" />
       <File RelativePath="..\..\..\..\src\zgossip_engine.inc" />
       <File RelativePath="..\..\..\..\src\zhash_primes.inc" />
+      <File RelativePath="..\..\..\..\src\zclass_example.xml" />
     </Filter>
   </Files>
   <Globals />

--- a/builds/msvc/vs2010/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2010/czmq/czmq.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="..\..\..\..\include\czmq_prelude.h" />
     <ClInclude Include="..\..\..\..\src\zgossip_engine.inc" />
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc" />
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">

--- a/builds/msvc/vs2010/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2010/czmq/czmq.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\builds\msvc\platform.h">

--- a/builds/msvc/vs2012/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2012/czmq/czmq.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="..\..\..\..\include\czmq_prelude.h" />
     <ClInclude Include="..\..\..\..\src\zgossip_engine.inc" />
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc" />
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">

--- a/builds/msvc/vs2012/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2012/czmq/czmq.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\builds\msvc\platform.h">

--- a/builds/msvc/vs2013/czmq/czmq.vcxproj
+++ b/builds/msvc/vs2013/czmq/czmq.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="..\..\..\..\include\czmq_prelude.h" />
     <ClInclude Include="..\..\..\..\src\zgossip_engine.inc" />
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc" />
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">

--- a/builds/msvc/vs2013/czmq/czmq.vcxproj.filters
+++ b/builds/msvc/vs2013/czmq/czmq.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClInclude Include="..\..\..\..\src\zhash_primes.inc">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\src\zclass_example.xml">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\builds\msvc\platform.h">

--- a/model/Makefile.am.supplement
+++ b/model/Makefile.am.supplement
@@ -7,4 +7,6 @@ dist_bin_SCRIPTS = \
     model/build-vs2008.gsl \
     model/build-vs2010.gsl \
     model/build-vs2012.gsl \
-    model/build-vs2013.gsl
+    model/build-vs2013.gsl \
+    src/zclass_c.gsl \
+    src/zclass_lib.gsl

--- a/model/project.xml
+++ b/model/project.xml
@@ -45,6 +45,7 @@
     <!-- Other source files in src that we need to package -->
     <extra name = "zgossip_engine.inc" />
     <extra name = "zhash_primes.inc" />
+    <extra name = "zclass_example.xml" />
 
     <!-- Deprecated V2 API, remove some time after 3.0 stability -->
     <class name = "zauth_v2" />

--- a/src/Makefile.am.supplement
+++ b/src/Makefile.am.supplement
@@ -54,6 +54,7 @@ libczmq_la_SOURCES = \
     src/platform.h \
     src/zgossip_engine.inc \
     src/zhash_primes.inc \
+    src/zclass_example.xml \
     src/zactor.c \
     src/zauth.c \
     src/zarmour.c \
@@ -96,13 +97,6 @@ libczmq_la_SOURCES = \
     src/zthread.c
 
 bin_PROGRAMS = czmq_selftest
-
-dist_bin_SCRIPTS += \
-    src/zclass_c.gsl \
-    src/zclass_lib.gsl
-
-EXTRA_DIST += \
-    src/zclass_example.xml
 
 czmq_selftest_LDADD = \
     libczmq.la


### PR DESCRIPTION
Problem: Packaging of zclass generation scripts and example file was lost when generating.
Solution: Moved scripts to model/Makefile.am.supplement and example to project.xml as extra.
Question: Is this the correct way to package these things?
