### PR TITLE
Problem: various sources have whitespace issues

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -235,7 +235,7 @@ zcert_load (const char *filename)
             //  Load metadata into certificate
             self = zcert_new_from (public_key, secret_key);
             zconfig_t *metadata = zconfig_locate (root, "/metadata");
-            zconfig_t *item = metadata ? zconfig_child (metadata) : NULL;
+            zconfig_t *item = metadata? zconfig_child (metadata): NULL;
             while (item) {
                 zcert_set_meta (self, zconfig_name (item), zconfig_value (item));
                 item = zconfig_next (item);

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -696,7 +696,7 @@ s_on_read_timer (zloop_t *loop, int timer_id, void *arg)
                 zsys_info ("zdir_watch: Found %d changes in %s:", zlist_size (diff), zdir_path (sub->dir));
                 while (patch)
                 {
-                    zsys_info ("zdir_watch:   %s %s", zfile_filename (zdir_patch_file (patch), NULL), zdir_patch_op (patch) == ZDIR_PATCH_CREATE ? "created" : "deleted");
+                    zsys_info ("zdir_watch:   %s %s", zfile_filename (zdir_patch_file (patch), NULL), zdir_patch_op (patch) == ZDIR_PATCH_CREATE? "created": "deleted");
                     patch = (zdir_patch_t *) zlist_next (diff);
                 }
             }

--- a/src/zdir_patch.c
+++ b/src/zdir_patch.c
@@ -112,7 +112,7 @@ zdir_patch_dup (zdir_patch_t *self)
                 copy->vpath = strdup (self->vpath);
             if (copy->vpath)
                 //  Don't recalculate hash when we duplicate patch
-                copy->digest = self->digest ? strdup (self->digest) : NULL;
+                copy->digest = self->digest? strdup (self->digest): NULL;
 
             if (copy->digest == NULL && copy->op != patch_delete)
                 zdir_patch_destroy (&copy);

--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -260,7 +260,7 @@ zhashx_insert (zhashx_t *self, const void *key, void *value)
             return -1;
         self->chain_limit += CHAIN_GROWS;
     }
-    return s_item_insert (self, key, value) ? 0 : -1;
+    return s_item_insert (self, key, value)? 0: -1;
 }
 
 

--- a/src/zlist.c
+++ b/src/zlist.c
@@ -134,7 +134,7 @@ void *
 zlist_head (zlist_t *self)
 {
     assert (self);
-    return self->head ? self->head->item : NULL;
+    return self->head? self->head->item: NULL;
 }
 
 
@@ -146,7 +146,7 @@ void *
 zlist_tail (zlist_t *self)
 {
     assert (self);
-    return self->tail ? self->tail->item : NULL;
+    return self->tail? self->tail->item: NULL;
 }
 
 

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -217,7 +217,7 @@ void *
 zlistx_head (zlistx_t *self)
 {
     assert (self);
-    return self->head ? self->head->item : NULL;
+    return self->head? self->head->item: NULL;
 }
 
 
