### PR TITLE
Problem: not using libuuid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,7 @@ case "${host_os}" in
         # Define on Linux to enable all library features
         CPPFLAGS="-D_GNU_SOURCE -DLINUX $CPPFLAGS"
         AC_DEFINE(CZMQ_HAVE_LINUX, 1, [Have Linux OS])
-        
+
         case "${host_os}" in
             *android*)
                 AC_DEFINE(CZMQ_HAVE_ANDROID, 1, [Have Android OS])
@@ -281,6 +281,7 @@ AM_COND_IF([WITH_TEST_ZGOSSIP], [AC_MSG_NOTICE([WITH_TEST_ZGOSSIP defined])])
 # Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs)
+AC_CHECK_LIB([uuid], [uuid_generate])
 
 # Set pkgconfigdir
 AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -172,6 +172,11 @@ memcheck: src/czmq_selftest
 		--suppressions=$(srcdir)/src/.valgrind.supp \
 		$(srcdir)/src/czmq_selftest
 
+# Run the selftest binary under valgrind to check for performance leaks
+callcheck: src/czmq_selftest
+	$(LIBTOOL) --mode=execute valgrind --tool=callgrind \
+		$(srcdir)/src/czmq_selftest
+
 # Run the selftest binary under gdb for debugging
 debug: src/czmq_selftest
 	$(LIBTOOL) --mode=execute gdb -q \


### PR DESCRIPTION
This forced zuuid_new to always use /dev/urandom, which failed in
heavily multithreaded cases (ran out of open file handlers).

Solution: use libuuid, via zproject.