### PR TITLE
Fix Unicode/MBCS ambiguity for VS2013

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -683,7 +683,7 @@ zsys_dir_change (const char *pathname)
 #if (defined (__UNIX__))
     return chdir (pathname);
 #elif (defined (__WINDOWS__))
-    return !SetCurrentDirectory (pathname);
+    return !SetCurrentDirectoryA (pathname);
 #endif
     return -1;              //  Not implemented
 }


### PR DESCRIPTION
Use explicit SetCurrentDirectoryA() instead of character-set-dependent SetCurrentDirectory macro.

I have only tested this with VS2013, but calling SetCurrentDirectoryA() with a const char* parameter should be correct for any version.