### PR TITLE
Problem: there isn't an option to build library without makecert add-on program

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,9 @@ PKG_PROG_PKG_CONFIG
 
 # Check for makecert intent
 AC_ARG_WITH([makecert],
-    AS_HELP_STRING([--with-makecert], 
-        [Include the program makecert in compilation and installation.]),
-    [with_makecert=$withval],
+    AS_HELP_STRING([--without-makecert],
+        [Exclude the program makecert from compilation and installation.]),
+    [with_makecert=no],
     [with_makecert=yes])
 
 AM_CONDITIONAL([WITH_MAKECERT], [test x$with_makecert != xno])


### PR DESCRIPTION
When building this library building also the makecert add-on program is the default, and an option to turn this off isn't there yet. The option to _do_ build is present (--with-makecert) but isn't necessary, as it's the default behaviour.

Change inverts this options' semantics and renames it to --without-makecert, which resolves the problem.

(This is the next iteration at zeromq/czmq#913.)
