### PR TITLE
Problem: creating UUID from existing data is inefficient

### DIFF
--- a/include/zuuid.h
+++ b/include/zuuid.h
@@ -30,9 +30,22 @@ CZMQ_EXPORT zuuid_t *
 CZMQ_EXPORT void
     zuuid_destroy (zuuid_t **self_p);
 
+//  Create UUID object from supplied ZUUID_LEN-octet value
+CZMQ_EXPORT zuuid_t *
+    zuuid_new_from (byte *source);
+
 //  Return UUID binary data
 CZMQ_EXPORT byte *
     zuuid_data (zuuid_t *self);
+
+//  Set UUID to new supplied ZUUID_LEN-octet value
+CZMQ_EXPORT void
+    zuuid_set (zuuid_t *self, byte *source);
+
+//  Set UUID to new supplied string value skipping '-' and '{' '}'
+//  optional delimiters. Return 0 if OK, else returns -1.
+CZMQ_EXPORT int
+    zuuid_set_str (zuuid_t *self, const char *source);
 
 //  Return UUID binary size
 CZMQ_EXPORT size_t
@@ -47,15 +60,6 @@ CZMQ_EXPORT const char *
 //  http://en.wikipedia.org/wiki/Universally_unique_identifier
 CZMQ_EXPORT const char *
     zuuid_str_canonical (zuuid_t *self);
-
-//  Set UUID to new supplied ZUUID_LEN-octet value
-CZMQ_EXPORT void
-    zuuid_set (zuuid_t *self, byte *source);
-    
-//  Set UUID to new supplied string value skipping '-' and '{' '}'
-//  optional delimiters. Return 0 if OK, else returns -1.
-CZMQ_EXPORT int
-    zuuid_set_str (zuuid_t *self, const char *source);
 
 //  Store UUID blob in target array
 CZMQ_EXPORT void

--- a/include/zuuid.h
+++ b/include/zuuid.h
@@ -32,20 +32,20 @@ CZMQ_EXPORT void
 
 //  Create UUID object from supplied ZUUID_LEN-octet value
 CZMQ_EXPORT zuuid_t *
-    zuuid_new_from (byte *source);
-
-//  Return UUID binary data
-CZMQ_EXPORT byte *
-    zuuid_data (zuuid_t *self);
+    zuuid_new_from (const byte *source);
 
 //  Set UUID to new supplied ZUUID_LEN-octet value
 CZMQ_EXPORT void
-    zuuid_set (zuuid_t *self, byte *source);
+    zuuid_set (zuuid_t *self, const byte *source);
 
 //  Set UUID to new supplied string value skipping '-' and '{' '}'
 //  optional delimiters. Return 0 if OK, else returns -1.
 CZMQ_EXPORT int
     zuuid_set_str (zuuid_t *self, const char *source);
+
+//  Return UUID binary data
+CZMQ_EXPORT const byte *
+    zuuid_data (zuuid_t *self);
 
 //  Return UUID binary size
 CZMQ_EXPORT size_t
@@ -67,11 +67,11 @@ CZMQ_EXPORT void
 
 //  Check if UUID is same as supplied value
 CZMQ_EXPORT bool
-    zuuid_eq (zuuid_t *self, byte *compare);
+    zuuid_eq (zuuid_t *self, const byte *compare);
 
 //  Check if UUID is different from supplied value
 CZMQ_EXPORT bool
-    zuuid_neq (zuuid_t *self, byte *compare);
+    zuuid_neq (zuuid_t *self, const byte *compare);
 
 //  Make copy of UUID object; if uuid is null, or memory was exhausted,
 //  returns null.

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -106,7 +106,7 @@ zuuid_destroy (zuuid_t **self_p)
 //  Create UUID object from supplied ZUUID_LEN-octet value
 
 zuuid_t *
-zuuid_new_from (byte *source)
+zuuid_new_from (const byte *source)
 {
     zuuid_t *self = (zuuid_t *) zmalloc (sizeof (zuuid_t));
     if (self)
@@ -119,7 +119,7 @@ zuuid_new_from (byte *source)
 //  Set UUID to new supplied ZUUID_LEN-octet value
 
 void
-zuuid_set (zuuid_t *self, byte *source)
+zuuid_set (zuuid_t *self, const byte *source)
 {
     assert (self);
     memcpy (self->uuid, source, ZUUID_LEN);
@@ -172,7 +172,7 @@ zuuid_set_str (zuuid_t *self, const char *source)
 //  -----------------------------------------------------------------
 //  Return UUID binary data
 
-byte *
+const byte *
 zuuid_data (zuuid_t *self)
 {
     assert (self);
@@ -246,7 +246,7 @@ zuuid_export (zuuid_t *self, byte *target)
 //  Check if UUID is same as supplied value
 
 bool
-zuuid_eq (zuuid_t *self, byte *compare)
+zuuid_eq (zuuid_t *self, const byte *compare)
 {
     assert (self);
     return (memcmp (self->uuid, compare, ZUUID_LEN) == 0);
@@ -257,7 +257,7 @@ zuuid_eq (zuuid_t *self, byte *compare)
 //  Check if UUID is different from supplied value
 
 bool
-zuuid_neq (zuuid_t *self, byte *compare)
+zuuid_neq (zuuid_t *self, const byte *compare)
 {
     assert (self);
     return (memcmp (self->uuid, compare, ZUUID_LEN) != 0);

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -103,6 +103,19 @@ zuuid_destroy (zuuid_t **self_p)
 
 
 //  -----------------------------------------------------------------
+//  Create UUID object from supplied ZUUID_LEN-octet value
+
+zuuid_t *
+zuuid_new_from (byte *source)
+{
+    zuuid_t *self = (zuuid_t *) zmalloc (sizeof (zuuid_t));
+    if (self)
+        zuuid_set (self, source);
+    return self;
+}
+
+
+//  -----------------------------------------------------------------
 //  Set UUID to new supplied ZUUID_LEN-octet value
 
 void
@@ -210,7 +223,7 @@ zuuid_str_canonical (zuuid_t *self)
     strncat (self->str_canonical, self->str + 16, 4);
     strcat  (self->str_canonical, "-");
     strncat (self->str_canonical, self->str + 20, 12);
-    
+
     int char_nbr;
     for (char_nbr = 0; char_nbr < 36; char_nbr++)
         self->str_canonical [char_nbr] = tolower (self->str_canonical [char_nbr]);
@@ -258,12 +271,8 @@ zuuid_neq (zuuid_t *self, byte *compare)
 zuuid_t *
 zuuid_dup (zuuid_t *self)
 {
-    if (self) {
-        zuuid_t *copy = zuuid_new ();
-        if (copy)
-            zuuid_set (copy, zuuid_data (self));
-        return copy;
-    }
+    if (self)
+        return zuuid_new_from (zuuid_data (self));
     else
         return NULL;
 }
@@ -281,7 +290,7 @@ zuuid_test (bool verbose)
     //  Simple create/destroy test
     assert (ZUUID_LEN == 16);
     assert (ZUUID_STR_LEN == 32);
-    
+
     zuuid_t *uuid = zuuid_new ();
     assert (uuid);
     assert (zuuid_size (uuid) == ZUUID_LEN);


### PR DESCRIPTION
This eats up valuable random data, and potentially blocks.

Solution: add zuuid_new_from (), and use this in zuuid_dup ().