### PR TITLE
Problem: lack of min/max macros is causing some friction in Malamute

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -392,6 +392,8 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
 
 #define streq(s1,s2)    (!strcmp ((s1), (s2)))
 #define strneq(s1,s2)   (strcmp ((s1), (s2)))
+#define min(a,b)        (((a)<(b))? (a): (b))
+#define max(a,b)        (((a)>(b))? (a): (b))
 
 //  Provide random number from 0..(num-1)
 #if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -392,8 +392,12 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
 
 #define streq(s1,s2)    (!strcmp ((s1), (s2)))
 #define strneq(s1,s2)   (strcmp ((s1), (s2)))
-#define min(a,b)        (((a)<(b))? (a): (b))
-#define max(a,b)        (((a)>(b))? (a): (b))
+#if !defined (min)
+#   define min(a,b)     (((a)<(b))? (a): (b))
+#endif
+#if !defined (max)
+#   define max(a,b)     (((a)>(b))? (a): (b))
+#endif
 
 //  Provide random number from 0..(num-1)
 #if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \


### PR DESCRIPTION
Solution: define these in "inevitable macros" section of czmq_prelude.h.