### PR TITLE
Problem: mingw 64Bit relies on int[32/64]/uint[32/64] definitions whereas mingw 32Bit does not.

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -433,10 +433,12 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
     typedef long ssize_t;
 #       endif
 #   endif
+#   if (!defined (__MINGW32__) || (defined (__MINGW32__) && defined (__IS_64BIT__)))
     typedef __int32 int32_t;
     typedef __int64 int64_t;
     typedef unsigned __int32 uint32_t;
     typedef unsigned __int64 uint64_t;
+#   endif    
 #   if (!defined (PRId64))
 #       define PRId64   "I64d"
 #   endif


### PR DESCRIPTION
Solution: include those defines in case of mingw 64Bit and exclude them in case of mingw 32Bit.
