### PR TITLE
Pass zsock_t instead of handle to zsock_resolve aware functions 

### DIFF
--- a/src/zframe.c
+++ b/src/zframe.c
@@ -121,7 +121,7 @@ zframe_recv (void *source)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsock_rcvmore (handle);
+        self->more = zsock_rcvmore (source);
     }
     return self;
 }
@@ -407,7 +407,7 @@ zframe_recv_nowait (void *source)
             zframe_destroy (&self);
             return NULL;            //  Interrupted or terminated
         }
-        self->more = zsock_rcvmore (handle);
+        self->more = zsock_rcvmore (source);
     }
     return self;
 }

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -100,9 +100,8 @@ zmsg_recv (void *source)
     if (!self)
         return NULL;
 
-    void *handle = zsock_resolve (source);
     while (true) {
-        zframe_t *frame = zframe_recv (handle);
+        zframe_t *frame = zframe_recv (source);
         if (!frame) {
             zmsg_destroy (&self);
             break;              //  Interrupted or terminated
@@ -111,7 +110,7 @@ zmsg_recv (void *source)
             zmsg_destroy (&self);
             break;
         }
-        if (!zsock_rcvmore (handle))
+        if (!zsock_rcvmore (source))
             break;              //  Last message frame
     }
     return self;
@@ -132,12 +131,11 @@ zmsg_send (zmsg_t **self_p, void *dest)
     zmsg_t *self = *self_p;
 
     int rc = 0;
-    void *handle = zsock_resolve (dest);
     if (self) {
         assert (zmsg_is (self));
         zframe_t *frame = (zframe_t *) zlist_pop (self->frames);
         while (frame) {
-            rc = zframe_send (&frame, handle,
+            rc = zframe_send (&frame, dest,
                               zlist_size (self->frames) ? ZFRAME_MORE : 0);
             if (rc != 0)
                 break;
@@ -165,12 +163,11 @@ zmsg_sendm (zmsg_t **self_p, void *dest)
     zmsg_t *self = *self_p;
 
     int rc = 0;
-    void *handle = zsock_resolve (dest);
     if (self) {
         assert (zmsg_is (self));
         zframe_t *frame = (zframe_t *) zlist_pop (self->frames);
         while (frame) {
-            rc = zframe_send (&frame, handle,ZFRAME_MORE);
+            rc = zframe_send (&frame, dest, ZFRAME_MORE);
             if (rc != 0)
                 break;
             frame = (zframe_t *) zlist_pop (self->frames);
@@ -856,9 +853,8 @@ zmsg_recv_nowait (void *source)
     if (!self)
         return NULL;
 
-    void *handle = zsock_resolve (source);
     while (true) {
-        zframe_t *frame = zframe_recv_nowait (handle);
+        zframe_t *frame = zframe_recv_nowait (source);
         if (!frame) {
             zmsg_destroy (&self);
             break;              //  Interrupted or terminated

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -197,7 +197,7 @@ s_self_switch (self_t *self, zsock_t *input, zsock_t *output)
     while (true) {
         if (zmq_recvmsg (zmq_input, &msg, ZMQ_DONTWAIT) == -1)
             break;      //  Presumably EAGAIN
-        int send_flags = zsock_rcvmore (zmq_input)? ZMQ_SNDMORE: 0;
+        int send_flags = zsock_rcvmore (input)? ZMQ_SNDMORE: 0;
         if (zmq_capture) {
             zmq_msg_t dup;
             zmq_msg_init (&dup);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1243,7 +1243,7 @@ zsock_bsend (void *self, const char *picture, ...)
     unsigned int frame_nbr;
     for (frame_nbr = 0; frame_nbr < nbr_frames; frame_nbr++) {
         bool more = frame_nbr < nbr_frames - 1;
-        zframe_send (&frames [frame_nbr], handle,
+        zframe_send (&frames [frame_nbr], self,
                      ZFRAME_REUSE + (more? ZFRAME_MORE: 0));
     }
     return 0;


### PR DESCRIPTION
Ported my analysis code from czmq 2.2.0 to 3.0.2 and noticed a 50% slowdown with czmq 3.0.2.  Profiled the code on OSX and saw a huge overhead in getsockopt being called from sock_resolve from my calls to zmsg_send.  zsock_resolve was converting zsock_t* to a void* and then sub-functions were then calling zsock_resolve on the void*. This commit passes the original zsock_t to any function that then calls zsock_resolve so that getsockopt is almost never called.  This fixed my slowdown.