### PR TITLE
Fix broken autogen step

### DIFF
--- a/model/build-autoconf.gsl
+++ b/model/build-autoconf.gsl
@@ -70,11 +70,6 @@ src_lib$(project.name)_la_LDFLAGS += \\
     -avoid-version
 endif
 
-if ON_ANDROID
-src_libczmq_la_LIBADD += \\
-    -llog
-endif
-
 .if count(package_dependency, defined(package_dependency.for_lib) | defined (package_dependency.for_all)) > 0
 src_lib$(project.name)_la_LIBADD = \\
 .for package_dependency where defined (package_dependency.for_lib) | defined (package_dependency.for_all)
@@ -85,6 +80,11 @@ src_lib$(project.name)_la_LIBADD = \\
 .   endif
 .endfor
 .endif
+
+if ON_ANDROID
+src_lib$(project.name)_la_LIBADD += \\
+    -llog
+endif
 
 check_PROGRAMS += src/$(project.name)_selftest
 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -117,13 +117,13 @@ src_libczmq_la_LDFLAGS += \
     -avoid-version
 endif
 
+src_libczmq_la_LIBADD = \
+    ${zmq_LIBS}
+
 if ON_ANDROID
 src_libczmq_la_LIBADD += \
     -llog
 endif
-
-src_libczmq_la_LIBADD = \
-    ${zmq_LIBS}
 
 check_PROGRAMS += src/czmq_selftest
 


### PR DESCRIPTION
CZMQ is broken currently because the autogen.sh step fails. This is related to the previous commit that made an Android focused change. This change resolves the issue for a standard Linux build by placing the ``+=`` item after the ``=`` item as append can only be used after then item has been declared. I've also substitued the hardcoded project name for the project name from the `project.xml`` file for consistency with the rest of the file. 

With this change I can now build czmq normally.

NOTE: I have not tested this for Android.