### PR TITLE
Problem: ziflist_print uses illegal for declaration

### DIFF
--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -44,7 +44,7 @@ CZMQ_EXPORT zmsg_t *
 CZMQ_EXPORT int
     zmsg_send (zmsg_t **self_p, void *dest);
 
-//  Send message to destination socket as part of a multipart sequence, and 
+//  Send message to destination socket as part of a multipart sequence, and
 //  destroy the message after sending it successfully. Note that after a    
 //  zmsg_sendm, you must call zmsg_send or another method that sends a final
 //  message part. If the message has no frames, sends nothing but destroys  

--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -95,13 +95,14 @@ ziflist_new (void)
 
 //  Print properties of the ziflist object.
 //  --------------------------------------------------------------------------
-CZMQ_EXPORT void
+
+void
 ziflist_print (ziflist_t *self)
 {
-    for (interface_t *iface = (interface_t *) zlistx_first ((zlistx_t *) self) ;
-         iface != NULL ;
-         iface = (interface_t *) zlistx_next ((zlistx_t *) self))
-    {
+    interface_t *iface;
+    for (iface = (interface_t *) zlistx_first ((zlistx_t *) self);
+         iface != NULL;
+         iface = (interface_t *) zlistx_next ((zlistx_t *) self)) {
         zsys_info (" - interface name : %s", iface->name);
         zsys_info (" - interface address : %s", iface->address);
         zsys_info (" - interface netmask : %s", iface->netmask);

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -150,12 +150,15 @@ zmsg_send (zmsg_t **self_p, void *dest)
 }
 
 //  --------------------------------------------------------------------------
-//  Send (More) message to destination socket, and destroy the message after sending
-//  it successfully. If the message has no frames, sends nothing but destroys
+//  Send message to destination socket as part of a multipart sequence, and
+//  destroy the message after sending it successfully. Note that after a
+//  zmsg_sendm, you must call zmsg_send or another method that sends a final
+//  message part. If the message has no frames, sends nothing but destroys
 //  the message anyhow. Nullifies the caller's reference to the message (as
 //  it is a destructor).
-CZMQ_EXPORT int
-    zmsg_sendm (zmsg_t **self_p, void *dest)
+
+int
+zmsg_sendm (zmsg_t **self_p, void *dest)
 {
     assert (self_p);
     assert (dest);


### PR DESCRIPTION
Solution: remove this.

Also remove two bogus CZMQ_EXPORTs in sources.