### PR TITLE
Problem: ztrie selftest comments have typos and weird grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,37 +53,37 @@
 &emsp;<a href="#toc4-6414">zstr - sending and receiving strings</a>
 &emsp;<a href="#toc4-6518">zsys - system-level methods</a>
 &emsp;<a href="#toc4-6954">ztrie - simple trie for tokenizable strings</a>
-&emsp;<a href="#toc4-7113">zuuid - UUID support class</a>
+&emsp;<a href="#toc4-7119">zuuid - UUID support class</a>
 
-**<a href="#toc3-7227">API v2 Summary</a>**
-&emsp;<a href="#toc4-7232">zauth_v2 - authentication for ZeroMQ servers (deprecated)</a>
-&emsp;<a href="#toc4-7424">zctx - working with ØMQ contexts (deprecated)</a>
-&emsp;<a href="#toc4-7552">zmonitor_v2 - socket event monitor (deprecated)</a>
-&emsp;<a href="#toc4-7636">zmutex - working with mutexes (deprecated)</a>
-&emsp;<a href="#toc4-7681">zproxy_v2 - run a steerable proxy in the background (deprecated)</a>
-&emsp;<a href="#toc4-7789">zsocket - working with ØMQ sockets (deprecated)</a>
-&emsp;<a href="#toc4-7954">zsockopt - get/set ØMQ socket options (deprecated)</a>
-&emsp;<a href="#toc4-8946">zthread - working with system threads (deprecated)</a>
+**<a href="#toc3-7233">API v2 Summary</a>**
+&emsp;<a href="#toc4-7238">zauth_v2 - authentication for ZeroMQ servers (deprecated)</a>
+&emsp;<a href="#toc4-7430">zctx - working with ØMQ contexts (deprecated)</a>
+&emsp;<a href="#toc4-7558">zmonitor_v2 - socket event monitor (deprecated)</a>
+&emsp;<a href="#toc4-7642">zmutex - working with mutexes (deprecated)</a>
+&emsp;<a href="#toc4-7687">zproxy_v2 - run a steerable proxy in the background (deprecated)</a>
+&emsp;<a href="#toc4-7795">zsocket - working with ØMQ sockets (deprecated)</a>
+&emsp;<a href="#toc4-7960">zsockopt - get/set ØMQ socket options (deprecated)</a>
+&emsp;<a href="#toc4-8952">zthread - working with system threads (deprecated)</a>
 
-**<a href="#toc2-9063">Error Handling</a>**
+**<a href="#toc2-9069">Error Handling</a>**
 
-**<a href="#toc2-9080">CZMQ Actors</a>**
+**<a href="#toc2-9086">CZMQ Actors</a>**
 
-**<a href="#toc2-9226">Under the Hood</a>**
+**<a href="#toc2-9232">Under the Hood</a>**
 
-**<a href="#toc3-9229">Adding a New Class</a>**
+**<a href="#toc3-9235">Adding a New Class</a>**
 
-**<a href="#toc3-9241">Documentation</a>**
+**<a href="#toc3-9247">Documentation</a>**
 
-**<a href="#toc3-9280">Development</a>**
+**<a href="#toc3-9286">Development</a>**
 
-**<a href="#toc3-9290">Porting CZMQ</a>**
+**<a href="#toc3-9296">Porting CZMQ</a>**
 
-**<a href="#toc3-9301">Hints to Contributors</a>**
+**<a href="#toc3-9307">Hints to Contributors</a>**
 
-**<a href="#toc3-9312">Code Generation</a>**
+**<a href="#toc3-9318">Code Generation</a>**
 
-**<a href="#toc3-9317">This Document</a>**
+**<a href="#toc3-9323">This Document</a>**
 
 <A name="toc2-13" title="Overview" />
 ## Overview
@@ -7074,26 +7074,28 @@ This is the class self test code:
     
     //  Let's start by inserting a couple of routes into the trie.
     //  This one is for the route '/foo/bar' the slash at the beginning of the
