### PR TITLE
Problem: Templates outputs have been manually edited.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 #######################################################################
 # Do we build and register self tests ?
 ######################################################################
-set(CZMQ_BUILD_TESTS   true   CACHE BOOL "build czmq selftest")
+set(CZMQ_BUILD_TESTS true CACHE BOOL "build czmq selftest")
 
 ########################################################################
 # determine version
@@ -216,9 +216,9 @@ install(
 # tests
 ########################################################################
 if (CZMQ_BUILD_TESTS)
-  add_executable(czmq_selftest ${SOURCE_DIR}/src/czmq_selftest.c)
-  target_link_libraries(czmq_selftest czmq ${ZEROMQ_LIBRARIES})
-  add_test(czmq_selftest czmq_selftest)
+    add_executable(czmq_selftest ${SOURCE_DIR}/src/czmq_selftest.c)
+    target_link_libraries(czmq_selftest czmq ${ZEROMQ_LIBRARIES})
+    add_test(czmq_selftest czmq_selftest)
 endif()
 
 ########################################################################

--- a/model/build-autoconf.gsl
+++ b/model/build-autoconf.gsl
@@ -64,12 +64,6 @@ src_lib$(project.name)_la_LDFLAGS += \\
     -avoid-version
 endif
 
-if ON_CYGWIN
-src_lib$(project.name)_la_LDFLAGS += \\
-    -no-undefined \\
-    -avoid-version
-endif
-
 .if count(package_dependency, defined(package_dependency.for_lib) | defined (package_dependency.for_all)) > 0
 src_lib$(project.name)_la_LIBADD = \\
 .for package_dependency where defined (package_dependency.for_lib) | defined (package_dependency.for_all)
@@ -80,6 +74,11 @@ src_lib$(project.name)_la_LIBADD = \\
 .   endif
 .endfor
 .endif
+
+if ON_ANDROID
+src_lib$(project.name)_la_LIBADD += \\
+    -llog
+endif
 
 check_PROGRAMS += src/$(project.name)_selftest
 
@@ -110,14 +109,14 @@ TESTS = src/$(project.name)_selftest
 
 # Run the selftest binary under valgrind to check for memory leaks
 memcheck: src/$(project.name)_selftest
-	libtool --mode=execute valgrind --tool=memcheck \\
+	$\(LIBTOOL) --mode=execute valgrind --tool=memcheck \\
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \\
 		--suppressions=$\(srcdir)/src/.valgrind.supp \\
 		$\(srcdir)/src/$(project.name)_selftest
 
 # Run the selftest binary under gdb for debugging
 debug: src/$(project.name)_selftest
-	libtool --mode=execute gdb -q \\
+	$\(LIBTOOL) --mode=execute gdb -q \\
 		$\(srcdir)/src/$(project.name)_selftest
 .for model
 .   if first ()
@@ -151,7 +150,7 @@ code:
 .endfor
 MAN1 =
 MAN3 =$(manpages)
-MAN7 = $\(srcdir)/$(project.manpage)
+MAN7 = $(project.manpage)
 MAN_DOC = $\(MAN1) $\(MAN3) $\(MAN7)
 
 MAN_TXT = $\(MAN1:%.1=%.txt)

--- a/model/build-cmake.gsl
+++ b/model/build-cmake.gsl
@@ -22,6 +22,11 @@ enable_testing()
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+#######################################################################
+# Do we build and register self tests ?
+######################################################################
+set($(PROJECT.NAME)_BUILD_TESTS true CACHE BOOL "build $(project.name) selftest")
+
 ########################################################################
 # determine version
 ########################################################################
@@ -75,11 +80,6 @@ endif()
 # required libraries for mingw
 if (MINGW)
     set(MORE_LIBRARIES -lws2_32 -lrpcrt4 -liphlpapi)
-endif()
-
-# required libraries for cygwin
-if (CYGWIN)
-    set(MORE_LIBRARIES -luuid)
 endif()
 
 ########################################################################
@@ -153,9 +153,11 @@ install(
 ########################################################################
 # tests
 ########################################################################
-add_executable($(project.name)_selftest ${SOURCE_DIR}/src/$(project.name)_selftest.c)
-target_link_libraries($(project.name)_selftest $(project.name) ${ZEROMQ_LIBRARIES})
-add_test($(project.name)_selftest $(project.name)_selftest)
+if ($(PROJECT.NAME)_BUILD_TESTS)
+    add_executable($(project.name)_selftest ${SOURCE_DIR}/src/$(project.name)_selftest.c)
+    target_link_libraries($(project.name)_selftest $(project.name) ${ZEROMQ_LIBRARIES})
+    add_test($(project.name)_selftest $(project.name)_selftest)
+endif()
 
 ########################################################################
 # summary


### PR DESCRIPTION
This retrofits all manual edits back to the templates under the assumption that the outputs are authoritative, since the outputs are what have been built to date.

It's possible that there were template changes that were not applied to outputs and are now removed. It's hard to tell, and safer to have the templates generate the current outputs.