### PR TITLE
Link to pthread

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,7 @@
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
+    AC_CHECK_HEADERS(pthread.h)
+    AC_CHECK_LIB([pthread], [pthread_create],
+        [CFLAGS="${CFLAGS} -pthread"],
+        [AC_MSG_ERROR([cannot link with -pthread.])]
+    )
+])

--- a/src/CMakeLists-local.txt
+++ b/src/CMakeLists-local.txt
@@ -1,0 +1,8 @@
+# pthread requires special checks and flags to be added
+if(THREADS_HAVE_PTHREAD_ARG)
+  target_compile_options(PUBLIC czmq "-pthread")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(czmq "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+

--- a/src/CMakeLists-local.txt
+++ b/src/CMakeLists-local.txt
@@ -6,3 +6,6 @@ if(CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(czmq "${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
+# at least C99 is required for zdir which uses ‘for’ loop initial declarations
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+


### PR DESCRIPTION
As reported in https://github.com/zeromq/zproject/issues/199 CZMQ uses Pthread symbols without linking to it. Although this does not cause build problems since ZMQ links to Pthread, it causes errors to be printed by the Debian build environment, since a library is expected to link against all its dependencies.

Finally, with autotool -std=gnu99 is used to build, but not with CMake, which causes a compile error since zdir uses C99's ‘for’ loop initial declarations. So, gnu99 is added to CFLAGS in the project-local CMake hooks.

Please note that this won't have any effect until https://github.com/zeromq/zproject/pull/202 is merged and ./generate.sh is run again on this project.