### PR TITLE
Problem: zmq.h is included rather late in czmq_prelude.h

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -204,6 +204,11 @@
 #   define __UTYPE_GENERIC
 #endif
 
+//- Always include ZeroMQ headers -------------------------------------------
+
+#include "zmq.h"
+#include "zmq_utils.h"
+
 //- Standard ANSI include files ---------------------------------------------
 
 #include <ctype.h>
@@ -563,10 +568,7 @@ typedef int SOCKET;
 #   endif
 #endif
 
-//- Always include ZeroMQ header file ---------------------------------------
-
-#include "zmq.h"
-#include "zmq_utils.h"
+//  ZMQ compatibility macros
 
 #if ZMQ_VERSION_MAJOR == 4
 #   define ZMQ_POLL_MSEC    1           //  zmq_poll is msec


### PR DESCRIPTION
Solution: include at start (after system detection).