@@ -230,7 +230,7 @@ void *
 zlistx_tail (zlistx_t *self)
 {
     assert (self);
-    return self->head ? self->head->prev->item : NULL;
+    return self->head? self->head->prev->item: NULL;
 }
 
 

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -829,8 +829,8 @@ zloop_start (zloop_t *self)
                 && !poller->tolerant) {
                     if (self->verbose)
                         zsys_warning ("zloop: can't poll %s socket (%p, %d): %s",
-                                      poller->item.socket ?
-                                      zsys_sockname (zsock_type (poller->item.socket)) : "FD",
+                                      poller->item.socket?
+                                      zsys_sockname (zsock_type (poller->item.socket)): "FD",
                                       poller->item.socket, poller->item.fd,
                                       zmq_strerror (zmq_errno ()));
                     //  Give handler one chance to handle error, then kill
@@ -846,8 +846,8 @@ zloop_start (zloop_t *self)
                 if (self->pollset [item_nbr].revents) {
                     if (self->verbose)
                         zsys_debug ("zloop: call %s socket handler (%p, %d)",
-                                    poller->item.socket ?
-                                    zsys_sockname (zsock_type (poller->item.socket)) : "FD",
+                                    poller->item.socket?
+                                    zsys_sockname (zsock_type (poller->item.socket)): "FD",
                                     poller->item.socket, poller->item.fd);
                     rc = poller->handler (self, &self->pollset [item_nbr], poller->arg);
                     if (rc == -1 || self->need_rebuild)

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -143,8 +143,7 @@ zmsg_send (zmsg_t **self_p, void *dest)
         zframe_t *frame;
         while ((frame = (zframe_t *) zlist_head (self->frames))) {
             rc = zframe_send (&frame, dest,
-                              zlist_size (self->frames) > 1 ?
-                                      ZFRAME_MORE : 0);
+                              zlist_size (self->frames) > 1? ZFRAME_MORE: 0);
             if (rc != 0) {
                 if (errno == EINTR && sent_some)
                     continue;

--- a/src/zmutex.c
+++ b/src/zmutex.c
@@ -120,11 +120,11 @@ zmutex_try_lock (zmutex_t *self)
 #if defined (__UNIX__)
     //  rc is either EBUSY or 0
     int rc = pthread_mutex_trylock (&self->mutex);
-    return rc == EBUSY ? 0 : 1;
+    return rc == EBUSY? 0: 1;
 #elif defined (__WINDOWS__)
     //  rc is nonzero if the mutex lock has been acquired
     int rc = TryEnterCriticalSection (&self->mutex);
-    return rc != 0 ? 1 : 0;
+    return rc != 0? 1: 0;
 #endif
 }
 

--- a/src/zproxy_v2.c
+++ b/src/zproxy_v2.c
@@ -154,10 +154,10 @@ s_proxy_task (void *args, zctx_t *ctx, void *command_pipe)
         int send_flags;         //  Flags for outgoing message
 
         if (which && zmq_recvmsg (which, &msg, 0) != -1) {
-            send_flags = zsocket_rcvmore (which) ? ZMQ_SNDMORE : 0;
+            send_flags = zsocket_rcvmore (which)? ZMQ_SNDMORE: 0;
             if (which == self->frontend || which == self->backend) {
-                void *output = which == self->frontend ?
-                               self->backend : self->frontend;
+                void *output = which == self->frontend?
+                               self->backend: self->frontend;
 
                 //  Loop on all waiting messages, since polling adds a
                 //  non-trivial cost per message, especially on OS/X
@@ -175,7 +175,7 @@ s_proxy_task (void *args, zctx_t *ctx, void *command_pipe)
                     }
                     if (zmq_recvmsg (which, &msg, ZMQ_DONTWAIT) == -1)
                         break;      //  Presumably EAGAIN
-                    send_flags = zsocket_rcvmore (which) ? ZMQ_SNDMORE : 0;
+                    send_flags = zsocket_rcvmore (which)? ZMQ_SNDMORE: 0;
                 }
             }
             else

--- a/src/zsocket.c
+++ b/src/zsocket.c
@@ -181,8 +181,8 @@ zsocket_sendmem (void *self, const void *data, size_t size, int flags)
     assert (self);
     assert (size == 0 || data);
 
-    int snd_flags = (flags & ZFRAME_MORE) ? ZMQ_SNDMORE : 0;
-    snd_flags |= (flags & ZFRAME_DONTWAIT) ? ZMQ_DONTWAIT : 0;
+    int snd_flags = (flags & ZFRAME_MORE)? ZMQ_SNDMORE: 0;
+    snd_flags |= (flags & ZFRAME_DONTWAIT)? ZMQ_DONTWAIT: 0;
 
     zmq_msg_t msg;
     zmq_msg_init_size (&msg, size);

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -42,7 +42,7 @@ s_send_string (void *dest, bool more, char *string)
     zmq_msg_t message;
     zmq_msg_init_size (&message, len);
     memcpy (zmq_msg_data (&message), string, len);
-    if (zmq_sendmsg (handle, &message, more ? ZMQ_SNDMORE : 0) == -1) {
+    if (zmq_sendmsg (handle, &message, more? ZMQ_SNDMORE: 0) == -1) {
         zmq_msg_close (&message);
         return -1;
     }
@@ -88,7 +88,7 @@ int
 zstr_send (void *dest, const char *string)
 {
     assert (dest);
-    return s_send_string (dest, false, string ? (char *) string : "");
+    return s_send_string (dest, false, string? (char *) string: "");
 }
 
 

--- a/src/ztrie.c
+++ b/src/ztrie.c
@@ -145,7 +145,7 @@ s_ztrie_node_new (ztrie_node_t *parent, char *token, int token_len, zlistx_t *pa
         //  Sort regexes to the end to avoid conlficts
         zlistx_sort (self->parent->children);
     }
-    size_t parent_path_len = self->parent ? self->parent->path_len : 0;
+    size_t parent_path_len = self->parent? self->parent->path_len: 0;
     self->path_len = parent_path_len + strlen (self->token) + 1; // +1 path delimiter
     self->children = zlistx_new ();
     zlistx_set_comparator (self->children, s_ztrie_node_compare);
@@ -360,10 +360,10 @@ s_ztrie_parse_path (ztrie_t *self, char *path, int mode)
             //  Token ends with delimiter.
             else
             if (state < 3) {
-                int matchType = zlistx_size (self->params) > 0 ? NODE_TYPE_PARAM :
-                                    beginRegex ? NODE_TYPE_REGEX : NODE_TYPE_STRING;
-                char *matchToken = beginRegex ? beginRegex : beginToken;
-                int matchTokenLen = needle - matchToken - (beginRegex ? 1 : 0);
+                int matchType = zlistx_size (self->params) > 0? NODE_TYPE_PARAM:
+                                    beginRegex? NODE_TYPE_REGEX: NODE_TYPE_STRING;
+                char *matchToken = beginRegex? beginRegex: beginToken;
+                int matchTokenLen = needle - matchToken - (beginRegex? 1: 0);
                 //  Illegal token
                 if (matchTokenLen == 0)
                     return NULL;
@@ -380,10 +380,10 @@ s_ztrie_parse_path (ztrie_t *self, char *path, int mode)
                         return NULL;
                 }
                 else {
-                    matchType = zlistx_size (self->params) > 0 ? NODE_TYPE_PARAM :
-                                        beginRegex ? NODE_TYPE_REGEX : NODE_TYPE_STRING;
-                    matchToken = beginRegex ? beginRegex : beginToken;
-                    matchTokenLen = needle - matchToken - (beginRegex ? 1 : 0);
+                    matchType = zlistx_size (self->params) > 0? NODE_TYPE_PARAM:
+                                        beginRegex? NODE_TYPE_REGEX: NODE_TYPE_STRING;
+                    matchToken = beginRegex? beginRegex: beginToken;
+                    matchTokenLen = needle - matchToken - (beginRegex? 1: 0);
                 }
 
                 //  In insert and lookup mode only do a string comparison
@@ -517,7 +517,7 @@ ztrie_matches (ztrie_t *self, char *path)
 {
     assert (self);
     self->match = s_ztrie_parse_path (self, path, MODE_MATCH);
-    return self->match ? true : false;
+    return self->match? true: false;
 }
 
 
@@ -610,11 +610,9 @@ s_ztrie_print_tree_line (ztrie_node_t *self, bool isEOL)
                 printf ("\u2502   ");
         }
         if (isEOL) {
-            char *isEndpoint = self->endpoint ? "true" : "false";
-            printf ("%s (params: %zu, endpoint: %s, type: %d)\n", self->token,
-                                                                 self->parameter_count,
-                                                                 isEndpoint,
-                                                                 self->token_type);
+            char *isEndpoint = self->endpoint? "true": "false";
+            printf ("%s (params: %zu, endpoint: %s, type: %d)\n",
+                self->token, self->parameter_count, isEndpoint, self->token_type);
         }
     }
 }


### PR DESCRIPTION
CLASS specifies "condition? first: second" yet various sources
use "condition ? first : second".

Solution: fix the code.

Argument: in CLASS, punctuation sticks to the rules for written
English where possible. So:

 phrase;     not phrase ;
 (phrase)    not ( phrase )
 [phrase]    not [ phrase ]
 1 + 2       not 1+2
 a? b: c     not a ? b : c