### PR TITLE
Fix compilation error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,8 @@ ACLOCAL_AMFLAGS = -I config
 AM_CPPFLAGS = \
     -I$(srcdir)/include
 
+SUBDIRS = src
+
 EXTRA_DIST = \
 	version.sh \
 	builds/android/Android.mk \


### PR DESCRIPTION
This issue was introduced with PR #747, which has forgotten to also add
list 'src' part of SUBDIRS.

Closes zeromq/czmq#751
