### PR TITLE
Problem: Low-level CZMQ primitives needlessly use extended container zlistx.

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -25,7 +25,7 @@
 //  Structure of our class
 
 struct _zpoller_t {
-    zlistx_t *reader_list;      //  List of sockets to read from
+    zlist_t *reader_list;      //  List of sockets to read from
     zmq_pollitem_t *poll_set;   //  Current zmq_poll set
     void **poll_readers;        //  Matching table of socket readers
     size_t poll_size;           //  Size of poll set
@@ -47,14 +47,14 @@ zpoller_new (void *reader, ...)
 {
     zpoller_t *self = (zpoller_t *) zmalloc (sizeof (zpoller_t));
     if (self) {
-        self->reader_list = zlistx_new ();
+        self->reader_list = zlist_new ();
         if (self->reader_list) {
             self->need_rebuild = true;
 
             va_list args;
             va_start (args, reader);
             while (reader) {
-                if (zlistx_add_end (self->reader_list, reader) == NULL) {
+                if (zlist_append (self->reader_list, reader)) {
                     zpoller_destroy (&self);
                     break;
                 }
@@ -78,7 +78,7 @@ zpoller_destroy (zpoller_t **self_p)
     assert (self_p);
     if (*self_p) {
         zpoller_t *self = *self_p;
-        zlistx_destroy (&self->reader_list);
+        zlist_destroy (&self->reader_list);
         free (self->poll_readers);
         free (self->poll_set);
         free (self);
@@ -96,7 +96,7 @@ zpoller_add (zpoller_t *self, void *reader)
 {
     assert (self);
     assert (reader);
-    int rc = zlistx_add_end (self->reader_list, reader)? 0: -1;
+    int rc = zlist_append (self->reader_list, reader);
     self->need_rebuild = true;
     return rc;
 }
@@ -112,9 +112,7 @@ zpoller_remove (zpoller_t *self, void *reader)
 {
     assert (self);
     assert (reader);
-    void *handle = zlistx_find (self->reader_list, reader);
-    if (handle)
-        zlistx_delete (self->reader_list, handle);
+    zlist_remove (self->reader_list, reader);
     self->need_rebuild = true;
     return 0;
 }
@@ -166,7 +164,7 @@ s_rebuild_poll_set (zpoller_t *self)
     free (self->poll_readers);
     self->poll_readers = NULL;
 
-    self->poll_size = zlistx_size (self->reader_list);
+    self->poll_size = zlist_size (self->reader_list);
     self->poll_set = (zmq_pollitem_t *)
                      zmalloc (self->poll_size * sizeof (zmq_pollitem_t));
     self->poll_readers = (void **) zmalloc (self->poll_size * sizeof (void *));
@@ -174,7 +172,7 @@ s_rebuild_poll_set (zpoller_t *self)
         return -1;
 
     uint reader_nbr = 0;
-    void *reader = zlistx_first (self->reader_list);
+    void *reader = zlist_first (self->reader_list);
     while (reader) {
         self->poll_readers [reader_nbr] = reader;
         void *socket = zsock_resolve (reader);
@@ -191,7 +189,7 @@ s_rebuild_poll_set (zpoller_t *self)
         self->poll_set [reader_nbr].events = ZMQ_POLLIN;
 
         reader_nbr++;
-        reader = zlistx_next (self->reader_list);
+        reader = zlist_next (self->reader_list);
     }
     self->need_rebuild = false;
     return 0;


### PR DESCRIPTION
Solution: Use simple container zlist where it is sufficient.
