### PR TITLE
PROBLEM: zring was removed, but can't be implemented using zlistx and zhashx

### DIFF
--- a/include/zlistx.h
+++ b/include/zlistx.h
@@ -77,6 +77,11 @@ CZMQ_EXPORT void *
 CZMQ_EXPORT void *
     zlistx_handle (zlistx_t *self);
 
+//  Returns the item associated with the given list handle, or NULL if passed
+//  in handle is NULL. Asserts that the passed in handle points to a list element.
+CZMQ_EXPORT  void *
+    zlistx_handle_item (void *handle);
+
 //  Find an item in the list, searching from the start. Uses the item
 //  comparator, if any, else compares item values directly. Returns the
 //  item handle found, or NULL. Sets the cursor to the found item, if any.

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -287,6 +287,21 @@ zlistx_handle (zlistx_t *self)
     return self->cursor == self->head? NULL: self->cursor;
 }
 
+//  --------------------------------------------------------------------------
+//  Returns the item associated with the given list handle, or NULL if passed
+//  handle is NULL. asserts that the passed in ptr points to a list node.
+
+void *
+zlistx_handle_item (void *handle)
+{
+    if (!handle)
+        return NULL;
+
+    node_t *node = (node_t *) handle;
+    assert (node->tag == NODE_TAG);
+    return node->item;
+}
+
 
 //  --------------------------------------------------------------------------
 //  Find an item in the list, searching from the start. Uses the item
@@ -633,6 +648,10 @@ zlistx_test (int verbose)
     zlistx_sort (list);
     assert (zlistx_size (list) == 2);
     void *handle = zlistx_find (list, "hello");
+    char *item1 = (char *) zlistx_item (list);
+    char *item2 = (char *) zlistx_handle_item (handle);
+    assert (item1 == item2);
+    assert (streq (item1, "hello"));
     zlistx_delete (list, handle);
     assert (zlistx_size (list) == 1);
     char *string = (char *) zlistx_detach (list, NULL);


### PR DESCRIPTION
zring has been removed recently because it's a weird data structure.
Yet, I have found it really useful, so tried to implement it on top
of zlistx and and zhashx, by storing list handles in the hash.
However, when deleting an item from the hash, one needs to convert a
list handle to the item stored in it, which is currently not possible,
because the pointer is opaque.

SOLUTION: add a function to convert a handle into the associated item.
