### PR TITLE
Problem: zloop crashes if ticket handler deletes own ticket

### DIFF
--- a/include/zloop.h
+++ b/include/zloop.h
@@ -101,7 +101,9 @@ CZMQ_EXPORT void *
 CZMQ_EXPORT void
     zloop_ticket_reset (zloop_t *self, void *handle);
     
-//  Delete a ticket timer.
+//  Delete a ticket timer. We do not actually delete the ticket here, as
+//  other code may still refer to the ticket. We mark as deleted, and remove
+//  later and safely.
 CZMQ_EXPORT void
     zloop_ticket_delete (zloop_t *self, void *handle);
 


### PR DESCRIPTION
This broke Hydra.

Solution: do not delete ticket in handler, but flag it and move to
end of ticket list, then delete after ticket handlers are all done.