### PR TITLE
Problem: compile error when compiling for iOS

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -299,10 +299,12 @@
      || (defined (_POSIX_VERSION)  && (_POSIX_VERSION  >= 199309L)))
 #       include <sched.h>
 #   endif
-#   if (defined (__UTYPE_OSX))
-#       include <crt_externs.h>         //  For _NSGetEnviron()
+#   if (defined (__UTYPE_OSX) || defined (__UTYPE_IOS))
 #       include <mach/clock.h>
 #       include <mach/mach.h>           //  For monotonic clocks
+#   endif
+#   if (defined (__UTYPE_OSX))
+#       include <crt_externs.h>         //  For _NSGetEnviron()
 #   endif
 #   if (defined (__UTYPE_ANDROID))
 #       include <android/log.h>

--- a/src/zclock.c
+++ b/src/zclock.c
@@ -102,7 +102,7 @@ zclock_time (void)
 int64_t
 zclock_mono (void)
 {
-#if defined (__UTYPE_OSX)
+#if (defined (__UTYPE_OSX) || defined (__UTYPE_IOS))
     clock_serv_t cclock;
     mach_timespec_t mts;
     host_get_clock_service (mach_host_self (), SYSTEM_CLOCK, &cclock);
@@ -140,7 +140,7 @@ zclock_mono (void)
 int64_t
 zclock_usecs (void)
 {
-#if defined (__UTYPE_OSX)
+#if (defined (__UTYPE_OSX) || defined (__UTYPE_IOS))
     clock_serv_t cclock;
     mach_timespec_t mts;
     host_get_clock_service (mach_host_self (), SYSTEM_CLOCK, &cclock);


### PR DESCRIPTION
`clock_gettime` is `clock_get_time` on iOS and OS X. The conditional
compilation was only handling OS X.