### PR TITLE
Problem: zsock and zgossip_msg don't build on ZMQv2

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -576,6 +576,8 @@ typedef int SOCKET;
 #   define zmq_recvmsg      zmq_recv
 #   define zmq_ctx_new      zmq_init
 #   define zmq_ctx_term     zmq_term
+#   define zmq_msg_send(m,s,f)  zmq_sendmsg ((s),(m),(f))
+#   define zmq_msg_recv(m,s,f)  zmq_recvmsg ((s),(m),(f))
     //  Older libzmq APIs may be missing some aspects of libzmq v3.0
 #   ifndef ZMQ_ROUTER
 #       define ZMQ_ROUTER       ZMQ_XREP

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -964,7 +964,7 @@ zsock_bsend (void *self, const char *picture, ...)
                 }
             }
             else
-                frames [nbr_frames++] = NULL;
+                frames [nbr_frames++] = zframe_new_empty ();
         }
         else {
             zsys_error ("zsock_bsend: invalid picptr element '%c'", *picptr);
@@ -1048,11 +1048,8 @@ zsock_bsend (void *self, const char *picture, ...)
     int frame_nbr;
     for (frame_nbr = 0; frame_nbr < nbr_frames; frame_nbr++) {
         bool more = frame_nbr < nbr_frames - 1;
-        if (frames [frame_nbr])
-            zframe_send (&frames [frame_nbr], handle,
-                         ZFRAME_REUSE + (more? ZFRAME_MORE: 0));
-        else
-            zmq_send (handle, NULL, 0, more? ZMQ_SNDMORE: 0);
+        zframe_send (&frames [frame_nbr], handle,
+                     ZFRAME_REUSE + (more? ZFRAME_MORE: 0));
     }
     return 0;
 }


### PR DESCRIPTION
Solution: use a macro to emulate zmq_msg_send() and zmq_msg_recv()
and do not use zmq_send in version-independent code.
