### PR TITLE
Problem: Can't install czmq.7

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,7 @@
 #################################################################
 MAN1 =
 MAN3 = zactor.3 zauth.3 zarmour.3 zbeacon.3 zcert.3 zcertstore.3 zchunk.3 zclock.3 zconfig.3 zdigest.3 zdir.3 zdir_patch.3 zfile.3 zframe.3 zgossip.3 zhashx.3 ziflist.3 zlistx.3 zloop.3 zmonitor.3 zmsg.3 zpoller.3 zproxy.3 zrex.3 zsock.3 zsock_option.3 zstr.3 zsys.3 zuuid.3 zauth_v2.3 zbeacon_v2.3 zctx.3 zhash.3 zlist.3 zmonitor_v2.3 zmutex.3 zproxy_v2.3 zsocket.3 zsockopt.3 zthread.3
-MAN7 = $(srcdir)/czmq.7
+MAN7 = czmq.7
 MAN_DOC = $(MAN1) $(MAN3) $(MAN7)
 
 MAN_TXT = $(MAN1:%.1=%.txt)


### PR DESCRIPTION
Searching for czmq.7 in srcdir while it is generated in buildir. Fixed
by removing srcdir and change submitted to zproject:
https://github.com/zeromq/zproject/pull/101
