### PR TITLE
can't shut down an actor system in a controlled way after interupt

### DIFF
--- a/include/zloop.h
+++ b/include/zloop.h
@@ -95,12 +95,12 @@ CZMQ_EXPORT int
 //  zloop_ticket_reset and zloop_ticket_delete.
 CZMQ_EXPORT void *
     zloop_ticket (zloop_t *self, zloop_timer_fn handler, void *arg);
-    
+
 //  Reset a ticket timer, which moves it to the end of the ticket list and
 //  resets its execution time. This is a very fast operation.
 CZMQ_EXPORT void
     zloop_ticket_reset (zloop_t *self, void *handle);
-    
+
 //  Delete a ticket timer. We do not actually delete the ticket here, as
 //  other code may still refer to the ticket. We mark as deleted, and remove
 //  later and safely.
@@ -130,6 +130,13 @@ CZMQ_EXPORT void
 //  cancel sockets. Returns 0 if interrupted, -1 if cancelled by a handler.
 CZMQ_EXPORT int
     zloop_start (zloop_t *self);
+
+//  Ignore zsys_interrupted flag in this loop. By default, a zloop_start will
+//  exit as soon as it detects zsys_interrupted is set to something other than
+//  zero. Calling zloop_ignore_interrupts will supress this behavior.
+
+CZMQ_EXPORT void
+    zloop_ignore_interrupts(zloop_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT void

--- a/include/zpoller.h
+++ b/include/zpoller.h
@@ -61,6 +61,13 @@ CZMQ_EXPORT bool
 CZMQ_EXPORT bool
     zpoller_terminated (zpoller_t *self);
 
+//  Ignore zsys_interrupted flag in this poller. By default, a zpoller_wait will
+//  return immediately if detects zsys_interrupted is set to something other than
+//  zero. Calling zpoller_ignore_interrupts will supress this behavior.
+
+CZMQ_EXPORT void
+    zpoller_ignore_interrupts(zpoller_t *self);
+
 //  Self test of this class
 CZMQ_EXPORT void
     zpoller_test (bool verbose);

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -45,6 +45,7 @@ struct _zloop_t {
     bool need_rebuild;          //  True if pollset needs rebuilding
     bool verbose;               //  True if verbose tracing wanted
     bool terminated;            //  True when stopped running
+    bool ignore_interrupts;     //  True when this loop should ingnore intterupts
     zlistx_t *zombies;          //  List of timers to kill
 };
 
@@ -695,6 +696,18 @@ zloop_set_verbose (zloop_t *self, bool verbose)
     self->verbose = verbose;
 }
 
+//  --------------------------------------------------------------------------
+//  Ignore zsys_interrupted flag in this loop. By default, a zloop_start will
+//  exit as soon as it detects zsys_interrupted is set to something other than
+//  zero. Calling zloop_ignore_interrupts will supress this behavior.
+
+void
+zloop_ignore_interrupts(zloop_t *self)
+{
+    assert (self);
+    self->ignore_interrupts = true;
+}
+
 
 //  --------------------------------------------------------------------------
 //  Set hard limit on number of timers allowed. Setting more than a small
@@ -725,7 +738,7 @@ zloop_start (zloop_t *self)
     int rc = 0;
 
     //  Main reactor loop