-    //  route is importent because everything before will be discarded. The
-    //  slash at the end of the route is optional. The data associated with this
-    //  node is passed without destroy function which means it must be destroyed
-    //  by us.
+    //  route is important because everything before the first delimiter will be
+    //  discarded. A slash at the end of a route is optional though. The data
+    //  associated with this node is passed without destroy function which means
+    //  it must be destroyed by the caller.
     int foo_bar_data = 10;
     ret = ztrie_insert_route (self, "/foo/bar", &foo_bar_data, NULL);
     assert (ret == 0);
     
     //  Now suppose we like to match all routes that start with '/foo' but aren't
-    //  '/foo/bar'. This is posssible by using regular expressions which are enclosed
-    //  in an opening and closing curly bracket. Regular expression for a route are
-    //  always match after all the pure string based like '/foo/bar' have been matched.
-    //  Note there is no order is you enter multiple expression for a route which may
-    //  have overlapping results.
+    //  '/foo/bar'. This is possible by using regular expressions which are enclosed
+    //  in an opening and closing curly bracket. Tokens that contain regular
+    //  expressions are always match after string based tokens.
+    //  Note: There is no order in which regular expressions are sorted thus if you
+    //  enter multiple expressions for a route you will have to make sure they don't
+    //  have overlapping results. For example '{/foo/{[^/]+}' and '{/foo/{\d+}.
     int foo_other_data = 100;
     ret = ztrie_insert_route (self, "/foo/{[^/]+}", &foo_other_data, NULL);
     assert (ret == 0);
     
-    //  Routes are identified by their endpoint, which is the last matched node. It is
-    //  possible to insert routes for a node that already exists but isn't an endpoint yet.
+    //  Routes are identified by their endpoint, which is the last token of the route.
+    //  It is possible to insert routes for a node that already exists but isn't an
+    //  endpoint yet.
     ret = ztrie_insert_route (self, "/foo", NULL, NULL);
     assert (ret == 0);
     
@@ -7101,28 +7103,31 @@ This is the class self test code:
     ret = ztrie_insert_route (self, "/foo", NULL, NULL);
     assert (ret == -1);
     
-    //  Of course you are allowed to remove routes in case there is data associated with a
+    //  Of course you are allowed to remove routes, in case there is data associated with a
     //  route and a destroy data function has been supplied that data will be destroyed.
     ret = ztrie_remove_route (self, "/foo");
     assert (ret == 0);
     
-    //  Removing a non existent route will return a -1.
+    //  Removing a non existent route will  as well return -1.
     ret = ztrie_remove_route (self, "/foo");
     assert (ret == -1);
     
-    //  Removing a route with regular expression must exaclty match the entered.
+    //  Removing a route with a regular expression must exactly match the entered one.
     ret = ztrie_remove_route (self, "/foo/{[^/]+}");
     assert (ret == 0);
     
-    //  Next we like to match a path by regular expressions and also extract the matched
-    //  parts of a route. This can be done by naming the regular expression. The first one is
-    //  named 'name' and is seperated by a colon. If there is no capturing group defined in the
-    //  regular expression the whole matched string will be associated with this parameter. In case
-    //  you don't like the get the whole matched string use a capturing group like it's done with
-    //  the 'id' parameter. This is nice but you can even match as many parameter for a token as
-    //  you like. Therefore simply put the parameter names seperated by colons in front of the
-    //  regular expression and make sure to add a capturing group for each parameter. The first
-    //  parameter will be associated with the first capturing and so on.
+    //  Next we like to match a path by regular expressions and also extract matched
+    //  parts of a route. This can be done by naming the regular expression. The name of a
+    //  regular expression is entered at the beginning of the curly brackets and separated
+    //  by a colon from the regular expression. The fist one in this examples is named
+    //  'name' and names the expression '[^/]'. If there is no capturing group defined in
+    //  the expression the whole matched string will be associated with this parameter. In
+    //  case you don't like the get the whole matched string use a capturing group like
+    //  it have been done for the 'id' parameter. This is nice but you can even match as
+    //  many parameter for a token as you like. Therefore simply put the parameter names
+    //  separated by colons in front of the regular expression and make sure to add a
+    //  capturing group for each parameter. The first parameter will be associated with
+    //  the first capturing and so on.
     char *data = (char *) malloc (80);
     sprintf (data, "%s", "Hello World!");
     ret = ztrie_insert_route (self, "/baz/{name:[^/]+}/{id:--(\\d+)}/{street:nr:(\\a+)(\\d+)}", data, NULL);
