### PR TITLE
Problem: PKG_CHECK_MODULES doesn't add to LIBS on android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,11 @@ AM_CONDITIONAL(ON_ANDROID, test "x$czmq_on_android" = "xyes")
 AM_CONDITIONAL(INSTALL_MAN, test "x$czmq_install_man" = "xyes")
 AM_CONDITIONAL(BUILD_DOC, test "x$czmq_build_doc" = "xyes")
 
+# PKG_CHECK_MODULES doesn't add to LIBS on android
+if test "x$czmq_on_android" = "xyes"; then
+    LIBS="-lzmq $LIBS"
+fi
+
 # Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs)


### PR DESCRIPTION
Solution: Add -lzmq to LIBS manually

Took me quite a while to figure out why czmq was failing at runtime on android, but it's because it wasn't actually getting linked to libzmq.  Looking at `config.log`, I saw that `configure` was not adding it to `LIBS`, even though libzmq was getting successfully detected.  This works fine on my desktop, and I'm not sure why it's different, but `PKG_CHECK_MODULES` doesn't seem to be adding to `LIBS` when compiling for android.

It seems like `PKG_CHECK_MODULES` was added in a recent commit (https://github.com/zeromq/czmq/commit/313714f8b73c23d68b1216bc2df3d0ccc6ab1ffd).  I'm no expert on C build systems, but this seemed like a reasonable way to go about a workaround.
