### PR TITLE
Problem: Python tests failing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,8 +204,6 @@ install(TARGETS czmq
     RUNTIME DESTINATION bin              # .dll file
 )
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/src/CMakeLists-local.txt) # Optional project-local hook
-
 ########################################################################
 # pkgconfig
 ########################################################################

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -729,7 +729,7 @@ size octets from the specified data into the frame body."""
         return Zframe(lib.zframe_new_empty(), True)
 
     @staticmethod
-    def from(string):
+    def from_(string):
         """Create a frame with a specified string content."""
         return Zframe(lib.zframe_from(string), True)
 

--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,6 @@ AC_PROG_SED
 AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
-AX_PROJECT_LOCAL_HOOK # Optional project-local hook (acinclude.m4)
-
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting.])],


### PR DESCRIPTION
Solution: Regenerate using latest zproject to correctly decorate methods which match a keyword