### PR TITLE
Problem: zmsg_sendm not defined in API model

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,9 +24,9 @@ noinst_LTLIBRARIES =
 TESTS =
 
 EXTRA_DIST = \
-    zgossip_engine.inc \
-    zhash_primes.inc \
-    zclass_example.xml \
+    src/zgossip_engine.inc \
+    src/zhash_primes.inc \
+    src/zclass_example.xml \
     version.sh
 
 include $(srcdir)/src/Makemodule.am

--- a/api/zmsg.xml
+++ b/api/zmsg.xml
@@ -30,6 +30,18 @@
         <return type = "integer" />
     </method>
 
+    <method name = "sendm" singleton = "1">
+        Send message to destination socket as part of a multipart sequence, and
+        destroy the message after sending it successfully. Note that after a
+        zmsg_sendm, you must call zmsg_send or another method that sends a final
+        message part. If the message has no frames, sends nothing but destroys
+        the message anyhow. Nullifies the caller's reference to the message (as
+        it is a destructor).
+        <argument name = "self_p" type = "zmsg" by_reference = "1" />
+        <argument name = "dest" type = "anything" />
+        <return type = "integer" />
+    </method>
+
     <method name = "size">
         Return size of message, i.e. number of frames (0 or more).
         <return type = "size" />

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -1388,6 +1388,8 @@ lib.zmsg_recv.restype = zmsg_p
 lib.zmsg_recv.argtypes = [c_void_p]
 lib.zmsg_send.restype = c_int
 lib.zmsg_send.argtypes = [POINTER(zmsg_p), c_void_p]
+lib.zmsg_sendm.restype = c_int
+lib.zmsg_sendm.argtypes = [POINTER(zmsg_p), c_void_p]
 lib.zmsg_size.restype = c_size_t
 lib.zmsg_size.argtypes = [zmsg_p]
 lib.zmsg_content_size.restype = c_size_t
@@ -1491,6 +1493,16 @@ it successfully. If the message has no frames, sends nothing but destroys
 the message anyhow. Nullifies the caller's reference to the message (as
 it is a destructor)."""
         return lib.zmsg_send(byref(zmsg_p.from_param(self_p)), dest)
+
+    @staticmethod
+    def sendm(self_p, dest):
+        """Send message to destination socket as part of a multipart sequence, and
+destroy the message after sending it successfully. Note that after a
+zmsg_sendm, you must call zmsg_send or another method that sends a final
+message part. If the message has no frames, sends nothing but destroys
+the message anyhow. Nullifies the caller's reference to the message (as
+it is a destructor)."""
+        return lib.zmsg_sendm(byref(zmsg_p.from_param(self_p)), dest)
 
     def size(self):
         """Return size of message, i.e. number of frames (0 or more)."""

--- a/bindings/qml/src/QmlZmsg.cpp
+++ b/bindings/qml/src/QmlZmsg.cpp
@@ -223,6 +223,17 @@ int QmlZmsgAttached::send (QmlZmsg *selfP, void *dest) {
 };
 
 ///
+//  Send message to destination socket as part of a multipart sequence, and 
+//  destroy the message after sending it successfully. Note that after a    
+//  zmsg_sendm, you must call zmsg_send or another method that sends a final
+//  message part. If the message has no frames, sends nothing but destroys  
+//  the message anyhow. Nullifies the caller's reference to the message (as 
+//  it is a destructor).                                                    
+int QmlZmsgAttached::sendm (QmlZmsg *selfP, void *dest) {
+    return zmsg_sendm (&selfP->self, dest);
+};
+
+///
 //  Load/append an open file into message, create new message if 
 //  null message provided. Returns NULL if the message could not 
 //  be loaded.                                                   

--- a/bindings/qml/src/QmlZmsg.h
+++ b/bindings/qml/src/QmlZmsg.h
@@ -153,6 +153,14 @@ public slots:
     //  it is a destructor).                                                     
     int send (QmlZmsg *selfP, void *dest);
 
+    //  Send message to destination socket as part of a multipart sequence, and 
+    //  destroy the message after sending it successfully. Note that after a    
+    //  zmsg_sendm, you must call zmsg_send or another method that sends a final
+    //  message part. If the message has no frames, sends nothing but destroys  
+    //  the message anyhow. Nullifies the caller's reference to the message (as 
+    //  it is a destructor).                                                    
+    int sendm (QmlZmsg *selfP, void *dest);
+
     //  Load/append an open file into message, create new message if 
     //  null message provided. Returns NULL if the message could not 
     //  be loaded.                                                   

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -200,6 +200,7 @@ module CZMQ
       attach_function :zmsg_destroy, [:pointer], :void, **opts
       attach_function :zmsg_recv, [:pointer], :pointer, **opts
       attach_function :zmsg_send, [:pointer, :pointer], :int, **opts
+      attach_function :zmsg_sendm, [:pointer, :pointer], :int, **opts
       attach_function :zmsg_size, [:pointer], :size_t, **opts
       attach_function :zmsg_content_size, [:pointer], :size_t, **opts
       attach_function :zmsg_prepend, [:pointer, :pointer], :int, **opts

--- a/bindings/ruby/lib/czmq/ffi/zmsg.rb
+++ b/bindings/ruby/lib/czmq/ffi/zmsg.rb
@@ -84,6 +84,18 @@ module CZMQ
         result
       end
       
+      # Send message to destination socket as part of a multipart sequence, and 
+      # destroy the message after sending it successfully. Note that after a    
+      # zmsg_sendm, you must call zmsg_send or another method that sends a final
+      # message part. If the message has no frames, sends nothing but destroys  
+      # the message anyhow. Nullifies the caller's reference to the message (as 
+      # it is a destructor).                                                    
+      def self.sendm self_p, dest
+        self_p = self_p.__ptr_give_ref
+        result = ::CZMQ::FFI.zmsg_sendm self_p, dest
+        result
+      end
+      
       # Return size of message, i.e. number of frames (0 or more).
       def size
         raise DestroyedError unless @ptr

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -44,10 +44,12 @@ CZMQ_EXPORT zmsg_t *
 CZMQ_EXPORT int
     zmsg_send (zmsg_t **self_p, void *dest);
 
-//  Send (More) message to destination socket, and destroy the message after sending
-//  it successfully. If the message has no frames, sends nothing but destroys
-//  the message anyhow. Nullifies the caller's reference to the message (as  
-//  it is a destructor).                                                     
+//  Send message to destination socket as part of a multipart sequence, and 
+//  destroy the message after sending it successfully. Note that after a    
+//  zmsg_sendm, you must call zmsg_send or another method that sends a final
+//  message part. If the message has no frames, sends nothing but destroys  
+//  the message anyhow. Nullifies the caller's reference to the message (as 
+//  it is a destructor).                                                    
 CZMQ_EXPORT int
     zmsg_sendm (zmsg_t **self_p, void *dest);
 


### PR DESCRIPTION
Causes loss of prototype when regenerating project.xml.

Solution: add it to right place.

Incidental fix, the Makefile also reflects zproject PR #192.