### PR TITLE
Problem: No builtin way to valgrind or gdb

### DIFF
--- a/src/.valgrind.supp
+++ b/src/.valgrind.supp
@@ -1,0 +1,14 @@
+{
+   <socketcall_sendto>
+   Memcheck:Param
+   socketcall.sendto(msg)
+   fun:send
+   ...
+}
+{
+   <socketcall_sendto>
+   Memcheck:Param
+   socketcall.send(msg)
+   fun:send
+   ...
+}

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -135,6 +135,18 @@ code:
 	cd $(srcdir)/src; gsl -q zgossip.xml
 	cd $(srcdir)/src; gsl -q zgossip_msg.xml
 
+# Run the selftest binary under valgrind to check for memory leaks
+memcheck: src/czmq_selftest
+	libtool --mode=execute valgrind --tool=memcheck \
+		--leak-check=full --show-reachable=yes --error-exitcode=1 \
+		--suppressions=$(srcdir)/src/.valgrind.supp \
+		$(srcdir)/src/czmq_selftest
+
+# Run the selftest binary under gdb for debugging
+debug: src/czmq_selftest
+	libtool --mode=execute gdb -q \
+		$(srcdir)/src/czmq_selftest
+
 #################################################################
 #   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
 #   Please read the README.txt file in the model directory.     #


### PR DESCRIPTION
Solution: Add the `make memcheck` and `make debug` targets
