### PR TITLE
Problem: There is no easy way to check if two list items are equal

### DIFF
--- a/api/zlist.xml
+++ b/api/zlist.xml
@@ -10,6 +10,13 @@
         <return type = "boolean" />
     </callback_type>
 
+    <callback_type name = "equals_fn">
+        Equals function
+        <argument name = "item1" type = "anything" />
+        <argument name = "item2" type = "anything" />
+        <return type = "boolean" />
+    </callback_type>
+
     <callback_type name = "free_fn">
         Callback function for zlist_freefn method
         <argument name = "data" type = "anything" />
@@ -80,6 +87,14 @@
         <return type = "anything" />
     </method>
 
+    <method name = "exists">
+        Checks if an item already is present. Uses compare method to determine if 
+        items are equal. If the compare method is NULL the check will only compare 
+        pointers. Returns true if item is present else false.
+        <argument name = "item" type = "anything" />
+        <return type = "boolean" />
+    </method>
+
     <method name = "remove">
         Remove the specified item from the list if present
         <argument name = "item" type = "anything" />
@@ -116,6 +131,14 @@
         list values, you must free them explicitly before destroying the list.
         The usual technique is to pop list items and destroy them, until the
         list is empty.
+    </method>
+
+    <method name = "equalsfn">
+        Set an equals function for the list. This function is used for the
+        methods zlist_exists and zlist_remove. If there is more than one item
+        in the list that equals matchesi, only the first occurence will be
+        processed.  
+        <argument name = "fn" type = "zlist_equals_fn" callback = "1" />
     </method>
 
     <method name = "freefn">

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -2240,6 +2240,7 @@ Callback function for zhash_foreach method"""
 
 # zlist
 zlist_compare_fn = CFUNCTYPE(c_bool, c_void_p, c_void_p)
+zlist_equals_fn = CFUNCTYPE(c_bool, c_void_p, c_void_p)
 zlist_free_fn = CFUNCTYPE(None, c_void_p)
 lib.zlist_new.restype = zlist_p
 lib.zlist_new.argtypes = []
@@ -2263,6 +2264,8 @@ lib.zlist_push.restype = c_int
 lib.zlist_push.argtypes = [zlist_p, c_void_p]
 lib.zlist_pop.restype = c_void_p
 lib.zlist_pop.argtypes = [zlist_p]
+lib.zlist_exists.restype = c_bool
+lib.zlist_exists.argtypes = [zlist_p, c_void_p]
 lib.zlist_remove.restype = None
 lib.zlist_remove.argtypes = [zlist_p, c_void_p]
 lib.zlist_dup.restype = zlist_p
@@ -2275,6 +2278,8 @@ lib.zlist_sort.restype = None
 lib.zlist_sort.argtypes = [zlist_p, zlist_compare_fn]
 lib.zlist_autofree.restype = None
 lib.zlist_autofree.argtypes = [zlist_p]
+lib.zlist_equalsfn.restype = None
+lib.zlist_equalsfn.argtypes = [zlist_p, zlist_equals_fn]
 lib.zlist_freefn.restype = c_void_p
 lib.zlist_freefn.argtypes = [zlist_p, c_void_p, zlist_free_fn, c_bool]
 lib.zlist_test.restype = None
@@ -2353,6 +2358,12 @@ been set, this method will also duplicate the item."""
         """Pop the item off the start of the list, if any"""
         return c_void_p(lib.zlist_pop(self._as_parameter_))
 
+    def exists(self, item):
+        """Checks if an item already is present. Uses compare method to determine if 
+items are equal. If the compare method is NULL the check will only compare 
+pointers. Returns true if item is present else false."""
+        return lib.zlist_exists(self._as_parameter_, item)
+
     def remove(self, item):
         """Remove the specified item from the list if present"""
         return lib.zlist_remove(self._as_parameter_, item)
@@ -2386,6 +2397,13 @@ list values, you must free them explicitly before destroying the list.
 The usual technique is to pop list items and destroy them, until the
 list is empty."""
         return lib.zlist_autofree(self._as_parameter_)
+
+    def equalsfn(self, fn):
+        """Set an equals function for the list. This function is used for the
+methods zlist_exists and zlist_remove. If there is more than one item
+in the list that equals matchesi, only the first occurence will be
+processed."""
+        return lib.zlist_equalsfn(self._as_parameter_, fn)
 
     def freefn(self, item, fn, at_tail):
         """Set a free function for the specified list item. When the item is

--- a/bindings/qml/src/QmlZlist.cpp
+++ b/bindings/qml/src/QmlZlist.cpp
@@ -71,6 +71,14 @@ void *QmlZlist::pop () {
 };
 
 ///
