### PR TITLE
Add Windows Visual Studio CI appveyoyer.yml file

### DIFF
--- a/FindUuid.cmake
+++ b/FindUuid.cmake
@@ -3,11 +3,16 @@
 #  Please refer to the README for information about making permanent changes.  #
 ################################################################################
 
+if (NOT MSVC)
 include(FindPkgConfig)
 PKG_CHECK_MODULES(PC_UUID "uuid")
 IF (NOT PC_UUID_FOUND)
     PKG_CHECK_MODULES(PC_UUID "uuid")
 ENDIF (NOT PC_UUID_FOUND)
+else (NOT MSVC)
+set(PC_UUID_INCLUDE_DIRS "C:/Program Files")
+set(PC_UUID_LIBRARY_DIRS "C:/Program Files")
+endif (NOT MSVC)
 
 # some libraries install the headers is a subdirectory of the include dir
 # returned by pkg-config, so use a wildcard match to improve chances of finding

--- a/FindZeroMQ.cmake
+++ b/FindZeroMQ.cmake
@@ -3,11 +3,13 @@
 #  Please refer to the README for information about making permanent changes.  #
 ################################################################################
 
+if (NOT MSVC)
 include(FindPkgConfig)
 PKG_CHECK_MODULES(PC_ZEROMQ "libzmq")
 IF (NOT PC_ZEROMQ_FOUND)
     PKG_CHECK_MODULES(PC_ZEROMQ "zmq")
 ENDIF (NOT PC_ZEROMQ_FOUND)
+endif (NOT MSVC)
 
 # some libraries install the headers is a subdirectory of the include dir
 # returned by pkg-config, so use a wildcard match to improve chances of finding

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,80 @@
+version: build-{build}
+
+clone_depth: 1 #clone entire repository history if not defined
+
+#do not build on tags
+skip_tags: true
+
+os: Visual Studio 2015 #  Windows Server 2012
+
+environment:
+  CMAKE_GENERATOR: "Visual Studio 14 2015"
+
+matrix:
+  fast_finish: false #finish build once one of the jobs fails
+
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Release
+  - Debug
+
+#scripts that are called at very beginning, before repo cloning
+init:
+  #Put this line somewhere when you want to debug something using rdp
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  #- set #debug: view all environment variables
+  - ps: Update-AppveyorBuild -Version "git-$($env:appveyor_repo_commit.substring(0,8))"
+  - cmake --version
+  - msbuild /version
+  - cmd: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
+  #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  #- cmake --help #debug: view available generators
+
+#scripts that run after cloning repository
+install:
+  # Build the dependency (libzmq)
+  - cmd: if "%Platform%"=="x64" set "CMAKE_GENERATOR=%CMAKE_GENERATOR% Win64"
+  - cmd: echo "Generator='%CMAKE_GENERATOR%'"
+  - cmd: echo "Platform='%Platform%'"
+  - cmd: cd C:\projects
+  - cmd: git clone https://github.com/zeromq/libzmq.git --depth 1
+  - cmd: set LIBZMQ_BUILDDIR=C:\projects\build_libzmq\%Platform%\%Configuration%
+  - cmd: md "%LIBZMQ_BUILDDIR%"
+  - cmd: cd "%LIBZMQ_BUILDDIR%"
+  - ps: $blockRdp = $true;
+  - cmd: cmake -D CMAKE_CXX_FLAGS_RELEASE="/MT" -D CMAKE_CXX_FLAGS_DEBUG="/MTd" -G "%CMAKE_GENERATOR%" C:\projects\libzmq
+  - cmd: msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration% libzmq.vcxproj #zeromq.sln
+  - cmd: set ZEROMQ_INCLUDE_DIRS="C:\projects\libzmq\include"
+  - cmd: set ZEROMQ_LIBRARY_DIRS="%LIBZMQ_BUILDDIR%\lib\%Configuration%"
+  - cmd: move "%ZEROMQ_LIBRARY_DIRS%\libzmq-*lib" "%ZEROMQ_LIBRARY_DIRS%\zmq.lib"
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
+
+#where to clone the git repository to
+clone_folder: C:\projects\czmq
+
+#scripts to run before build
+before_build:
+  - cmd: set CZMQ_BUILDDIR=C:\projects\build_czmq
+  - cmd: md "%CZMQ_BUILDDIR%"
+  - cd "%CZMQ_BUILDDIR%"
+  - cmd: cmake -G "%CMAKE_GENERATOR%" -D PC_ZEROMQ_INCLUDE_DIRS="%ZEROMQ_INCLUDE_DIRS%" -D PC_ZEROMQ_LIBRARY_DIRS="%ZEROMQ_LIBRARY_DIRS%" -D CMAKE_CXX_FLAGS_RELEASE="/MT" -D CMAKE_CXX_FLAGS_DEBUG="/MTd" "%APPVEYOR_BUILD_FOLDER%" 
+
+build:
+  parallel: true
+  project: C:\projects\build_czmq\czmq.sln
+  verbosity: minimal #quiet|minimal|normal|detailed
+
+#scripts to run after build
+after_build:
+  # Pack the artifacts
+  - cmd: cd "%CZMQ_BUILDDIR%\%Configuration%"
+  - cmd: copy "%LIBZMQ_BUILDDIR%\bin\%Configuration%\libzmq-*dll" .
+  - cmd: 7z a -y -bd -mx=9 czmq.zip czmq_selftest.exe czmq.dll libzmq-*.dll
+  - ps: Push-AppveyorArtifact "czmq.zip" -Filename "czmq-${env:Platform}-${env:Configuration}.zip"
+  - cmd: czmq_selftest # -v
+
+test:
+  none


### PR DESCRIPTION
In #1094, a CI test for Windows was requested.
Appveyor provides a framework for Visual Studio on Windows.
See http://www.appveyor.com/

Notes:
- Only tests Visual Studio 2015
- It builds 32- and 64-bit
- It builds Release and Debug
- It will build the libzmq dependency everytime
- It does not build and run the libzmq tests
- It will run the selftest of czmq after the build
- It will produce a zip with the built files, which can be downloaded
  from the artifacts page.
- Remote debugging (using rdesktop) is possible. See
  http://www.appveyor.com/docs/how-to/rdp-to-build-worker
  on how to pause the build and rdp to the worker.

Known problems:
- In FindUuid.cmake, a bad path is set. So UUID is not used in Visual Studio.
- No output of the czmq_selftest
- The self test fails at an assertion. For an unknown reason, the Release fails
  and Debug succeeds.
- The self test fails. An assertion can cause a dialog to appear, which can time out the test.

Sample output:
- https://ci.appveyor.com/project/madebr/czmq/build/git-980628ee
  (the self test times out)
- https://ci.appveyor.com/project/madebr/czmq/build/build-108
  (I've re-run the same test, that's why an error appears at the top because no 2 builds can have the same names)

Please reply when you would have some remarks.