### PR TITLE
Warning instead of error if cannot link pthread

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2,6 +2,6 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
     AC_CHECK_HEADERS(pthread.h)
     AC_CHECK_LIB([pthread], [pthread_create],
         [CFLAGS="${CFLAGS} -pthread"],
-        [AC_MSG_ERROR([cannot link with -pthread.])]
+        [AC_MSG_WARN([cannot link with -pthread.])]
     )
 ])


### PR DESCRIPTION
Android's libc, Bionic, does not provide a -pthread flag to link,
but instead links automagically when it founds <pthread.h> included.
Use AC_MSG_WARN instead of AC_MSG_ERR to avoid failing the build.

After this commit, if -pthread is not possible like on Android, the build will continue and this will be printed to warn the user:

"configure: WARNING: cannot link with -pthread."