### PR TITLE
Fix zsys_allocs export&import when build under msvc 2013

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -511,8 +511,11 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
 #endif
 
 //- Memory allocations ------------------------------------------------------
-
-CZMQ_EXPORT extern volatile uint64_t zsys_allocs;
+#if defined(__cplusplus)
+   extern "C" CZMQ_EXPORT volatile uint64_t zsys_allocs;
+#else
+   extern CZMQ_EXPORT volatile uint64_t zsys_allocs;
+#endif
 
 //  Replacement for malloc() which asserts if we run out of heap, and
 //  which zeroes the allocated block.


### PR DESCRIPTION
This one seems to completely fix https://github.com/zeromq/czmq/issues/870