### PR TITLE
Enable container-based build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os:
 - linux
 - osx
 
+sudo: false
+
 env:
 - BUILD_TYPE=default ZMQ_REPO=zeromq2-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq3-x
@@ -16,8 +18,13 @@ env:
 - BUILD_TYPE=check-py
 - BUILD_TYPE=cmake
 
+addons:
+  apt:
+    packages:
+    - uuid-dev
+
 before_install:
-- if [ $TRAVIS_OS_NAME == "linux" ] ; then sudo apt-get install uuid-dev ; elif [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils ; fi
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so

--- a/builds/check-py/ci_build.sh
+++ b/builds/check-py/ci_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 mkdir tmp
 BUILD_PREFIX=$PWD/tmp
 

--- a/builds/check-py/ci_build.sh
+++ b/builds/check-py/ci_build.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+CONFIG_OPTS=()
+CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
 git clone git://github.com/jedisct1/libsodium.git &&
-( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install &&
-    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make check && make install ) || exit 1
 
 # Build, check, and install ZeroMQ
 git clone git://github.com/zeromq/libzmq.git &&
-( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install &&
-    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+( cd libzmq; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make check && make install ) || exit 1
 
 # Build, check, and install CZMQ from local source
-( cd ../..; ./autogen.sh && ./configure && make check-py )
+( cd ../..; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make check-py ) || exit 1

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 mkdir tmp
 BUILD_PREFIX=$PWD/tmp
 

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,13 +1,27 @@
 #!/usr/bin/env bash
 
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+CONFIG_OPTS=()
+CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+
+CMAKE_OPTS=()
+CMAKE_OPTS+=("-DCMAKE_INSTALL_PREFIX:PATH=${BUILD_PREFIX}")
+CMAKE_OPTS+=("-DCMAKE_PREFIX_PATH:PATH=${BUILD_PREFIX}")
+CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
+CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
+
 git clone git://github.com/jedisct1/libsodium.git &&
-( cd libsodium; ./autogen.sh && ./configure && make check && sudo make install &&
-    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make check && make install ) || exit 1
 
 # Build, check, and install ZeroMQ
 git clone git://github.com/zeromq/libzmq.git &&
-( cd libzmq; ./autogen.sh && ./configure && make check && sudo make install &&
-    if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+( cd libzmq; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --prefix=${BUILD_PREFIX} && make check && make install ) || exit 1
 
 # Build, check, and install CZMQ from local source
-( cd ../..; mkdir build_cmake && cd build_cmake && cmake .. && make all VERBOSE=1 && sudo make install )
+( cd ../..; mkdir build_cmake && cd build_cmake && PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .. && make all VERBOSE=1 && make install ) || exit 1

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 
 if [ $BUILD_TYPE == "default" ]; then
+    mkdir tmp
+    BUILD_PREFIX=$PWD/tmp
+
+    CONFIG_OPTS=()
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+    CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+    CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
     # Build, check, and install libsodium if WITH_LIBSODIUM is set
     if [ -n "$WITH_LIBSODIUM" ]; then
         git clone git://github.com/jedisct1/libsodium.git &&
-        ( cd libsodium; ./autogen.sh && ./configure &&
-            make check && sudo make install &&
-            if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+        ( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX &&
+            make check && make install ) || exit 1
     fi
 
     # Build, check, and install the version of ZeroMQ given by ZMQ_REPO
     git clone git://github.com/zeromq/${ZMQ_REPO}.git &&
-    ( cd ${ZMQ_REPO}; ./autogen.sh && ./configure &&
-        make check && sudo make install &&
-        if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi ) || exit 1
+    ( cd ${ZMQ_REPO}; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
+        make check && make install ) || exit 1
 
     # Build, check, and install CZMQ from local source
-    ./autogen.sh && ./configure && make check-verbose VERBOSE=1 && sudo make install
+    (./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make check-verbose VERBOSE=1 && make install) || exit 1
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi


### PR DESCRIPTION
Hello,

As discussed in https://github.com/zeromq/libzmq/pull/1529 here's a PR to switch from VM to container based Travis CI builds. Needed changes were removing "sudo" and installing in local directory rather than in the default /usr/local.

Also -x is set in ci_build.sh, since it prints the executed commands to the log, which is very helpful when debugging.

CMake is particularly quirky, it took a while to make it work, it really didn't want to accept the local pkg-config path!

Please note that the build failures are due to ZMQ test failing, please see this build with ZMQ pinned to the latest working commit for an all-green CI build:

https://travis-ci.org/bluca/czmq/builds/75871849