### PR TITLE
Problem: Android ndk #defines errno as a preprocessor macro

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -788,7 +788,9 @@ zsys_udp_close (SOCKET handle)
 #include <errno.h>
 
 #ifndef _CRT_ERRNO_DEFINED
+#ifndef errno
 extern int errno;
+#endif
 #endif
 
 void


### PR DESCRIPTION
Solution: Guard errno declaration in zsys
Android macro defined here: https://android.googlesource.com/platform/prebuilts/ndk/+/master/9/platforms/android-19/arch-arm/usr/include/errno.h

When building for android (with my own build script), I encountered this: 

```
In file included from src/../include/czmq_prelude.h:217:0,
                 from src/../include/czmq.h:19,
                 from src/zsys.c:24:
src/zsys.c:787:12: error: conflicting types for '__errno'
 extern int errno;
            ^
/home/jemc/android/android-ndk-r9d/platforms/android-9/arch-arm/usr/include/errno.h:44:24: note: previous declaration of '__errno' was here
 extern volatile int*   __errno(void);
                        ^
make: *** [src/zsys.lo] Error 1
```

**Please consider carefully before merging!**
I think I am going about this fix the right way, but please check my sanity before merging - doing this the wrong way could break czmq for another platform...
