### PR TITLE
Problem: Tests for cmake and qt android failed as they added a optional dependency as required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,6 @@ include_directories(${ZEROMQ_INCLUDE_DIRS})
 list(APPEND MORE_LIBRARIES ${ZEROMQ_LIBRARIES})
 
 ########################################################################
-# UUID dependency
-########################################################################
-find_package(Uuid REQUIRED)
-include_directories(${UUID_INCLUDE_DIRS})
-list(APPEND MORE_LIBRARIES ${UUID_LIBRARIES})
-
-########################################################################
 # includes
 ########################################################################
 set (czmq_headers

--- a/builds/qt-android/build.sh
+++ b/builds/qt-android/build.sh
@@ -68,7 +68,6 @@ fi
 # Verify shared libraries in prefix
 
 android_build_verify_so "libzmq.so"
-android_build_verify_so "libuuid.so"
 android_build_verify_so "libczmq.so" "libzmq.so"
 
 ################################################################################


### PR DESCRIPTION
Solution: Don't use the optional dependencies at all until this issue has been fixed in zproject.