### PR TITLE
Problem: zsys_allocs is not defined as external

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -331,6 +331,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT extern volatile int zsys_interrupted;
 //  Deprecated name for this variable
 CZMQ_EXPORT extern volatile int zctx_interrupted;
+
+//  Counts number of zmalloc calls, see czmq_prelude.h
+CZMQ_EXPORT extern volatile int zsys_allocs;
+
 //  @end
 
 #ifdef __cplusplus

--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -85,11 +85,7 @@ main (int argc, char *argv [])
 
     zsys_shutdown ();
 
-// In VS builds zsys_allocs causes an unresolved external error.
-#ifdef _MSC_VER
     printf ("Number of memory allocations=%" PRId64 "\n", zsys_allocs);
-#endif
-
     printf ("Tests passed OK\n");
     return 0;
 }


### PR DESCRIPTION
Solution: define properly in zsys.h.
