### PR TITLE
CMake needs find_package(Threads) to link pthread

### DIFF
--- a/src/CMakeLists-local.txt
+++ b/src/CMakeLists-local.txt
@@ -1,4 +1,5 @@
 # pthread requires special checks and flags to be added
+find_package(Threads)
 if(THREADS_HAVE_PTHREAD_ARG)
   target_compile_options(PUBLIC czmq "-pthread")
 endif()


### PR DESCRIPTION
Turns out the CMake special flags are not enough for pthread, find_package needs to be run as well.

If the Threads package is not found, a warning will be printed but the build will continue. :-)

You can check a Travis run which includes a CMake target here: https://travis-ci.org/bluca/czmq/builds/72931553