### PR TITLE
Problem: local hooks generated from Zproject were removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,8 @@ install(TARGETS czmq
     RUNTIME DESTINATION bin              # .dll file
 )
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/src/CMakeLists-local.txt) # Optional project-local hook
+
 ########################################################################
 # pkgconfig
 ########################################################################

--- a/bindings/ruby/lib/czmq/ffi/zactor.rb
+++ b/bindings/ruby/lib/czmq/ffi/zactor.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zdir.rb
+++ b/bindings/ruby/lib/czmq/ffi/zdir.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zdir_patch.rb
+++ b/bindings/ruby/lib/czmq/ffi/zdir_patch.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zfile.rb
+++ b/bindings/ruby/lib/czmq/ffi/zfile.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zframe.rb
+++ b/bindings/ruby/lib/czmq/ffi/zframe.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zhash.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhash.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zhashx.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhashx.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/ziflist.rb
+++ b/bindings/ruby/lib/czmq/ffi/ziflist.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zlist.rb
+++ b/bindings/ruby/lib/czmq/ffi/zlist.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zloop.rb
+++ b/bindings/ruby/lib/czmq/ffi/zloop.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zmsg.rb
+++ b/bindings/ruby/lib/czmq/ffi/zmsg.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -38,6 +38,8 @@ module CZMQ
         raise DestroyedError unless @ptr
         @ptr
       end
+      # So external Libraries can just pass the Object to a FFI function which expects a :pointer
+      alias_method :to_ptr, :__ptr
       # Nullify internal pointer and return pointer pointer
       def __ptr_give_ref
         raise DestroyedError unless @ptr

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,8 @@ AC_PROG_SED
 AC_PROG_AWK
 PKG_PROG_PKG_CONFIG
 
+AX_PROJECT_LOCAL_HOOK # Optional project-local hook (acinclude.m4)
+
 # Code coverage
 AC_ARG_WITH(gcov, [AS_HELP_STRING([--with-gcov=yes/no],
                   [With GCC Code Coverage reporting.])],


### PR DESCRIPTION
Solution: regenerate from the latest Zproject version to add back autoconf and CMake project-local hooks that were removed in #1051 and fix the CMake CI build.