### PR TITLE
Dir patch does not duplicate delete patches

### DIFF
--- a/src/zdir_patch.c
+++ b/src/zdir_patch.c
@@ -114,7 +114,7 @@ zdir_patch_dup (zdir_patch_t *self)
                 //  Don't recalculate hash when we duplicate patch
                 copy->digest = self->digest ? strdup (self->digest) : NULL;
 
-            if (copy->digest == NULL)
+            if (copy->digest == NULL && copy->op != patch_delete)
                 zdir_patch_destroy (&copy);
         }
         return copy;


### PR DESCRIPTION
Problem: The zdir_patch object does not duplicate a patch that is
a delete operation. The duplication method requires that the file's
digest is not NULL, but a delete operation will not have a file to
read to calculate the digest.

Solution: Added a test for the operation type before the zdir_patch
object is destroyed for having an empty digest.
