### PR TITLE
Problem: min, max macros conflict with C++ limits header

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -392,12 +392,6 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
 
 #define streq(s1,s2)    (!strcmp ((s1), (s2)))
 #define strneq(s1,s2)   (strcmp ((s1), (s2)))
-#if !defined (min)
-#   define min(a,b)     (((a)<(b))? (a): (b))
-#endif
-#if !defined (max)
-#   define max(a,b)     (((a)>(b))? (a): (b))
-#endif
 
 //  Provide random number from 0..(num-1)
 #if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \


### PR DESCRIPTION
Solution: remove these macros. The Malamute code that uses them
can just take the long route.