### PR TITLE
fix for failing test.py #998

### DIFF
--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -892,7 +892,7 @@ class TestCZMQ(unittest.TestCase):
         self.assertEquals(number4.value, 123 * 123 * 123)
         self.assertEquals(number8.value, 123 * 123 * 123 * 123)
         self.assertEquals(string_at(string), "This is a string")
-        self.assertEquals(string_at(data), "ABCDE")
+        self.assertEquals(string_at(data, size.value), "ABCDE")
         self.assertEquals(size.value, 5)
         #self.assertEquals(memcmp (chunk.data(), "HELLO", 5), 0)
         #self.assertEquals(chunk.size(), 5)


### PR DESCRIPTION
From https://docs.python.org/2/library/ctypes.html:
The string_at method expects a NULL terminated string if it isn't supplied with the size of address space.

This fix uses the size of the message for the string_at method. It fixes the failing unittest.
Tested on 32bit debian jessie. 