### PR TITLE
signal handling: dont catch any interrupts if zsys_handler_reset(NULL…

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -163,8 +163,8 @@ zsys_init (void)
             s_logsystem = false;
     }
     //  Catch SIGINT and SIGTERM unless ZSYS_SIGHANDLER=false
-    if (getenv ("ZSYS_SIGHANDLER") == NULL
-    ||  strneq (getenv ("ZSYS_SIGHANDLER"), "false"))
+    if ((getenv ("ZSYS_SIGHANDLER") == NULL
+	 ||  strneq (getenv ("ZSYS_SIGHANDLER"), "false")) && s_first_time)
         zsys_catch_interrupts ();
 
     ZMUTEX_INIT (s_mutex);


### PR DESCRIPTION
…) was called

see also: http://lists.zeromq.org/pipermail/zeromq-dev/2015-May/028945.html


btw: I also get an unrelated make check failure:

lt-czmq_selftest: src/zdir.c:93: s_posix_populate_entry: Assertion `subdir' failed.
 * zdir: make[2]: *** [check-local] Aborted (core dumped)
