### PR TITLE
Fix sha1 on bigendian machines.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,7 @@ AC_TYPE_SSIZE_T
 AC_HEADER_TIME
 AC_TYPE_UINT32_T
 AC_C_VOLATILE
+AC_C_BIGENDIAN
 
 # These options are GNU compiler specific.
 if test "x$GCC" = "xyes"; then

--- a/src/zdigest.c
+++ b/src/zdigest.c
@@ -23,6 +23,7 @@
 @end
 */
 
+#include "platform.h"
 #include "../include/czmq.h"
 #include "../foreign/sha1/sha1.c"
 


### PR DESCRIPTION
Hello, I have stumbled upon failing zdigest test on bigendian machines in fedora.

http://s390.koji.fedoraproject.org/koji/buildinfo?buildID=303454
http://ppc.koji.fedoraproject.org/koji/buildinfo?buildID=296552

Code in sha1.c seems bigendian compatible, but endianess is not checked in configure. So I have added check in configure.ac. To use result of endianity check, platform.h is included in zdigest.c.

I have tested it on s390x, powerpc64(le), x86, aarch64, arm( build/tests pass) , but it still fails on s390(31bit)..., still looking in to it.

