### PR TITLE
Problem: zlist selftest is missing explicit casts and does not compile.

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -547,10 +547,10 @@ zlist_test (int verbose)
     zlist_append (list, tmp);
     assert (zlist_size (list) == 2);
     assert (zlist_first (list) != tmp);
-    assert (streq (zlist_first (list), bread));
+    assert (streq ((const char *) zlist_first (list), bread));
     item = (char *) zlist_pop (list);
     assert (zlist_first (list) != tmp);
-    assert (streq (zlist_first (list), tmp));
+    assert (streq ((const char *) zlist_first (list), tmp));
     zlist_destroy (&list);
     assert (list == NULL);
 


### PR DESCRIPTION
Solution: Added missing casts in zlist selftest.
