### PR TITLE
Fix memory leak in zactor_new error path

### DIFF
--- a/src/zactor.c
+++ b/src/zactor.c
@@ -111,6 +111,7 @@ zactor_new (zactor_fn *actor, void *args)
     }
     shim->pipe = zsys_create_pipe (&self->pipe);
     if (!shim->pipe) {
+        free(shim);
         zactor_destroy (&self);
         return NULL;
     }


### PR DESCRIPTION
In zactor_new(), if zsys_create_pipe() returns an error, the function returns NULL and the reference to shim is lost and the allocated buffer leaked. Very unlikely to matter in practice since it's in the error path, but still worth fixing.