### PR TITLE
Bring docs up to date wrt the deprecated zframe_recv_nowait.

### DIFF
--- a/doc/zframe.doc
+++ b/doc/zframe.doc
@@ -29,7 +29,7 @@ This is the class interface:
     
     //  Receive frame from socket, returns zframe_t object or NULL if the recv
     //  was interrupted. Does a blocking recv, if you want to not block then use
-    //  zframe_recv_nowait().
+    //  zpoller or zloop.
     CZMQ_EXPORT zframe_t *
         zframe_recv (void *source);
     

--- a/doc/zframe.txt
+++ b/doc/zframe.txt
@@ -26,7 +26,7 @@ CZMQ_EXPORT void
 
 //  Receive frame from socket, returns zframe_t object or NULL if the recv
 //  was interrupted. Does a blocking recv, if you want to not block then use
-//  zframe_recv_nowait().
+//  zpoller or zloop.
 CZMQ_EXPORT zframe_t *
     zframe_recv (void *source);
 

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -37,7 +37,7 @@ CZMQ_EXPORT void
 
 //  Receive frame from socket, returns zframe_t object or NULL if the recv
 //  was interrupted. Does a blocking recv, if you want to not block then use
-//  zframe_recv_nowait().
+//  zpoller or zloop.
 CZMQ_EXPORT zframe_t *
     zframe_recv (void *source);
 


### PR DESCRIPTION
Small fix. The src file comments were not updated in the rest of the tree.
