### PR TITLE
zuuid: proposed a feature to export UUID in their canonical form

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,3 +55,4 @@ Mike Gatny
 Chris Busbey 
 Goswin von Brederlow
 Svein L. Ellingsen
+oikosdev

--- a/include/zuuid.h
+++ b/include/zuuid.h
@@ -42,6 +42,11 @@ CZMQ_EXPORT size_t
 CZMQ_EXPORT char *
     zuuid_str (zuuid_t *self);
 
+// Set target string with UUID as formatted string in the canonical format 8-4-4-4-12, lower case 
+// see: http://en.wikipedia.org/wiki/Universally_unique_identifier
+CZMQ_EXPORT void
+    zuuid_formatted_str (zuuid_t *self, char *target);
+
 //  Set UUID to new supplied ZUUID_LEN-octet value
 CZMQ_EXPORT void
     zuuid_set (zuuid_t *self, byte *source);

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -159,6 +159,31 @@ zuuid_str (zuuid_t *self)
     return self->str;
 }
 
+//  -----------------------------------------------------------------
+// Set target string with UUID as formatted string in the canonical format 8-4-4-4-12, lower case 
+// see: http://en.wikipedia.org/wiki/Universally_unique_identifier
+
+void
+zuuid_formatted_str (zuuid_t *self, char *target)
+{
+    assert (self);
+    target[0]='\0';
+    strncat(target,self->str,8);
+    strcat(target,"-");
+    strncat(target,self->str+8,4);
+    strcat(target,"-");
+    strncat(target,self->str+12,4);
+    strcat(target,"-");
+    strncat(target,self->str+16,4);
+    strcat(target,"-");
+    strncat(target,self->str+20,12);
+    int i = 0;
+    while (i<36)
+    {
+      target[i] = tolower(target[i]);
+      i++;
+    }
+}
 
 //  -----------------------------------------------------------------
 //  Store UUID blob into a target array


### PR DESCRIPTION
Problem: Missing feature to export UUID as fomatted string in canonical form (8-4-4-4-12)

Solution: Added a method zuuid_formatted_str to export the UUID string in canonical form
