### PR TITLE
Problem: The defines for optional dependencies are based on the library

### DIFF
--- a/builds/msvc/platform.h
+++ b/builds/msvc/platform.h
@@ -29,6 +29,6 @@
 
 #define CZMQ_HAVE_WINDOWS
 
-#define HAVE_LIBUUID 1
+#define HAVE_UUID 1
 
 #endif

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -451,7 +451,7 @@ typedef struct sockaddr_in inaddr_t;    //  Internet socket address structure
     typedef __int16 int16_t;
     typedef __int32 int32_t;
     typedef __int64 int64_t;
-    typedef unsigned __int8 uint8_t;    
+    typedef unsigned __int8 uint8_t;
     typedef unsigned __int16 uint16_t;
     typedef unsigned __int32 uint32_t;
     typedef unsigned __int64 uint64_t;
@@ -583,13 +583,13 @@ typedef int SOCKET;
 #   endif
 #endif
 
-#if defined (__WINDOWS__) && !defined (HAVE_LIBUUID)
-#   define HAVE_LIBUUID 1
+#if defined (__WINDOWS__) && !defined (HAVE_UUID)
+#   define HAVE_UUID 1
 #endif
-#if defined (__UTYPE_OSX) && !defined (HAVE_LIBUUID)
-#   define HAVE_LIBUUID 1
+#if defined (__UTYPE_OSX) && !defined (HAVE_UUID)
+#   define HAVE_UUID 1
 #endif
-#if defined (HAVE_LIBUUID)
+#if defined (HAVE_UUID)
 #   if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD)
 #       include <uuid.h>
 #   elif defined __UTYPE_HPUX

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -41,7 +41,7 @@ zuuid_new (void)
 {
     zuuid_t *self = (zuuid_t *) zmalloc (sizeof (zuuid_t));
     if (self) {
-#if defined (HAVE_LIBUUID)
+#if defined (HAVE_UUID)
 #   if defined (__WINDOWS__)
         UUID uuid;
         assert (sizeof (uuid) == ZUUID_LEN);


### PR DESCRIPTION
name and due to changes in zproject won't get a 'LIB' prepended.
Solution: Remove the prepended 'LIB' when checking for the library uuid.