### PR TITLE
Problem: extended containers are non-trivial to learn

### DIFF
--- a/doc/czmq.txt
+++ b/doc/czmq.txt
@@ -42,7 +42,9 @@ These classes support authentication and encryption:
 
 These classes provide generic containers:
 
+* linkczmq:zhash[3] - simple generic hash container
 * linkczmq:zhashx[3] - extended generic hash container
+* linkczmq:zlist[3] - simple generic list container
 * linkczmq:zlistx[3] - extended generic list container
 
 These classes wrap-up non-portable functionality:
@@ -68,8 +70,6 @@ These classes are deprecated:
 * linkczmq:zctx[3] - working with ZeroMQ contexts
 * linkczmq:zsocket[3] - working with ZeroMQ sockets (low-level)
 * linkczmq:zsockopt[3] - get/set ZeroMQ socket options
-* linkczmq:zhash[3] - generic type-free hash container (dictionary)
-* linkczmq:zlist[3] - generic type-free list container (singly-linked list)
 * linkczmq:zthread[3] - working with system threads
 * linkczmq:zauth_v2[3] - authentication for ZeroMQ servers
 * linkczmq:zbeacon_v2[3] - LAN discovery and presence

--- a/include/zhash.h
+++ b/include/zhash.h
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    zhash - generic type-free hash container (deprecated)
+    zhash - generic type-free hash container (simple)
 
     Copyright (c) the Contributors as noted in the AUTHORS file.
     This file is part of CZMQ, the high-level C binding for 0MQ:

--- a/include/zlist.h
+++ b/include/zlist.h
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    zlist - generic type-free list container (deprecated)
+    zlist - simple generic list container
 
     Copyright (c) the Contributors as noted in the AUTHORS file.
     This file is part of CZMQ, the high-level C binding for 0MQ:

--- a/src/zhash.c
+++ b/src/zhash.c
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    zhash - generic type-free hash container (deprecated)
+    zhash - simple generic hash container
 
     Copyright (c) the Contributors as noted in the AUTHORS file.
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -13,8 +13,8 @@
 
 /*
 @header
-    zhash is an expandable hash table container. This is the deprecated V2
-    class. For new applications we recommend using zhashx.
+    zhash is an expandable hash table container. This is a simple container.
+    For heavy-duty applications we recommend using zhashx.
 @discuss
     Note that it's relatively slow (~50K insertions/deletes per second), so
     don't do inserts/updates on the critical path for message I/O. It can

--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -13,7 +13,8 @@
 
 /*
 @header
-    zhashx is an expandable hash table container.
+    zhashx is an extended hash table container with more functionality than
+    zhash, its simpler cousin.
 @discuss
     The hash table always has a size that is prime and roughly doubles its
     size when 75% full. In case of hash collisions items are chained in a

--- a/src/zlist.c
+++ b/src/zlist.c
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    zlist - generic type-free list container (deprecated)
+    zlist - simple generic list container
 
     Copyright (c) the Contributors as noted in the AUTHORS file.
     This file is part of CZMQ, the high-level C binding for 0MQ:
@@ -15,8 +15,8 @@
 @header
     Provides a generic container implementing a fast singly-linked list. You
     can use this to construct multi-dimensional lists, and other structures
-    together with other generic containers like zhash. This is the deprecated
-    V2 class. For new applications we recommend using zlistx.
+    together with other generic containers like zhash. This is a simple
+    class. For demanding applications we recommend using zlistx.
 @discuss
     To iterate through a list, use zlist_first to get the first item, then
     loop while not null, and do zlist_next at the end of each iteration.

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -19,8 +19,8 @@
     use strdup, strcmp, and zstr_free. To store custom objects, define your
     own duplicator and comparator, and use the standard object destructor.
 @discuss
-    This is a reworking of the old V2 list container. It is faster to insert
-    and delete items anywhere in the list, and to keep ordered lists.
+    This is a reworking of the simpler zlist container. It is faster to 
+    insert and delete items anywhere in the list, and to keep ordered lists.
 @end
 */
 


### PR DESCRIPTION
Solution: un-deprecate zlist and zhash and offer these as the
"simple" containers, with zlistx and zhashx as upgrades for
more demanding applications.