@@ -7131,11 +7136,11 @@ This is the class self test code:
     //  Test matches
     bool hasMatch = false;
     
-    //  The first match will fail as this route has never been inserted.
+    //  The route '/bar/foo' will fail to match as this route has never been inserted.
     hasMatch = ztrie_matches (self, "/bar/foo");
     assert (!hasMatch);
     
-    //  The '/foo/bar' will match and we can obtain the data associated with it.
+    //  The route '/foo/bar' will match and we can obtain the data associated with it.
     hasMatch = ztrie_matches (self, "/foo/bar");
     assert (hasMatch);
     int foo_bar_hit_data = *((int *) ztrie_hit_data (self));
@@ -7145,23 +7150,24 @@ This is the class self test code:
     hasMatch = ztrie_matches (self, "/baz/blub");
     assert (!hasMatch);
     
-    //  Now we will match a patch with regular expressions and extract data from the matched route.
+    //  This route will match our named regular expressions route. Thus we can extract data
+    //  from the route by their names.
     hasMatch = ztrie_matches (self, "/baz/blub/--11/abc23");
     assert (hasMatch);
     char *match_data = (char *) ztrie_hit_data (self);
     assert (streq ("Hello World!", match_data));
     zhashx_t *parameters = ztrie_hit_parameters (self);
     assert (zhashx_size (parameters) == 4);
-    assert (streq ("blub", zhashx_lookup (parameters, "name")));
-    assert (streq ("11", zhashx_lookup (parameters, "id")));
-    assert (streq ("abc", zhashx_lookup (parameters, "street")));
-    assert (streq ("23", zhashx_lookup (parameters, "nr")));
+    assert (streq ("blub", (char *) zhashx_lookup (parameters, "name")));
+    assert (streq ("11", (char *) zhashx_lookup (parameters, "id")));
+    assert (streq ("abc", (char *) zhashx_lookup (parameters, "street")));
+    assert (streq ("23", (char *) zhashx_lookup (parameters, "nr")));
     zhashx_destroy (&parameters);
     
     free (data);
     ztrie_destroy (&self);
 
-<A name="toc4-7113" title="zuuid - UUID support class" />
+<A name="toc4-7119" title="zuuid - UUID support class" />
 #### zuuid - UUID support class
 
 The zuuid class generates UUIDs and provides methods for working with
@@ -7275,12 +7281,12 @@ This is the class self test code:
     zuuid_destroy (&copy);
 
 
-<A name="toc3-7227" title="API v2 Summary" />
+<A name="toc3-7233" title="API v2 Summary" />
 ### API v2 Summary
 
 This is the deprecated API provided by CZMQ v2.x, in alphabetical order.
 
-<A name="toc4-7232" title="zauth_v2 - authentication for ZeroMQ servers (deprecated)" />
+<A name="toc4-7238" title="zauth_v2 - authentication for ZeroMQ servers (deprecated)" />
 #### zauth_v2 - authentication for ZeroMQ servers (deprecated)
 
 A zauth object takes over authentication for all incoming connections in
@@ -7472,7 +7478,7 @@ This is the class self test code:
     zdir_remove (dir, true);
     zdir_destroy (&dir);
 
-<A name="toc4-7424" title="zctx - working with ØMQ contexts (deprecated)" />
+<A name="toc4-7430" title="zctx - working with ØMQ contexts (deprecated)" />
 #### zctx - working with ØMQ contexts (deprecated)
 
 The zctx class wraps ØMQ contexts. It manages open sockets in the context
@@ -7600,7 +7606,7 @@ This is the class self test code:
     assert (zctx_underlying (ctx));
     zctx_destroy (&ctx);
 
-<A name="toc4-7552" title="zmonitor_v2 - socket event monitor (deprecated)" />
+<A name="toc4-7558" title="zmonitor_v2 - socket event monitor (deprecated)" />
 #### zmonitor_v2 - socket event monitor (deprecated)
 
 The zmonitor class provides an API for obtaining socket events such as
@@ -7684,7 +7690,7 @@ This is the class self test code:
     zmonitor_destroy (&sourcemon);
     zctx_destroy (&ctx);
 
