### PR TITLE
add zhashx_values

### DIFF
--- a/include/zhashx.h
+++ b/include/zhashx.h
@@ -84,6 +84,12 @@ CZMQ_EXPORT size_t
 //  key_destructor as destructor for the list.
 CZMQ_EXPORT zlistx_t *
     zhashx_keys (zhashx_t *self);
+
+//  Return a zlistx_t containing the values for the items in the
+//  table. Uses the duplicator to duplicate all items and sets the
+//  destructor as destructor for the list.
+CZMQ_EXPORT zlistx_t *
+    zhashx_values (zhashx_t *self);
     
 //  Simple iterator; returns first item in hash table, in no given order,
 //  or NULL if the table is empty. This method is simpler to use than the


### PR DESCRIPTION
I am new to zmq and czqm. I was surprised to learn that there is zhashx_keys but no zhashx_values.

I needed the latter, so I implemented it. If possible I would like this included in czmq, hence the pull-request.

Code is pretty straightforward, mostly copy & pasted from zhashx_keys and modified to create a list of values instead of keys.