+//  Checks if an item already is present. Uses compare method to determine if  
+//  items are equal. If the compare method is NULL the check will only compare 
+//  pointers. Returns true if item is present else false.                      
+bool QmlZlist::exists (void *item) {
+    return zlist_exists (self, item);
+};
+
+///
 //  Remove the specified item from the list if present
 void QmlZlist::remove (void *item) {
     zlist_remove (self, item);
@@ -116,6 +124,15 @@ void QmlZlist::sort (zlist_compare_fn compare) {
 //  list is empty.                                                        
 void QmlZlist::autofree () {
     zlist_autofree (self);
+};
+
+///
+//  Set an equals function for the list. This function is used for the   
+//  methods zlist_exists and zlist_remove. If there is more than one item
+//  in the list that equals matchesi, only the first occurence will be   
+//  processed.                                                           
+void QmlZlist::equalsfn (zlist_equals_fn fn) {
+    zlist_equalsfn (self, fn);
 };
 
 ///

--- a/bindings/qml/src/QmlZlist.h
+++ b/bindings/qml/src/QmlZlist.h
@@ -63,6 +63,11 @@ public slots:
     //  Pop the item off the start of the list, if any
     void *pop ();
 
+    //  Checks if an item already is present. Uses compare method to determine if  
+    //  items are equal. If the compare method is NULL the check will only compare 
+    //  pointers. Returns true if item is present else false.                      
+    bool exists (void *item);
+
     //  Remove the specified item from the list if present
     void remove (void *item);
 
@@ -90,6 +95,12 @@ public slots:
     //  The usual technique is to pop list items and destroy them, until the  
     //  list is empty.                                                        
     void autofree ();
+
+    //  Set an equals function for the list. This function is used for the   
+    //  methods zlist_exists and zlist_remove. If there is more than one item
+    //  in the list that equals matchesi, only the first occurence will be   
+    //  processed.                                                           
+    void equalsfn (zlist_equals_fn fn);
 
     //  Set a free function for the specified list item. When the item is     
     //  destroyed, the free function, if any, is called on that item.         

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -305,12 +305,14 @@ module CZMQ
       attach_function :zlist_append, [:pointer, :pointer], :int, **opts
       attach_function :zlist_push, [:pointer, :pointer], :int, **opts
       attach_function :zlist_pop, [:pointer], :pointer, **opts
+      attach_function :zlist_exists, [:pointer, :pointer], :bool, **opts
       attach_function :zlist_remove, [:pointer, :pointer], :void, **opts
       attach_function :zlist_dup, [:pointer], :pointer, **opts
       attach_function :zlist_purge, [:pointer], :void, **opts
       attach_function :zlist_size, [:pointer], :size_t, **opts
       attach_function :zlist_sort, [:pointer, :pointer], :void, **opts
       attach_function :zlist_autofree, [:pointer], :void, **opts
+      attach_function :zlist_equalsfn, [:pointer, :pointer], :void, **opts
       attach_function :zlist_freefn, [:pointer, :pointer, :pointer, :bool], :pointer, **opts
       attach_function :zlist_test, [:int], :void, **opts
       

--- a/include/zlist.h
+++ b/include/zlist.h
@@ -25,6 +25,10 @@ extern "C" {
 typedef bool (zlist_compare_fn) (
     void *item1, void *item2);
 
+// Equals function
+typedef bool (zlist_equals_fn) (
+    void *item1, void *item2);
+
 // Callback function for zlist_freefn method
 typedef void (zlist_free_fn) (
     void *data);
@@ -81,6 +85,12 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void *
     zlist_pop (zlist_t *self);
 
+//  Checks if an item already is present. Uses compare method to determine if  
+//  items are equal. If the compare method is NULL the check will only compare 
+//  pointers. Returns true if item is present else false.                      
+CZMQ_EXPORT bool
+    zlist_exists (zlist_t *self, void *item);
+
 //  Remove the specified item from the list if present
 CZMQ_EXPORT void
     zlist_remove (zlist_t *self, void *item);
@@ -115,6 +125,13 @@ CZMQ_EXPORT void
 //  list is empty.                                                        
 CZMQ_EXPORT void
     zlist_autofree (zlist_t *self);
+
+//  Set an equals function for the list. This function is used for the   
+//  methods zlist_exists and zlist_remove. If there is more than one item
+//  in the list that equals matchesi, only the first occurence will be   
+//  processed.                                                           
+CZMQ_EXPORT void
+    zlist_equalsfn (zlist_t *self, zlist_equals_fn fn);
 
 //  Set a free function for the specified list item. When the item is     
 //  destroyed, the free function, if any, is called on that item.         


### PR DESCRIPTION
Solution: Introduce an equals function to the list which can be used by _exists and _remove methods.

I didn't choose the compare method for this problem as it doesn't work for equality. Of course I could have fix the compare method to work like strcmp for example but this would have broken user space.