-<A name="toc4-7636" title="zmutex - working with mutexes (deprecated)" />
+<A name="toc4-7642" title="zmutex - working with mutexes (deprecated)" />
 #### zmutex - working with mutexes (deprecated)
 
 The zmutex class provides a portable wrapper for mutexes. Please do not
@@ -7729,7 +7735,7 @@ This is the class self test code:
     zmutex_unlock (mutex);
     zmutex_destroy (&mutex);
 
-<A name="toc4-7681" title="zproxy_v2 - run a steerable proxy in the background (deprecated)" />
+<A name="toc4-7687" title="zproxy_v2 - run a steerable proxy in the background (deprecated)" />
 #### zproxy_v2 - run a steerable proxy in the background (deprecated)
 
 The zproxy class provides an equivalent to the ZMQ steerable proxy, on
@@ -7837,7 +7843,7 @@ This is the class self test code:
     zctx_destroy (&ctx);
     
 
-<A name="toc4-7789" title="zsocket - working with ØMQ sockets (deprecated)" />
+<A name="toc4-7795" title="zsocket - working with ØMQ sockets (deprecated)" />
 #### zsocket - working with ØMQ sockets (deprecated)
 
 The zsocket class provides helper functions for ØMQ sockets. It doesn't
@@ -8002,7 +8008,7 @@ This is the class self test code:
     zsocket_destroy (ctx, writer);
     zctx_destroy (&ctx);
 
-<A name="toc4-7954" title="zsockopt - get/set ØMQ socket options (deprecated)" />
+<A name="toc4-7960" title="zsockopt - get/set ØMQ socket options (deprecated)" />
 #### zsockopt - get/set ØMQ socket options (deprecated)
 
 The zsockopt class provides access to the ØMQ getsockopt/setsockopt API.
@@ -8994,7 +9000,7 @@ This is the class self test code:
     
     zctx_destroy (&ctx);
 
-<A name="toc4-8946" title="zthread - working with system threads (deprecated)" />
+<A name="toc4-8952" title="zthread - working with system threads (deprecated)" />
 #### zthread - working with system threads (deprecated)
 
 The zthread class wraps OS thread creation. It creates detached threads
@@ -9111,7 +9117,7 @@ This is the class self test code:
     zctx_destroy (&ctx);
 
 
-<A name="toc2-9063" title="Error Handling" />
+<A name="toc2-9069" title="Error Handling" />
 ## Error Handling
 
 The CZMQ policy is to reduce the error flow to 0/-1 where possible. libzmq still does a lot of errno setting. CZMQ does not do that, as it creates a fuzzy API. Things either work as expected, or they fail, and the application's best strategy is usually to assert on non-zero return codes.
@@ -9128,7 +9134,7 @@ There are a few cases where the return value is overloaded to return -1, 0, or o
 
 The overall goal with this strategy is robustness, and absolute minimal and predictable expression in the code. You can see that it works: the CZMQ code is generally very simple and clear, with a few exceptions of places where people have used their old C style (we fix these over time).
 
-<A name="toc2-9080" title="CZMQ Actors" />
+<A name="toc2-9086" title="CZMQ Actors" />
 ## CZMQ Actors
 
 The v2 API had a zthread class that let you create "attached threads" connected to their parent by an inproc:// PIPE socket. In v3 this has been simplified and better wrapped as the zactor class. CZMQ actors are in effect threads with a socket interface. A zactor_t instance works like a socket, and the CZMQ classes that deal with sockets (like zmsg and zpoller) all accept zactor_t references as well as zsock_t and libzmq void * socket handles.
@@ -9274,10 +9280,10 @@ To write an actor, use this template. Note that your actor is a single function 
 
 The selftest code shows how to create, talk to, and destroy an actor.
 
-<A name="toc2-9226" title="Under the Hood" />
+<A name="toc2-9232" title="Under the Hood" />
 ## Under the Hood
 
-<A name="toc3-9229" title="Adding a New Class" />
+<A name="toc3-9235" title="Adding a New Class" />
 ### Adding a New Class
 
 If you define a new CZMQ class `myclass` you need to:
