### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ This is the class interface:
     
     //  Append user-supplied data to chunk, return resulting chunk size. If the
     //  data would exceeed the available space, it is truncated. If you want to
-    //  grow the chunk to accomodate new data, use the zchunk_extend method.
+    //  grow the chunk to accommodate new data, use the zchunk_extend method.
     CZMQ_EXPORT size_t
         zchunk_append (zchunk_t *self, const void *data, size_t size);
     


### PR DESCRIPTION
zeromq, I've corrected a typographical error in the documentation of the [czmq](https://github.com/zeromq/czmq) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.