### PR TITLE
Travis osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ env:
 - BUILD_TYPE=check-py
 - BUILD_TYPE=cmake
 
+# ZMQ stress tests need more open socket (files) than the usual default
 before_script:
 - sudo apt-get install uuid-dev
+- ulimit -n 64000
 - ./autogen.sh
 
 # Build and check this project according to the BUILD_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ before_install:
 - if [ $TRAVIS_OS_NAME == "linux" ] ; then sudo apt-get install uuid-dev ; elif [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
+# On OSX, it seems the way to set the max files limit is constantly changing, so
+# try to use all known knobs to ensure compatibility across various versions
 before_script:
-- ulimit -n 64000
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then sudo sysctl -w kern.maxfiles=64000 ; sudo sysctl -w kern.maxfilesperproc=64000 ; sudo launchctl limit maxfiles 64000 64000 ; ulimit -n 64000 ; fi ; ulimit -n 64000
 - ./autogen.sh
 
 # Build and check this project according to the BUILD_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ env:
 - BUILD_TYPE=check-py
 - BUILD_TYPE=cmake
 
+before_install:
+- sudo apt-get install uuid-dev
+
 # ZMQ stress tests need more open socket (files) than the usual default
 before_script:
-- sudo apt-get install uuid-dev
 - ulimit -n 64000
 - ./autogen.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 - BUILD_TYPE=cmake
 
 before_install:
-- sudo apt-get install uuid-dev
+- if [ $TRAVIS_OS_NAME == "linux" ] ; then sudo apt-get install uuid-dev ; elif [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: c
 
+os:
+- linux
+- osx
+
 env:
 - BUILD_TYPE=default ZMQ_REPO=zeromq2-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq3-x

--- a/builds/check-py/ci_build.sh
+++ b/builds/check-py/ci_build.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# Assumes Travis CI os:linux (x86_64)
-
 git clone git://github.com/jedisct1/libsodium.git &&
-( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install &&
+    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
 
 # Build, check, and install ZeroMQ
 git clone git://github.com/zeromq/libzmq.git &&
-( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install &&
+    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
 
 # Build, check, and install CZMQ from local source
 ( cd ../..; ./autogen.sh && ./configure && make check-py )

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# Assumes Travis CI os:linux (x86_64)
-
 git clone git://github.com/jedisct1/libsodium.git &&
-( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install &&
+    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
 
 # Build, check, and install ZeroMQ
 git clone git://github.com/zeromq/libzmq.git &&
-( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig ) || exit 1
+( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install &&
+    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
 
 # Build, check, and install CZMQ from local source
 ( cd ../..; mkdir build_cmake && cd build_cmake && cmake .. && make all VERBOSE=1 && sudo make install )

--- a/builds/qt-android/android_build_helper.sh
+++ b/builds/qt-android/android_build_helper.sh
@@ -258,7 +258,16 @@ function android_build_verify_so {
     fi
     android_build_check_fail
     
-    local elfoutput=$(readelf -d ${sofile})
+    if command -v readelf >/dev/null 2>&1 ; then
+        local readelf_bin="readelf"
+    elif command -v greadelf >/dev/null 2>&1 ; then
+        local readelf_bin="greadelf"
+    else
+        ANDROID_BUILD_FAIL+=("Could not find [g]readelf")
+    fi
+    android_build_check_fail
+
+    local elfoutput=$($readelf_bin -d ${sofile})
     
     local soname_regexp='soname: \[([[:alnum:]\.]+)\]'
     if [[ $elfoutput =~ $soname_regexp ]]; then

--- a/builds/qt-android/ci_build.sh
+++ b/builds/qt-android/ci_build.sh
@@ -4,14 +4,29 @@
 #  Please refer to the README for information about making permanent changes.  #
 ################################################################################
 
-# Assumes Travis CI os:linux (x86_64)
-(cd '/tmp' \
-    && wget http://dl.google.com/android/ndk/android-ndk-r9-linux-x86_64.tar.bz2 \
-    && tar -xf android-ndk-r9-linux-x86_64.tar.bz2 \
-    && mv android-ndk-r9 android-ndk)
+NDK_VER=android-ndk-r10e
 
-export ANDROID_NDK_ROOT="/tmp/android-ndk"
-export TOOLCHAIN_PATH="/tmp/android-ndk/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin"
+if [ $TRAVIS_OS_NAME == "linux" ]
+then
+    NDK_PLATFORM=linux-x86_64
+elif [ $TRAVIS_OS_NAME == "osx" ]
+then
+    NDK_PLATFORM=darwin-x86_64
+else
+    echo "Unsupported platform $TRAVIS_OS_NAME"
+    exit 1
+fi
+
+export FILENAME=$NDK_VER-$NDK_PLATFORM.bin
+
+(cd '/tmp' \
+    && wget http://dl.google.com/android/ndk/$FILENAME \
+    && chmod a+x $FILENAME \
+    && ./$FILENAME &> /dev/null ) || exit 1
+unset FILENAME
+
+export ANDROID_NDK_ROOT="/tmp/$NDK_VER"
+export TOOLCHAIN_PATH="$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-4.8/prebuilt/$NDK_PLATFORM/bin"
 export TOOLCHAIN_NAME="arm-linux-androideabi-4.8"
 export TOOLCHAIN_HOST="arm-linux-androideabi"
 export TOOLCHAIN_ARCH="arm"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -5,13 +5,15 @@ if [ $BUILD_TYPE == "default" ]; then
     if [ -n "$WITH_LIBSODIUM" ]; then
         git clone git://github.com/jedisct1/libsodium.git &&
         ( cd libsodium; ./autogen.sh && ./configure &&
-            make check && sudo make install && sudo ldconfig ) || exit 1
+            make check && sudo make install &&
+            if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
     fi
 
     # Build, check, and install the version of ZeroMQ given by ZMQ_REPO
     git clone git://github.com/zeromq/${ZMQ_REPO}.git &&
     ( cd ${ZMQ_REPO}; ./autogen.sh && ./configure &&
-        make check && sudo make install && sudo ldconfig ) || exit 1
+        make check && sudo make install &&
+        if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
 
     # Build, check, and install CZMQ from local source
     ./autogen.sh && ./configure && make check-verbose VERBOSE=1 && sudo make install


### PR DESCRIPTION
This PR makes the CI build scripts compatible with OSX on Travis. Fixes #1053. Note that until OSX build is enabled on a project by emailing support@travis-ci.com, the option in travis.yml will have no effect.