### PR TITLE
Fixed zsys_file_mode to return int

### DIFF
--- a/doc/zdir.doc
+++ b/doc/zdir.doc
@@ -10,7 +10,7 @@ This is the class interface:
 
     //  Create a new directory item that loads in the full tree of the specified
     //  path, optionally located under some parent path. If parent is "-", then
-    //  loads only the top-level directory (and does not use parent as a path).
+    //  loads only the top-level directory, and does not use parent as a path.
     CZMQ_EXPORT zdir_t *
         zdir_new (const char *path, const char *parent);
     

--- a/doc/zdir.txt
+++ b/doc/zdir.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 ----
 //  Create a new directory item that loads in the full tree of the specified
 //  path, optionally located under some parent path. If parent is "-", then
-//  loads only the top-level directory (and does not use parent as a path).
+//  loads only the top-level directory, and does not use parent as a path.
 CZMQ_EXPORT zdir_t *
     zdir_new (const char *path, const char *parent);
 

--- a/doc/zhashx.doc
+++ b/doc/zhashx.doc
@@ -76,6 +76,12 @@ This is the class interface:
     //  key_destructor as destructor for the list.
     CZMQ_EXPORT zlistx_t *
         zhashx_keys (zhashx_t *self);
+    
+    //  Return a zlistx_t containing the values for the items in the
+    //  table. Uses the duplicator to duplicate all items and sets the
+    //  destructor as destructor for the list.
+    CZMQ_EXPORT zlistx_t *
+        zhashx_values (zhashx_t *self);
         
     //  Simple iterator; returns first item in hash table, in no given order,
     //  or NULL if the table is empty. This method is simpler to use than the
@@ -292,6 +298,10 @@ This is the class self test code:
     zlistx_t *keys = zhashx_keys (hash);
     assert (zlistx_size (keys) == 4);
     zlistx_destroy (&keys);
+    
+    zlistx_t *values = zhashx_values(hash);
+    assert (zlistx_size (values) == 4);
+    zlistx_destroy (&values);
     
     //  Test dup method
     zhashx_t *copy = zhashx_dup (hash);

--- a/doc/zhashx.txt
+++ b/doc/zhashx.txt
@@ -73,6 +73,12 @@ CZMQ_EXPORT size_t
 //  key_destructor as destructor for the list.
 CZMQ_EXPORT zlistx_t *
     zhashx_keys (zhashx_t *self);
+
+//  Return a zlistx_t containing the values for the items in the
+//  table. Uses the duplicator to duplicate all items and sets the
+//  destructor as destructor for the list.
+CZMQ_EXPORT zlistx_t *
+    zhashx_values (zhashx_t *self);
     
 //  Simple iterator; returns first item in hash table, in no given order,
 //  or NULL if the table is empty. This method is simpler to use than the
@@ -304,6 +310,10 @@ assert (streq (item, "a bad cafe"));
 zlistx_t *keys = zhashx_keys (hash);
 assert (zlistx_size (keys) == 4);
 zlistx_destroy (&keys);
+
+zlistx_t *values = zhashx_values(hash);
+assert (zlistx_size (values) == 4);
+zlistx_destroy (&values);
 
 //  Test dup method
 zhashx_t *copy = zhashx_dup (hash);

--- a/doc/zpoller.doc
+++ b/doc/zpoller.doc
@@ -96,7 +96,7 @@ This is the class self test code:
     //  Check we can poll an FD
     rc = zsock_connect (bowl, "tcp://127.0.0.1:%d", port_nbr);
     assert (rc != -1);
-    int fd = zsock_fd (bowl);
+    SOCKET fd = zsock_fd (bowl);
     rc = zpoller_add (poller, (void *) &fd);
     assert (rc != -1);
     zstr_send (vent, "Hello again, world");

--- a/doc/zpoller.txt
+++ b/doc/zpoller.txt
@@ -108,7 +108,7 @@ assert (rc == 0);
 //  Check we can poll an FD
 rc = zsock_connect (bowl, "tcp://127.0.0.1:%d", port_nbr);
 assert (rc != -1);
-int fd = zsock_fd (bowl);
+SOCKET fd = zsock_fd (bowl);
 rc = zpoller_add (poller, (void *) &fd);
 assert (rc != -1);
 zstr_send (vent, "Hello again, world");

--- a/doc/zsock.doc
+++ b/doc/zsock.doc
@@ -348,7 +348,7 @@ This is the class self test code:
     zmsg_destroy (&msg);
     
     //  Test resolve FD
-    int fd = zsock_fd (reader);
+    SOCKET fd = zsock_fd (reader);
     assert (zsock_resolve ((void *) &fd) == NULL);
     
     //  Test binding to ephemeral ports, sequential and random

--- a/doc/zsock.txt
+++ b/doc/zsock.txt
@@ -360,7 +360,7 @@ free (string);
 zmsg_destroy (&msg);
 
 //  Test resolve FD