@@ -9289,7 +9295,7 @@ If you define a new CZMQ class `myclass` you need to:
 * Add myclass to 'model/projects.xml` and read model/README.txt.
 * Add a section to README.txt.
 
-<A name="toc3-9241" title="Documentation" />
+<A name="toc3-9247" title="Documentation" />
 ### Documentation
 
 Man pages are generated from the class header and source files via the doc/mkman tool, and similar functionality in the gitdown tool (http://github.com/imatix/gitdown). The header file for a class must wrap its interface as follows (example is from include/zclock.h):
@@ -9328,7 +9334,7 @@ The source file for a class then provides the self test example as follows:
 
 The template for man pages is in doc/mkman.
 
-<A name="toc3-9280" title="Development" />
+<A name="toc3-9286" title="Development" />
 ### Development
 
 CZMQ is developed through a test-driven process that guarantees no memory violations or leaks in the code:
@@ -9338,7 +9344,7 @@ CZMQ is developed through a test-driven process that guarantees no memory violat
 * Run the 'selftest' script, which uses the Valgrind memcheck tool.
 * Repeat until perfect.
 
-<A name="toc3-9290" title="Porting CZMQ" />
+<A name="toc3-9296" title="Porting CZMQ" />
 ### Porting CZMQ
 
 When you try CZMQ on an OS that it's not been used on (ever, or for a while), you will hit code that does not compile. In some cases the patches are trivial, in other cases (usually when porting to Windows), the work needed to build equivalent functionality may be non-trivial. In any case, the benefit is that once ported, the functionality is available to all applications.
@@ -9349,7 +9355,7 @@ Before attempting to patch code for portability, please read the `czmq_prelude.h
 * Defining macros that rename exotic library functions to more conventional names: do this in czmq_prelude.h.
 * Reimplementing specific methods to use a non-standard API: this is typically needed on Windows. Do this in the relevant class, using #ifdefs to properly differentiate code for different platforms.
 
-<A name="toc3-9301" title="Hints to Contributors" />
+<A name="toc3-9307" title="Hints to Contributors" />
 ### Hints to Contributors
 
 CZMQ is a nice, neat library, and you may not immediately appreciate why. Read the CLASS style guide please, and write your code to make it indistinguishable from the rest of the code in the library. That is the only real criteria for good style: it's invisible.
@@ -9360,12 +9366,12 @@ Do read your code after you write it and ask, "Can I make this simpler?" We do u
 
 Before opening a pull request read our [contribution guidelines](https://github.com/zeromq/czmq/blob/master/CONTRIBUTING.md). Thanks!
 
-<A name="toc3-9312" title="Code Generation" />
+<A name="toc3-9318" title="Code Generation" />
 ### Code Generation
 
 We generate the zsockopt class using [GSL](https://github.com/imatix/gsl), using a code generator script in scripts/sockopts.gsl. We also generate the project files.
 
-<A name="toc3-9317" title="This Document" />
+<A name="toc3-9323" title="This Document" />
 ### This Document
 
 This document is originally at README.txt and is built using [gitdown](http://github.com/imatix/gitdown).

--- a/doc/ztrie.doc
+++ b/doc/ztrie.doc
@@ -69,26 +69,28 @@ This is the class self test code:
     
     //  Let's start by inserting a couple of routes into the trie.
     //  This one is for the route '/foo/bar' the slash at the beginning of the
-    //  route is importent because everything before will be discarded. The
-    //  slash at the end of the route is optional. The data associated with this
-    //  node is passed without destroy function which means it must be destroyed
-    //  by us.
+    //  route is important because everything before the first delimiter will be
+    //  discarded. A slash at the end of a route is optional though. The data
+    //  associated with this node is passed without destroy function which means
+    //  it must be destroyed by the caller.
     int foo_bar_data = 10;
     ret = ztrie_insert_route (self, "/foo/bar", &foo_bar_data, NULL);
     assert (ret == 0);
     
     //  Now suppose we like to match all routes that start with '/foo' but aren't
-    //  '/foo/bar'. This is posssible by using regular expressions which are enclosed
-    //  in an opening and closing curly bracket. Regular expression for a route are
-    //  always match after all the pure string based like '/foo/bar' have been matched.
-    //  Note there is no order is you enter multiple expression for a route which may
-    //  have overlapping results.
+    //  '/foo/bar'. This is possible by using regular expressions which are enclosed
+    //  in an opening and closing curly bracket. Tokens that contain regular
+    //  expressions are always match after string based tokens.
+    //  Note: There is no order in which regular expressions are sorted thus if you
+    //  enter multiple expressions for a route you will have to make sure they don't
+    //  have overlapping results. For example '{/foo/{[^/]+}' and '{/foo/{\d+}.
     int foo_other_data = 100;
     ret = ztrie_insert_route (self, "/foo/{[^/]+}", &foo_other_data, NULL);
     assert (ret == 0);
     
-    //  Routes are identified by their endpoint, which is the last matched node. It is
-    //  possible to insert routes for a node that already exists but isn't an endpoint yet.
+    //  Routes are identified by their endpoint, which is the last token of the route.
+    //  It is possible to insert routes for a node that already exists but isn't an
+    //  endpoint yet.
     ret = ztrie_insert_route (self, "/foo", NULL, NULL);
     assert (ret == 0);
     
@@ -96,28 +98,31 @@ This is the class self test code:
     ret = ztrie_insert_route (self, "/foo", NULL, NULL);
     assert (ret == -1);
     
-    //  Of course you are allowed to remove routes in case there is data associated with a
+    //  Of course you are allowed to remove routes, in case there is data associated with a
     //  route and a destroy data function has been supplied that data will be destroyed.
     ret = ztrie_remove_route (self, "/foo");
     assert (ret == 0);
     
-    //  Removing a non existent route will return a -1.
+    //  Removing a non existent route will  as well return -1.
     ret = ztrie_remove_route (self, "/foo");
     assert (ret == -1);
     
-    //  Removing a route with regular expression must exaclty match the entered.
+    //  Removing a route with a regular expression must exactly match the entered one.
     ret = ztrie_remove_route (self, "/foo/{[^/]+}");
     assert (ret == 0);
     
-    //  Next we like to match a path by regular expressions and also extract the matched
-    //  parts of a route. This can be done by naming the regular expression. The first one is
-    //  named 'name' and is seperated by a colon. If there is no capturing group defined in the
-    //  regular expression the whole matched string will be associated with this parameter. In case
-    //  you don't like the get the whole matched string use a capturing group like it's done with
-    //  the 'id' parameter. This is nice but you can even match as many parameter for a token as
-    //  you like. Therefore simply put the parameter names seperated by colons in front of the
-    //  regular expression and make sure to add a capturing group for each parameter. The first
-    //  parameter will be associated with the first capturing and so on.
+    //  Next we like to match a path by regular expressions and also extract matched
+    //  parts of a route. This can be done by naming the regular expression. The name of a
+    //  regular expression is entered at the beginning of the curly brackets and separated
+    //  by a colon from the regular expression. The fist one in this examples is named
+    //  'name' and names the expression '[^/]'. If there is no capturing group defined in
+    //  the expression the whole matched string will be associated with this parameter. In
+    //  case you don't like the get the whole matched string use a capturing group like
+    //  it have been done for the 'id' parameter. This is nice but you can even match as
+    //  many parameter for a token as you like. Therefore simply put the parameter names
+    //  separated by colons in front of the regular expression and make sure to add a
+    //  capturing group for each parameter. The first parameter will be associated with
+    //  the first capturing and so on.
     char *data = (char *) malloc (80);
     sprintf (data, "%s", "Hello World!");
     ret = ztrie_insert_route (self, "/baz/{name:[^/]+}/{id:--(\\d+)}/{street:nr:(\\a+)(\\d+)}", data, NULL);
@@ -126,11 +131,11 @@ This is the class self test code:
     //  Test matches
     bool hasMatch = false;
     
-    //  The first match will fail as this route has never been inserted.
+    //  The route '/bar/foo' will fail to match as this route has never been inserted.
     hasMatch = ztrie_matches (self, "/bar/foo");
     assert (!hasMatch);
     
-    //  The '/foo/bar' will match and we can obtain the data associated with it.
+    //  The route '/foo/bar' will match and we can obtain the data associated with it.
     hasMatch = ztrie_matches (self, "/foo/bar");
     assert (hasMatch);
     int foo_bar_hit_data = *((int *) ztrie_hit_data (self));
@@ -140,17 +145,18 @@ This is the class self test code:
     hasMatch = ztrie_matches (self, "/baz/blub");
     assert (!hasMatch);
     
-    //  Now we will match a patch with regular expressions and extract data from the matched route.
+    //  This route will match our named regular expressions route. Thus we can extract data
+    //  from the route by their names.
     hasMatch = ztrie_matches (self, "/baz/blub/--11/abc23");
     assert (hasMatch);
     char *match_data = (char *) ztrie_hit_data (self);
     assert (streq ("Hello World!", match_data));
     zhashx_t *parameters = ztrie_hit_parameters (self);
     assert (zhashx_size (parameters) == 4);
-    assert (streq ("blub", zhashx_lookup (parameters, "name")));
-    assert (streq ("11", zhashx_lookup (parameters, "id")));
-    assert (streq ("abc", zhashx_lookup (parameters, "street")));
-    assert (streq ("23", zhashx_lookup (parameters, "nr")));
+    assert (streq ("blub", (char *) zhashx_lookup (parameters, "name")));
+    assert (streq ("11", (char *) zhashx_lookup (parameters, "id")));
+    assert (streq ("abc", (char *) zhashx_lookup (parameters, "street")));
+    assert (streq ("23", (char *) zhashx_lookup (parameters, "nr")));
     zhashx_destroy (&parameters);
     
     free (data);

--- a/doc/ztrie.txt
+++ b/doc/ztrie.txt
@@ -81,26 +81,28 @@ int ret = 0;
 
 //  Let's start by inserting a couple of routes into the trie.
 //  This one is for the route '/foo/bar' the slash at the beginning of the
-//  route is importent because everything before will be discarded. The
-//  slash at the end of the route is optional. The data associated with this
-//  node is passed without destroy function which means it must be destroyed
-//  by us.
+//  route is important because everything before the first delimiter will be
+//  discarded. A slash at the end of a route is optional though. The data
+//  associated with this node is passed without destroy function which means
+//  it must be destroyed by the caller.
 int foo_bar_data = 10;
 ret = ztrie_insert_route (self, "/foo/bar", &foo_bar_data, NULL);
 assert (ret == 0);
 
 //  Now suppose we like to match all routes that start with '/foo' but aren't
-//  '/foo/bar'. This is posssible by using regular expressions which are enclosed
-//  in an opening and closing curly bracket. Regular expression for a route are
-//  always match after all the pure string based like '/foo/bar' have been matched.
-//  Note there is no order is you enter multiple expression for a route which may
-//  have overlapping results.
+//  '/foo/bar'. This is possible by using regular expressions which are enclosed
+//  in an opening and closing curly bracket. Tokens that contain regular
+//  expressions are always match after string based tokens.
+//  Note: There is no order in which regular expressions are sorted thus if you
+//  enter multiple expressions for a route you will have to make sure they don't
+//  have overlapping results. For example '{/foo/{[^/]+}' and '{/foo/{\d+}.
 int foo_other_data = 100;
 ret = ztrie_insert_route (self, "/foo/{[^/]+}", &foo_other_data, NULL);
 assert (ret == 0);
 
-//  Routes are identified by their endpoint, which is the last matched node. It is
-//  possible to insert routes for a node that already exists but isn't an endpoint yet.
+//  Routes are identified by their endpoint, which is the last token of the route.
+//  It is possible to insert routes for a node that already exists but isn't an
+//  endpoint yet.
 ret = ztrie_insert_route (self, "/foo", NULL, NULL);
 assert (ret == 0);
 
@@ -108,28 +110,31 @@ assert (ret == 0);
 ret = ztrie_insert_route (self, "/foo", NULL, NULL);
 assert (ret == -1);
 
-//  Of course you are allowed to remove routes in case there is data associated with a
+//  Of course you are allowed to remove routes, in case there is data associated with a
 //  route and a destroy data function has been supplied that data will be destroyed.
 ret = ztrie_remove_route (self, "/foo");
 assert (ret == 0);
 
-//  Removing a non existent route will return a -1.
+//  Removing a non existent route will  as well return -1.
 ret = ztrie_remove_route (self, "/foo");
 assert (ret == -1);
 
-//  Removing a route with regular expression must exaclty match the entered.
+//  Removing a route with a regular expression must exactly match the entered one.
 ret = ztrie_remove_route (self, "/foo/{[^/]+}");
 assert (ret == 0);
 
-//  Next we like to match a path by regular expressions and also extract the matched
-//  parts of a route. This can be done by naming the regular expression. The first one is
-//  named 'name' and is seperated by a colon. If there is no capturing group defined in the
-//  regular expression the whole matched string will be associated with this parameter. In case
-//  you don't like the get the whole matched string use a capturing group like it's done with
-//  the 'id' parameter. This is nice but you can even match as many parameter for a token as
-//  you like. Therefore simply put the parameter names seperated by colons in front of the
-//  regular expression and make sure to add a capturing group for each parameter. The first
-//  parameter will be associated with the first capturing and so on.
+//  Next we like to match a path by regular expressions and also extract matched
+//  parts of a route. This can be done by naming the regular expression. The name of a
+//  regular expression is entered at the beginning of the curly brackets and separated
+//  by a colon from the regular expression. The fist one in this examples is named
+//  'name' and names the expression '[^/]'. If there is no capturing group defined in
+//  the expression the whole matched string will be associated with this parameter. In
+//  case you don't like the get the whole matched string use a capturing group like
+//  it have been done for the 'id' parameter. This is nice but you can even match as
+//  many parameter for a token as you like. Therefore simply put the parameter names
+//  separated by colons in front of the regular expression and make sure to add a
+//  capturing group for each parameter. The first parameter will be associated with
+//  the first capturing and so on.
 char *data = (char *) malloc (80);
 sprintf (data, "%s", "Hello World!");
 ret = ztrie_insert_route (self, "/baz/{name:[^/]+}/{id:--(\\d+)}/{street:nr:(\\a+)(\\d+)}", data, NULL);
@@ -138,11 +143,11 @@ assert (ret == 0);
 //  Test matches
 bool hasMatch = false;
 
-//  The first match will fail as this route has never been inserted.
+//  The route '/bar/foo' will fail to match as this route has never been inserted.
 hasMatch = ztrie_matches (self, "/bar/foo");
 assert (!hasMatch);
 
-//  The '/foo/bar' will match and we can obtain the data associated with it.
+//  The route '/foo/bar' will match and we can obtain the data associated with it.
 hasMatch = ztrie_matches (self, "/foo/bar");
 assert (hasMatch);
 int foo_bar_hit_data = *((int *) ztrie_hit_data (self));
@@ -152,19 +157,24 @@ assert (foo_bar_data == foo_bar_hit_data);
 hasMatch = ztrie_matches (self, "/baz/blub");
 assert (!hasMatch);
 
-//  Now we will match a patch with regular expressions and extract data from the matched route.
+//  This route will match our named regular expressions route. Thus we can extract data
+//  from the route by their names.
 hasMatch = ztrie_matches (self, "/baz/blub/--11/abc23");
 assert (hasMatch);
 char *match_data = (char *) ztrie_hit_data (self);
 assert (streq ("Hello World!", match_data));
 zhashx_t *parameters = ztrie_hit_parameters (self);
 assert (zhashx_size (parameters) == 4);
-assert (streq ("blub", zhashx_lookup (parameters, "name")));
-assert (streq ("11", zhashx_lookup (parameters, "id")));
-assert (streq ("abc", zhashx_lookup (parameters, "street")));
-assert (streq ("23", zhashx_lookup (parameters, "nr")));
+assert (streq ("blub", (char *) zhashx_lookup (parameters, "name")));
+assert (streq ("11", (char *) zhashx_lookup (parameters, "id")));
+assert (streq ("abc", (char *) zhashx_lookup (parameters, "street")));
+assert (streq ("23", (char *) zhashx_lookup (parameters, "nr")));
 zhashx_destroy (&parameters);
 
 free (data);
 ztrie_destroy (&self);
 ----
+
+SEE ALSO
+--------
+linkczmq:czmq[7]


### PR DESCRIPTION
Solution: Fix typos and rework grammar.