### PR TITLE
Problem: No way to run verbose tests via make

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -14,7 +14,7 @@ if [ $BUILD_TYPE == "default" ]; then
         make check && sudo make install && sudo ldconfig ) || exit 1
 
     # Build, check, and install CZMQ from local source
-    ./autogen.sh && ./configure && make check && sudo make install
+    ./autogen.sh && ./configure && make check-verbose VERBOSE=1 && sudo make install
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi

--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -5,5 +5,11 @@ if ON_ANDROID
 src_libczmq_la_LIBADD += -llog
 endif
 
+check-local: src/czmq_selftest
+	src/czmq_selftest
+
+check-verbose: src/czmq_selftest
+	src/czmq_selftest -v
+
 check-py:
 	$(LIBTOOL) --mode=execute -dlopen src/.libs/libczmq.la python bindings/python/test.py

--- a/src/zgossip_msg.c
+++ b/src/zgossip_msg.c
@@ -597,13 +597,22 @@ zgossip_msg_test (bool verbose)
 {
     printf (" * zgossip_msg: ");
 
+    if (verbose)
+        printf("\n");
+
     //  @selftest
     //  Simple create/destroy test
+    if (verbose)
+        printf("create-destroy\n");
+
     zgossip_msg_t *self = zgossip_msg_new ();
     assert (self);
     zgossip_msg_destroy (&self);
 
     //  Create pair of sockets we can send through
+    if (verbose)
+        printf("socket-create\n");
+
     zsock_t *input = zsock_new (ZMQ_ROUTER);
     assert (input);
     zsock_connect (input, "inproc://selftest-zgossip_msg");
@@ -613,6 +622,9 @@ zgossip_msg_test (bool verbose)
     zsock_bind (output, "inproc://selftest-zgossip_msg");
 
     //  Encode/send/decode and verify each message type
+    if (verbose)
+        printf("encode-decode-twice 1\n");
+
     int instance;
     self = zgossip_msg_new ();
     zgossip_msg_set_id (self, ZGOSSIP_MSG_HELLO);
@@ -625,6 +637,10 @@ zgossip_msg_test (bool verbose)
         zgossip_msg_recv (self, input);
         assert (zgossip_msg_routing_id (self));
     }
+
+    if (verbose)
+        printf("encode-decode-twice 2\n");
+
     zgossip_msg_set_id (self, ZGOSSIP_MSG_PUBLISH);
 
     zgossip_msg_set_key (self, "Life is short but Now lasts for ever");
@@ -641,6 +657,10 @@ zgossip_msg_test (bool verbose)
         assert (streq (zgossip_msg_value (self), "Life is short but Now lasts for ever"));
         assert (zgossip_msg_ttl (self) == 123);
     }
+
+    if (verbose)
+        printf("encode-decode-twice 3\n");
+
     zgossip_msg_set_id (self, ZGOSSIP_MSG_PING);
 
     //  Send twice
@@ -651,6 +671,10 @@ zgossip_msg_test (bool verbose)
         zgossip_msg_recv (self, input);
         assert (zgossip_msg_routing_id (self));
     }
+
+    if (verbose)
+        printf("encode-decode-twice 4\n");
+
     zgossip_msg_set_id (self, ZGOSSIP_MSG_PONG);
 
     //  Send twice
@@ -661,6 +685,10 @@ zgossip_msg_test (bool verbose)
         zgossip_msg_recv (self, input);
         assert (zgossip_msg_routing_id (self));
     }
+
+    if (verbose)
+        printf("encode-decode-twice 5\n");
+
     zgossip_msg_set_id (self, ZGOSSIP_MSG_INVALID);
 
     //  Send twice
@@ -671,6 +699,9 @@ zgossip_msg_test (bool verbose)
         zgossip_msg_recv (self, input);
         assert (zgossip_msg_routing_id (self));
     }
+
+    if (verbose)
+        printf("destroy\n");
 
     zgossip_msg_destroy (&self);
     zsock_destroy (&input);


### PR DESCRIPTION
Solution: Make check-verbose.

Rationalle: Newer versions of automake >= 1.13 force `make check` to be
run through a parallel test runner which turns off all output. So we
need a way to at least see the non-verbose output in that sort of
environment, hence check-local.

check-verbose comes about because when CI failures or hangs occur, there
is very little information to go on, so making it always dump as much
information as possible should hopefully help diagnose these issues in
future.