### PR TITLE
Problem: CZMQ uses deprecated zsocket internally

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -349,8 +349,8 @@ zcert_apply (zcert_t *self, void *zocket)
 #if (ZMQ_VERSION_MAJOR == 4)
     void *handle = zsock_resolve (zocket);
     if (zsys_has_curve ()) {
-        zsocket_set_curve_secretkey_bin (handle, self->secret_key);
-        zsocket_set_curve_publickey_bin (handle, self->public_key);
+        zsock_set_curve_secretkey_bin (handle, self->secret_key);
+        zsock_set_curve_publickey_bin (handle, self->public_key);
     }
 #endif
 }

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -109,7 +109,7 @@ zframe_recv (void *source)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsocket_rcvmore (handle);
+        self->more = zsock_rcvmore (handle);
     }
     return self;
 }
@@ -391,7 +391,7 @@ zframe_recv_nowait (void *source)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsocket_rcvmore (handle);
+        self->more = zsock_rcvmore (handle);
     }
     return self;
 }

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -456,7 +456,7 @@ zloop_poller (zloop_t *self, zmq_pollitem_t *item, zloop_fn handler, void *arg)
     assert (self);
 
     if (item->socket
-    &&  streq (zsocket_type_str (item->socket), "UNKNOWN"))
+    &&  streq (zsys_sockname (zsock_type (item->socket)), "UNKNOWN"))
         return -1;
 
     s_poller_t *poller = s_poller_new (item, handler, arg);
@@ -469,7 +469,7 @@ zloop_poller (zloop_t *self, zmq_pollitem_t *item, zloop_fn handler, void *arg)
         self->need_rebuild = true;
         if (self->verbose)
             zsys_debug ("zloop: register %s poller (%p, %d)",
-                        item->socket ? zsocket_type_str (item->socket) : "FD",
+                        item->socket ? zsys_sockname (zsock_type (item->socket)) : "FD",
                         item->socket, item->fd);
         return 0;
     }
@@ -508,7 +508,7 @@ zloop_poller_end (zloop_t *self, zmq_pollitem_t *item)
     }
     if (self->verbose)
         zsys_debug ("zloop: cancel %s poller (%p, %d)",
-                    item->socket ? zsocket_type_str (item->socket) : "FD",
+                    item->socket ? zsys_sockname (zsock_type (item->socket)) : "FD",
                     item->socket, item->fd);
 }
 
@@ -797,7 +797,7 @@ zloop_start (zloop_t *self)
                     if (self->verbose)
                         zsys_warning ("zloop: can't poll %s socket (%p, %d): %s",
                                       poller->item.socket ?
-                                      zsocket_type_str (poller->item.socket) : "FD",
+                                      zsys_sockname (zsock_type (poller->item.socket)) : "FD",
                                       poller->item.socket, poller->item.fd,
                                       zmq_strerror (zmq_errno ()));
                     //  Give handler one chance to handle error, then kill
@@ -814,7 +814,7 @@ zloop_start (zloop_t *self)
                     if (self->verbose)
                         zsys_debug ("zloop: call %s socket handler (%p, %d)",
                                     poller->item.socket ?
-                                    zsocket_type_str (poller->item.socket) : "FD",
+                                    zsys_sockname (zsock_type (poller->item.socket)) : "FD",
                                     poller->item.socket, poller->item.fd);
                     rc = poller->handler (self, &self->pollset [item_nbr], poller->arg);
                     if (rc == -1 || self->need_rebuild)

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -110,7 +110,7 @@ zmsg_recv (void *source)
             zmsg_destroy (&self);
             break;
         }
-        if (!zsocket_rcvmore (handle))
+        if (!zsock_rcvmore (handle))
             break;              //  Last message frame
     }
     return self;
@@ -776,7 +776,7 @@ zmsg_recv_nowait (void *source)
             zmsg_destroy (&self);
             break;
         }
-        if (!zsocket_rcvmore (source))
+        if (!zsock_rcvmore (source))
             break;              //  Last message frame
     }
     return self;

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -193,7 +193,7 @@ s_self_switch (self_t *self, zsock_t *input, zsock_t *output)
     while (true) {
         if (zmq_recvmsg (zmq_input, &msg, ZMQ_DONTWAIT) == -1)
             break;      //  Presumably EAGAIN
-        int send_flags = zsocket_rcvmore (zmq_input) ? ZMQ_SNDMORE : 0;
+        int send_flags = zsock_rcvmore (zmq_input) ? ZMQ_SNDMORE : 0;
         if (zmq_capture) {
             zmq_msg_t dup;
             zmq_msg_init (&dup);

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -280,18 +280,18 @@ zsys_socket (int type, const char *filename, size_t line_nbr)
     ZMUTEX_LOCK (s_mutex);
     void *handle = zmq_socket (s_process_ctx, type);
     //  Configure socket with process defaults
-    zsocket_set_linger (handle, (int) s_linger);
+    zsock_set_linger (handle, (int) s_linger);
 #if (ZMQ_VERSION_MAJOR == 2)
     //  For ZeroMQ/2.x we use sndhwm for both send and receive
-    zsocket_set_hwm (handle, s_sndhwm);
+    zsock_set_hwm (handle, s_sndhwm);
 #else
     //  For later versions we use separate SNDHWM and RCVHWM
-    zsocket_set_sndhwm (handle, (int) s_sndhwm);
-    zsocket_set_rcvhwm (handle, (int) s_rcvhwm);
+    zsock_set_sndhwm (handle, (int) s_sndhwm);
+    zsock_set_rcvhwm (handle, (int) s_rcvhwm);
 #   if defined (ZMQ_IPV6)
-    zsocket_set_ipv6 (handle, s_ipv6);
+    zsock_set_ipv6 (handle, s_ipv6);
 #   else
-    zsocket_set_ipv4only (handle, s_ipv6 ? 0 : 1);
+    zsock_set_ipv4only (handle, s_ipv6 ? 0 : 1);
 #   endif
 #endif
     //  Add socket to reference tracker so we can report leaks; this is
@@ -1600,7 +1600,7 @@ zsys_test (bool verbose)
     zsys_set_logsender ("inproc://logging");
     void *logger = zsys_socket (ZMQ_SUB, NULL, 0);
     assert (logger);
-    rc = zsocket_connect (logger, "inproc://logging");
+    rc = zmq_connect (logger, "inproc://logging");
     assert (rc == 0);
     rc = zmq_setsockopt (logger, ZMQ_SUBSCRIBE, "", 0);
     assert (rc == 0);


### PR DESCRIPTION
Solution: Remove all internal uses of zsocket.h and zsockopt.h
Note: (Did not remove internal usage in other deprecated classes)
