### PR TITLE
Correct makecert with argument for consistency.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,9 @@ PKG_PROG_PKG_CONFIG
 
 # Check for makecert intent
 AC_ARG_WITH([makecert],
-    AS_HELP_STRING([--without-makecert],
-        [Exclude the program makecert from compilation and installation.]),
-    [with_makecert=no],
+    AS_HELP_STRING([--with-makecert],
+        [Include the program makecert for compilation and installation [default=yes].]),
+    [with_makecert=$withval],
     [with_makecert=yes])
 
 AM_CONDITIONAL([WITH_MAKECERT], [test x$with_makecert != xno])


### PR DESCRIPTION
In response to PR #916 which results in an inconsistency in behavior and documentation as seen by `./configure --help`

The output of which now includes:

```
Optional Packages:
  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
  --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
                          both]
  --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
  --with-sysroot=DIR Search for dependent libraries within DIR
                        (or the compiler's sysroot if not specified).
  --with-makecert         Include the program makecert for compilation and
                          installation [default=yes].
  --with-gcov=yes/no      With GCC Code Coverage reporting.
  --with-pkgconfigdir=PATH
                          Path to the pkgconfig directory [[LIBDIR/pkgconfig]]
```

The above consistently declares options `--with-PACKAGE` and relies on the `--without-PACKAGE` summary to communicate that option.  This also restores the `$withval` usage which allows for the equivalence of `--with-makecert=no` and `--without-makecert`.

The descriptive text has been modified to declare the default, which I believe was the key issue w.r.t. the previous change.