-    while (!zsys_interrupted) {
+    while (self->ignore_interrupts || !zsys_interrupted) {
         if (self->need_rebuild) {
             //  If s_rebuild_pollset() fails, break out of the loop and
             //  return its error
@@ -734,13 +747,13 @@ zloop_start (zloop_t *self)
                 break;
         }
         rc = zmq_poll (self->pollset, (int) self->poll_size, s_tickless (self));
-        if (rc == -1 || zsys_interrupted) {
+        if (rc == -1 || (!self->ignore_interrupts && zsys_interrupted)) {
             if (self->verbose)
                 zsys_debug ("zloop: interrupted");
             rc = 0;
             break;              //  Context has been shut down
         }
-        
+
         //  Handle any timers that have now expired
         int64_t time_now = zclock_mono ();
         s_timer_t *timer = (s_timer_t *) zlistx_first (self->timers);
@@ -758,7 +771,7 @@ zloop_start (zloop_t *self)
             }
             timer = (s_timer_t *) zlistx_next (self->timers);
         }
-        
+
         //  Handle any tickets that have now expired
         s_ticket_t *ticket = (s_ticket_t *) zlistx_first (self->tickets);
         while (ticket && time_now >= ticket->when) {
@@ -769,14 +782,14 @@ zloop_start (zloop_t *self)
             zlistx_delete (self->tickets, ticket->list_handle);
             ticket = (s_ticket_t *) zlistx_next (self->tickets);
         }
-        
+
         //  Handle any tickets that were flagged for deletion
         ticket = (s_ticket_t *) zlistx_last (self->tickets);
         while (ticket && ticket->deleted) {
             zlistx_delete (self->tickets, ticket->list_handle);
             ticket = (s_ticket_t *) zlistx_last (self->tickets);
         }
-        
+
         //  Handle any readers and pollers that are ready
         size_t item_nbr;
         for (item_nbr = 0; item_nbr < self->poll_size && rc >= 0; item_nbr++) {
@@ -868,6 +881,7 @@ s_cancel_timer_event (zloop_t *loop, int timer_id, void *arg)
     return zloop_timer_end (loop, cancel_timer_id);
 }
 
+
 static int
 s_timer_event (zloop_t *loop, int timer_id, void *output)
 {
@@ -879,6 +893,14 @@ static int
 s_socket_event (zloop_t *loop, zsock_t *handle, void *arg)
 {
     //  Just end the reactor
+    return -1;
+}
+
+static int
+s_timer_event3 (zloop_t *loop, int timer_id, void *called)
+{
+    *((bool*) called) = true;
+    //  end the reactor
     return -1;
 }
 
@@ -924,6 +946,26 @@ zloop_test (bool verbose)
     zloop_ticket_delete (loop, ticket2);
     zloop_ticket_delete (loop, ticket3);
 
+    //  Check whether loop properly ignores zsys_interrupted flag
+    //  when asked to
+    zloop_destroy (&loop);
+    loop = zloop_new ();
+
+    bool timer_event_called = false;
+    zloop_timer (loop, 1, 1, s_timer_event3, &timer_event_called);
+
+    zsys_interrupted = 1;
+    zloop_start (loop);
+    //  zloop returns immediately without giving any handler a chance to run
+    assert (!timer_event_called);
+
+    zloop_ignore_interrupts (loop);
+    zloop_start (loop);
+    //  zloop runs the handler which will terminate the loop
+    assert (timer_event_called);
+    zsys_interrupted = 0;
+
+    //  cleanup
     zloop_destroy (&loop);
     assert (loop == NULL);
 

--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -32,6 +32,7 @@ struct _zpoller_t {
     bool need_rebuild;          //  Does pollset needs rebuilding?
     bool expired;               //  Did poll timer expire?
     bool terminated;            //  Did poll call end with EINTR?
+    bool ignore_interrupts;     //  Should this poller ignore zsys_interrupted?
 };
 
 static int s_rebuild_poll_set (zpoller_t *self);
@@ -133,13 +134,13 @@ void *
 zpoller_wait (zpoller_t *self, int timeout)
 {
     self->expired = false;
-    if (zsys_interrupted) {
+    if (!self->ignore_interrupts && zsys_interrupted) {
         self->terminated = true;
         return NULL;
     }
     else
         self->terminated = false;
-    
+
     if (self->need_rebuild)
         s_rebuild_poll_set (self);
     int rc = zmq_poll (self->poll_set, (int) self->poll_size,
@@ -151,7 +152,7 @@ zpoller_wait (zpoller_t *self, int timeout)
                 return self->poll_readers [reader];
     }
     else
-    if (rc == -1 || zsys_interrupted)
+    if (rc == -1 || (!self->ignore_interrupts && zsys_interrupted))
         self->terminated = true;
     else
     if (rc == 0)
@@ -224,6 +225,17 @@ zpoller_terminated (zpoller_t *self)
     return self->terminated;
 }
 
+//  --------------------------------------------------------------------------
+//  Ignore zsys_interrupted flag in this poller. By default, a zpoller_wait will
+//  return immediately if detects zsys_interrupted is set to something other than
+//  zero. Calling zpoller_ignore_interrupts will supress this behavior.
+
+void
+zpoller_ignore_interrupts(zpoller_t *self)
+{
+    assert (self);
+    self->ignore_interrupts = true;
+}
 
 //  --------------------------------------------------------------------------
 //  Self test of this class
@@ -279,6 +291,16 @@ zpoller_test (bool verbose)
     assert (rc != -1);
     zstr_send (vent, "Hello again, world");
     assert (zpoller_wait (poller, 500) == &fd);
+
+    // Check whether poller properly ignores zsys_interrupted flag
+    // when asked to
+    zsys_interrupted = 1;
+    zpoller_wait (poller, 0);
+    assert (zpoller_terminated (poller));
+    zpoller_ignore_interrupts (poller);
+    zpoller_wait (poller, 0);
+    assert (!zpoller_terminated (poller));
+    zsys_interrupted = 0;
 
     //  Destroy poller and sockets
     zpoller_destroy (&poller);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -710,12 +710,10 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
     if (!msg)
         return -1;              //  Interrupted
 
-    //  Filter any signal that may come from dying actors
-    while (zmsg_signal (msg) >= 0) {
+    //  Filter a signal that may come from a dying actor
+    if (zmsg_signal (msg) >= 0) {
         zmsg_destroy (&msg);
-        if (zsys_interrupted)
-            return -1;
-        msg = zmsg_recv (self);
+        return -1;
     }
     //  Now parse message according to picture argument
     int rc = 0;

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -196,12 +196,10 @@ zstr_recvx (void *source, char **string_p, ...)
     if (!msg)
         return -1;
 
-    //  Filter any signal that may come from dying actors
-    while (zmsg_signal (msg) >= 0) {
+    //  Filter a signal that may come from a dying actor
+    if (zmsg_signal (msg) >= 0) {
         zmsg_destroy (&msg);
-        if (zsys_interrupted)
-            return -1;
-        msg = zmsg_recv (handle);
+        return -1;
     }
     int count = 0;
     va_list args;


### PR DESCRIPTION
After receiving an interrupt, all zloops and zpollers are put into a
state where they refuse to start/continue running. Unfortunately, this
makes it impossible to terminate a system of zactors in a controlled
order.

As an example, assume there is one actor used to linearize and format
output of all other actors. We definitely want to shut down this actor
after all others, so that we are able to log all events which occur
during systen shutdown. This doesn't work at the moment when the using
the default signal handling approach.

The patch adds two methods which can be used to make zloops and
zpollers ignore the zsys_interrupted global.

   void zloop_ignore_interrupts(zloop_t *self);
   void zpoller_ignore_interrupts(zpoller_t *self);

Note that there were two additional places in the code base which take the
global zsys_interrupted into account and had to be changed to always
ignore zsys_interrupted. This code was vulnerable to race conditions
when setting zsys_interrupted and could lead to programs which would
not be interruptible.