### PR TITLE
Changes addressing #787.

### DIFF
--- a/addons/Makemodule.am
+++ b/addons/Makemodule.am
@@ -1,6 +1,7 @@
 EXTRA_DIST += \
     addons/makecert.c 
 
+if WITH_MAKECERT
 bin_PROGRAMS += addons/makecert
 
 addons_makecert_LDADD = \
@@ -9,4 +10,4 @@ addons_makecert_LDADD = \
 
 addons_makecert_SOURCES = \
     addons/makecert.c
-
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,16 @@ AC_PROG_SED
 AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
+# Check for makecert intent
+AC_ARG_WITH([makecert],
+    AS_HELP_STRING([--with-makecert], 
+        [Include the program makecert in compilation and installation.]),
+    [with_makecert=$withval],
+    [with_makecert=yes])
+
+AM_CONDITIONAL([WITH_MAKECERT], [test x$with_makecert != xno])
+AM_COND_IF([WITH_MAKECERT], [AC_MSG_NOTICE([WITH_MAKECERT defined])])
+
 # Checks for libraries
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([uuid], [uuid_generate])

--- a/model/build-autoconf.gsl
+++ b/model/build-autoconf.gsl
@@ -64,7 +64,7 @@ src_lib$(project.name)_la_LDFLAGS += \\
     -avoid-version
 endif
 
-bin_PROGRAMS += src/$(project.name)_selftest
+check_PROGRAMS += src/$(project.name)_selftest
 
 src_$(project.name)_selftest_CPPFLAGS = \\
 .for package_dependency where defined (package_dependency.for_test)

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -109,7 +109,7 @@ src_libczmq_la_LDFLAGS += \
     -avoid-version
 endif
 
-bin_PROGRAMS += src/czmq_selftest
+check_PROGRAMS += src/czmq_selftest
 
 src_czmq_selftest_CPPFLAGS = \
     ${src_libczmq_la_CFLAGS}


### PR DESCRIPTION
Allow makecert generation to be disabled via --without-makecert.  Make czmq_selfttest a check_PROGRAM, not to be installed.
