### PR TITLE
Make testing optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ enable_testing()
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+#######################################################################
+# Do we build and register self tests ?
+######################################################################
+set(CZMQ_BUILD_TESTS   true   CACHE BOOL "build czmq selftest")
+
 ########################################################################
 # determine version
 ########################################################################
@@ -210,9 +215,11 @@ install(
 ########################################################################
 # tests
 ########################################################################
-add_executable(czmq_selftest ${SOURCE_DIR}/src/czmq_selftest.c)
-target_link_libraries(czmq_selftest czmq ${ZEROMQ_LIBRARIES})
-add_test(czmq_selftest czmq_selftest)
+if (CZMQ_BUILD_TESTS)
+  add_executable(czmq_selftest ${SOURCE_DIR}/src/czmq_selftest.c)
+  target_link_libraries(czmq_selftest czmq ${ZEROMQ_LIBRARIES})
+  add_test(czmq_selftest czmq_selftest)
+endif()
 
 ########################################################################
 # summary


### PR DESCRIPTION
Adds a new CMake variable: CZMQ_BUILD_TESTS that defaults to true.
When set to false, czmq self tests aren't build and not registered with cmake.
