### PR TITLE
Add Travis target for CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 - BUILD_TYPE=default ZMQ_REPO=libzmq    WITH_LIBSODIUM=1
 - BUILD_TYPE=qt-android
 - BUILD_TYPE=check-py
+- BUILD_TYPE=cmake
 
 before_script:
 - sudo apt-get install uuid-dev

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Assumes Travis CI os:linux (x86_64)
+
+git clone git://github.com/jedisct1/libsodium.git &&
+( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+
+# Build, check, and install ZeroMQ
+git clone git://github.com/zeromq/libzmq.git &&
+( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+
+# Build, check, and install CZMQ from local source
+( cd ../..; mkdir build_cmake && cd build_cmake && cmake .. && make all VERBOSE=1 && sudo make install )


### PR DESCRIPTION
Hello,

Is there any particular reason for not having a CMake target in Travis?

If not, this PR enables it. As you can see from here: https://travis-ci.org/bluca/czmq/builds/72932752 it seems to work fine :-)