### PR TITLE
Problem: zsock_fd returns SOCKET, not int, on Windows

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -274,7 +274,7 @@ zpoller_test (bool verbose)
     //  Check we can poll an FD
     rc = zsock_connect (bowl, "tcp://127.0.0.1:%d", port_nbr);
     assert (rc != -1);
-    int fd = zsock_fd (bowl);
+    SOCKET fd = zsock_fd (bowl);
     rc = zpoller_add (poller, (void *) &fd);
     assert (rc != -1);
     zstr_send (vent, "Hello again, world");

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1462,7 +1462,7 @@ zsock_test (bool verbose)
     zmsg_destroy (&msg);
 
     //  Test resolve FD
-    int fd = zsock_fd (reader);
+    SOCKET fd = zsock_fd (reader);
     assert (zsock_resolve ((void *) &fd) == NULL);
 
     //  Test binding to ephemeral ports, sequential and random


### PR DESCRIPTION
Solution: fix this in two places in test cases.

Fixes #899