-int fd = zsock_fd (reader);
+SOCKET fd = zsock_fd (reader);
 assert (zsock_resolve ((void *) &fd) == NULL);
 
 //  Test binding to ephemeral ports, sequential and random

--- a/doc/zsys.doc
+++ b/doc/zsys.doc
@@ -83,7 +83,8 @@ This is the class interface:
     
     //  Return file mode; provides at least support for the POSIX S_ISREG(m)
     //  and S_ISDIR(m) macros and the S_IRUSR and S_IWUSR bits, on all boxes.
-    CZMQ_EXPORT mode_t
+    //  Returns a mode_t cast to int, or -1 in case of error.
+    CZMQ_EXPORT int
         zsys_file_mode (const char *filename);
     
     //  Delete file. Does not complain if the file is absent
@@ -369,7 +370,7 @@ This is the class self test code:
     time_t when = zsys_file_modified (".");
     assert (when > 0);
     
-    mode_t mode = zsys_file_mode (".");
+    int mode = zsys_file_mode (".");
     assert (S_ISDIR (mode));
     assert (mode & S_IRUSR);
     assert (mode & S_IWUSR);

--- a/doc/zsys.txt
+++ b/doc/zsys.txt
@@ -84,7 +84,8 @@ CZMQ_EXPORT time_t
 
 //  Return file mode; provides at least support for the POSIX S_ISREG(m)
 //  and S_ISDIR(m) macros and the S_IRUSR and S_IWUSR bits, on all boxes.
-CZMQ_EXPORT mode_t
+//  Returns a mode_t cast to int, or -1 in case of error.
+CZMQ_EXPORT int
     zsys_file_mode (const char *filename);
 
 //  Delete file. Does not complain if the file is absent
@@ -381,7 +382,7 @@ assert (rc == -1);
 time_t when = zsys_file_modified (".");
 assert (when > 0);
 
-mode_t mode = zsys_file_mode (".");
+int mode = zsys_file_mode (".");
 assert (S_ISDIR (mode));
 assert (mode & S_IRUSR);
 assert (mode & S_IWUSR);

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -450,7 +450,8 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
     typedef unsigned __int16 uint16_t;
     typedef unsigned __int32 uint32_t;
     typedef unsigned __int64 uint64_t;
-#   endif    
+#   endif
+    typedef uint32_t in_addr_t;
 #   if (!defined (PRId8))
 #       define PRId8    "d"
 #   endif

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -95,7 +95,8 @@ CZMQ_EXPORT time_t
 
 //  Return file mode; provides at least support for the POSIX S_ISREG(m)
 //  and S_ISDIR(m) macros and the S_IRUSR and S_IWUSR bits, on all boxes.
-CZMQ_EXPORT mode_t
+//  Returns a mode_t cast to int, or -1 in case of error.
+CZMQ_EXPORT int
     zsys_file_mode (const char *filename);
 
 //  Delete file. Does not complain if the file is absent

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -31,10 +31,6 @@
 //  Constants
 #define INTERVAL_DFLT  1000         //  Default interval = 1 second
 
-#if (defined (__WINDOWS__))
-#define in_addr_t uint32_t
-#endif
-
 //  --------------------------------------------------------------------------
 //  The self_t structure holds the state for one actor instance
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -499,7 +499,7 @@ bool
 zsys_file_exists (const char *filename)
 {
     assert (filename);
-    return zsys_file_mode (filename) != (mode_t) -1;
+    return zsys_file_mode (filename) != -1;
 }
 
 
@@ -537,8 +537,9 @@ zsys_file_modified (const char *filename)
 //  --------------------------------------------------------------------------
 //  Return file mode; provides at least support for the POSIX S_ISREG(m)
 //  and S_ISDIR(m) macros and the S_IRUSR and S_IWUSR bits, on all boxes.
+//  Returns a mode_t cast to int, or -1 in case of error.
 
-mode_t
+int
 zsys_file_mode (const char *filename)
 {
 #if (defined (__WINDOWS__))
@@ -624,8 +625,8 @@ zsys_dir_create (const char *pathname, ...)
     while (true) {
         if (slash)
             *slash = 0;         //  Cut at slash
-        mode_t mode = zsys_file_mode (formatted);
-        if (mode == (mode_t) -1) {
+        int mode = zsys_file_mode (formatted);
+        if (mode == -1) {
             //  Does not exist, try to create it
 #if (defined (__WINDOWS__))
             if (!CreateDirectoryA (formatted, NULL)) {
@@ -1594,7 +1595,7 @@ zsys_test (bool verbose)
     time_t when = zsys_file_modified (".");
     assert (when > 0);
 
-    mode_t mode = zsys_file_mode (".");
+    int mode = zsys_file_mode (".");
     assert (S_ISDIR (mode));
     assert (mode & S_IRUSR);
     assert (mode & S_IWUSR);


### PR DESCRIPTION
Since mode_t is unsigned on at least OS/X and probably other platforms too.

Also some cosmetic changes and man page rebuilds.