### PR TITLE
Problem: There are no va_list versions of zsock_send/recv picture messages.

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -200,6 +200,12 @@ CZMQ_EXPORT const char *
 CZMQ_EXPORT int
     zsock_send (void *self, const char *picture, ...);
 
+//  Send a 'picture' message to the socket (or actor). This is a
+//  va_list version of zsock_send (), so please consult its documentation
+//  for the details.
+CZMQ_EXPORT int
+    zsock_vsend (void *self, const char *picture, va_list argptr);
+
 //  Receive a 'picture' message to the socket (or actor). See zsock_send for
 //  the format and meaning of the picture. Returns the picture elements into
 //  a series of pointers as provided by the caller:
@@ -226,6 +232,12 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsock_recv (void *self, const char *picture, ...);
 
+//  Receive a 'picture' message from the socket (or actor). This is a
+//  va_list version of zsock_recv (), so please consult its documentation
+//  for the details.
+CZMQ_EXPORT int
+    zsock_vrecv (void *self, const char *picture, va_list argptr);
+
 //  Send a binary encoded 'picture' message to the socket (or actor). This
 //  method is similar to zsock_send, except the arguments are encoded in a
 //  binary format that is compatible with zproto, and is designed to reduce
@@ -248,7 +260,7 @@ CZMQ_EXPORT int
 //  successful, -1 if sending failed for any reason.
 CZMQ_EXPORT int
     zsock_bsend (void *self, const char *picture, ...);
-    
+
 //  Receive a binary encoded 'picture' message from the socket (or actor).
 //  This method is similar to zsock_recv, except the arguments are encoded
 //  in a binary format that is compatible with zproto, and is designed to
@@ -259,7 +271,7 @@ CZMQ_EXPORT int
 //  values. Returns 0 if successful, or -1 if it failed to read a message.
 CZMQ_EXPORT int
     zsock_brecv (void *self, const char *picture, ...);
-    
+
 //  Set socket to use unbounded pipes (HWM=0); use this in cases when you are
 //  totally certain the message volume can fit in memory. This method works
 //  across all versions of ZeroMQ. Takes a polymorphic socket reference.
@@ -273,7 +285,7 @@ CZMQ_EXPORT void
 //  not be sent. Takes a polymorphic socket reference.
 CZMQ_EXPORT int
     zsock_signal (void *self, byte status);
-    
+
 //  Wait on a signal. Use this to coordinate between threads, over pipe
 //  pairs. Blocks until the signal is received. Returns -1 on error, 0 or
 //  greater on success. Accepts a zsock_t or a zactor_t as argument.

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -560,11 +560,24 @@ zsock_type_str (zsock_t *self)
 int
 zsock_send (void *self, const char *picture, ...)
 {
+    va_list argptr;
+    va_start (argptr, picture);
+    int rc = zsock_vsend (self, picture, argptr);
+    va_end (argptr);
+    return rc;
+}
+
+
+//  Send a 'picture' message to the socket (or actor). This is a
+//  va_list version of zsock_send (), so please consult its documentation
+//  for the details.
+
+int
+zsock_vsend (void *self, const char *picture, va_list argptr)
+{
     assert (self);
     assert (picture);
 
-    va_list argptr;
-    va_start (argptr, picture);
     zmsg_t *msg = zmsg_new ();
     while (*picture) {
         if (*picture == 'i')
@@ -624,7 +637,6 @@ zsock_send (void *self, const char *picture, ...)
         }
         picture++;
     }
-    va_end (argptr);
     return zmsg_send (&msg, self);
 }
 
@@ -657,6 +669,21 @@ zsock_send (void *self, const char *picture, ...)
 int
 zsock_recv (void *self, const char *picture, ...)
 {
+    va_list argptr;
+    va_start (argptr, picture);
+    int rc = zsock_vrecv (self, picture, argptr);
+    va_end (argptr);
+    return rc;
+}
+
+
+//  Receive a 'picture' message from the socket (or actor). This is a
+//  va_list version of zsock_recv (), so please consult its documentation
+//  for the details.
+
+int
+zsock_vrecv (void *self, const char *picture, va_list argptr)
+{
     assert (self);
     assert (picture);
     zmsg_t *msg = zmsg_recv (self);
@@ -664,8 +691,6 @@ zsock_recv (void *self, const char *picture, ...)
         return -1;              //  Interrupted
 
     int rc = 0;
-    va_list argptr;
-    va_start (argptr, picture);
     while (*picture) {
         if (*picture == 'i') {
             char *string = zmsg_popstr (msg);
@@ -781,7 +806,6 @@ zsock_recv (void *self, const char *picture, ...)
         }
         picture++;
     }
-    va_end (argptr);
     zmsg_destroy (&msg);
     return rc;
 }


### PR DESCRIPTION
Elaboration: When implementing classes using zsock functionality in other projects, it would be useful to be able to avoid duplicating the picture message code from zsock_send/recv.
Solution: Added va_list versions zsock_vsend/vrecv of zsock_send/recv; calling these from zsock_send/recv.
