### PR TITLE
Fixed typographical error, changed aquire to acquire in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2379,7 +2379,7 @@ This is the class interface:
     //      zstr_send (zgossip, "VERBOSE");
     //
     //  Bind zgossip to specified endpoint. TCP endpoints may specify
-    //  the port number as "*" to aquire an ephemeral port:
+    //  the port number as "*" to acquire an ephemeral port:
     //
     //      zstr_sendx (zgossip, "BIND", endpoint, NULL);
     //


### PR DESCRIPTION
@zeromq, I've corrected a typographical error in the documentation of the [czmq](https://github.com/zeromq/czmq) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.