### PR TITLE
fix zdir traversing too high

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -936,13 +936,13 @@ zdir_test (bool verbose)
     printf (" * zdir: ");
 
     //  @selftest
-    zdir_t *older = zdir_new (".", NULL);
+    zdir_t *older = zdir_new ("src", NULL);
     assert (older);
     if (verbose) {
         printf ("\n");
         zdir_dump (older, 0);
     }
-    zdir_t *newer = zdir_new ("..", NULL);
+    zdir_t *newer = zdir_new (".", NULL);
     assert (newer);
     zlist_t *patches = zdir_diff (older, newer, "/");
     assert (patches);


### PR DESCRIPTION
Bug https://github.com/zeromq/czmq/issues/527

czmq_selftest calls zdir_test, which enumerates the current and parent working directories. This breaks `make check` when the parent directory contains files with chmod 600 owned by other users (problematic if the build directory is somewhere shared, like /tmp/)

Since czmq_selftest is called in the czmq base directory by `make check`, it makes sense for this test to refer to "src" and "." instead of "." and "..", preventing zmq from playing outside its build directory