### PR TITLE
Use timeout on Windows CI for czmq_selftest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ os: Visual Studio 2015 #  Windows Server 2012
 
 environment:
   CMAKE_GENERATOR: "Visual Studio 14 2015"
+  PYTHON: "C:\\Python27-x64"
 
 matrix:
   fast_finish: false #finish build once one of the jobs fails
@@ -35,16 +36,21 @@ init:
 
 #scripts that run after cloning repository
 install:
+  # Install python test libraries
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python -m pip install --upgrade pip"
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "pip install pypiwin32"
+  - "easy_install --no-deps winpexpect"
   # Build the dependency (libzmq)
   - cmd: if "%Platform%"=="x64" set "CMAKE_GENERATOR=%CMAKE_GENERATOR% Win64"
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%Platform%'"
   - cmd: cd C:\projects
-  - cmd: git clone https://github.com/zeromq/libzmq.git --depth 1
+  - cmd: git clone --depth 1 --quiet https://github.com/zeromq/libzmq.git
   - cmd: set LIBZMQ_BUILDDIR=C:\projects\build_libzmq\%Platform%\%Configuration%
   - cmd: md "%LIBZMQ_BUILDDIR%"
   - cmd: cd "%LIBZMQ_BUILDDIR%"
-  - ps: $blockRdp = $true;
   - cmd: cmake -D CMAKE_CXX_FLAGS_RELEASE="/MT" -D CMAKE_CXX_FLAGS_DEBUG="/MTd" -G "%CMAKE_GENERATOR%" C:\projects\libzmq
   - cmd: msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration% libzmq.vcxproj #zeromq.sln
   - cmd: set ZEROMQ_INCLUDE_DIRS="C:\projects\libzmq\include"
@@ -74,7 +80,8 @@ after_build:
   - cmd: copy "%LIBZMQ_BUILDDIR%\bin\%Configuration%\libzmq-*dll" .
   - cmd: 7z a -y -bd -mx=9 czmq.zip czmq_selftest.exe czmq.dll libzmq-*.dll
   - ps: Push-AppveyorArtifact "czmq.zip" -Filename "czmq-${env:Platform}-${env:Configuration}.zip"
-  - cmd: czmq_selftest # -v
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - cmd: python %APPVEYOR_BUILD_FOLDER%\src\timeout.py -f "Tests passed OK" 60 czmq_selftest #-- -v
 
 test:
   none

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ init:
   #Put this line somewhere when you want to debug something using rdp
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   #- set #debug: view all environment variables
-  - ps: Update-AppveyorBuild -Version "git-$($env:appveyor_repo_commit.substring(0,8))"
   - cmake --version
   - msbuild /version
   - cmd: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import platform
+import sys
+import time
+
+WINDOWS = platform.system() == 'Windows'
+
+if WINDOWS:
+  from winpexpect import winspawn as spawn
+  import winpexpect as pexpect
+  import win32gui, win32process
+  WINDOWS = True
+else:
+  from pexpect import spawn
+  import pexpect
+args = sys.argv[1:]
+
+parser = argparse.ArgumentParser(description='Run PROGRAM for limited amount of time')
+parser.add_argument('timeout', metavar='TIMEOUT', type=int, help='Timeout in seconds')
+parser.add_argument('program', metavar='PROGRAM', type=str, help='Program to execute')
+parser.add_argument('-f', dest='final', metavar='FINAL_STRING', type=str, help='Final string')
+parser.add_argument('arguments', metavar='ARGS', type=str, nargs='*', help='Arguments for program')
+
+args = parser.parse_args()
+
+print('Running "{0}" for a maximum time of {1} seconds.'.format(args.program, args.timeout))
+p = spawn(args.program, args.arguments)
+start = time.time()
+timeout = False
+finalseen = False
+try:
+  while True:
+    p.expect('\n', start + args.timeout - time.time())
+    data = p.before
+    if isinstance(data, bytes):
+      data = data.decode('string_escape' if sys.version_info < (3, 0) else 'unicode_escape')
+    print(data)
+    if args.final and args.final in data:
+      finalseen = True
+except pexpect.EOF:
+  pass
+except pexpect.TIMEOUT:
+  timeout = True
+
+if WINDOWS:
+  def WindowIsVisible(pid):
+    def enumHandler(hwnd, data):
+      if (win32process.GetWindowThreadProcessId(hwnd)[1] == data[0] and
+            win32gui.IsWindowVisible(hwnd)):
+        data[1] = True
+
+    data = [pid, False]
+    win32gui.EnumWindows(enumHandler, data)
+    return data[1]
+
+  if WindowIsVisible(p.child_handle):
+    print('The program created a window!')
+
+if timeout:
+  print('{0}: timeout hit ({1}s)'.format(args.program, args.timeout))
+  p.terminate()
+  if finalseen:
+    sys.exit(1)
+
+print('Program finished')
+p.terminate()


### PR DESCRIPTION
This fixes my last Windows CI PR.
False detection of a non-finishing test will not cause a failed test.

Anyhow, czmq_selftest has some issues.
- On Windows, not all output is redirected into the web log (no subtest is shown at all)
- Assertion errors on windows are not shown in the web log
- On Linux, redirection of the output of czmq_test will also nog show all output. (#1129)

On my system, the second one will not show all output. Maybe the issues are related.