### PR TITLE
Problem: several sources break style with CLASS

### DIFF
--- a/src/zarmour.c
+++ b/src/zarmour.c
@@ -681,6 +681,7 @@ s_armour_test_long (zarmour_t *self, byte *test_data, size_t length, bool verbos
 {
     if (verbose)
         zarmour_print (self);
+
     char *test_string = zarmour_encode (self, test_data, length);
     assert (test_string);
     if (verbose)
@@ -690,10 +691,10 @@ s_armour_test_long (zarmour_t *self, byte *test_data, size_t length, bool verbos
     free (test_string);
     assert (test_data2);
     assert (test_size == length + 1);
-    unsigned int i;
-    for (i = 0; i < length; ++i) {
-        assert (test_data2[i] == i);
-    }
+    unsigned int index;
+    for (index = 0; index < length; index++)
+        assert (test_data2 [index] == index);
+
     free (test_data2);
     if (verbose)
         zsys_debug ("    decoded %d bytes, all match", test_size - 1);
@@ -753,6 +754,7 @@ zarmour_test (bool verbose)
     zarmour_set_pad (self, true);
     if (verbose)
         zarmour_print (self);
+
     s_armour_test (self, "", "", verbose);
     s_armour_test (self, "f", "Zg==", verbose);
     s_armour_test (self, "fo", "Zm8=", verbose);
@@ -899,10 +901,10 @@ zarmour_test (bool verbose)
     zarmour_set_pad (self, true);
     zarmour_set_line_breaks (self, true);
     byte test_data[256];
-    int i;
-    for (i = 0; i < 256; ++i) {
-        test_data[i] = i;
-    }
+    int index;
+    for (index = 0; index < 256; index++)
+        test_data [index] = index;
+
     zarmour_set_mode (self, ZARMOUR_MODE_BASE64_STD);
     s_armour_test_long (self, test_data, 256, verbose);
     zarmour_set_mode (self, ZARMOUR_MODE_BASE64_URL);

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -62,7 +62,8 @@ s_self_destroy (self_t **self_p)
         zsock_destroy (&self->frontend);
         zsock_destroy (&self->backend);
         zsock_destroy (&self->capture);
-        for (int index = 0; index < SOCKETS; index++) {
+        int index;
+        for (index = 0; index < SOCKETS; index++) {
             zstr_free (&self->domain [index]);
             zstr_free (&self->public_key [index]);
             zstr_free (&self->secret_key [index]);

--- a/src/ztrie.c
+++ b/src/ztrie.c
@@ -129,9 +129,10 @@ s_ztrie_node_new (ztrie_node_t *parent, char *token, int token_len, zlistx_t *pa
         self->parameter_names = (char **) malloc (sizeof (char *) * self->parameter_count);
         self->parameter_values = (char **) malloc (sizeof (char *) * self->parameter_count);
         char *key = (char *) zlistx_first (param_keys);
-        for (int i = 0; i < zlistx_size (param_keys); i++) {
-            self->parameter_names [i] = key;
-            self->parameter_values [i] = NULL;
+        int index;
+        for (index = 0; index < zlistx_size (param_keys); index++) {
+            self->parameter_names [index] = key;
+            self->parameter_values [index] = NULL;
             key = (char *) zlistx_next (param_keys);
         }
     }
@@ -167,10 +168,11 @@ s_ztrie_node_destroy (ztrie_node_t **self_p)
         zstr_free (&self->token);
         zstr_free (&self->asterisk_match);
         if (self->parameter_count > 0) {
-            for (int i = 0; i < self->parameter_count; i++) {
-                free (self->parameter_names [i]);
-                if (self->parameter_values [i])
-                    free (self->parameter_values [i]);
+            int index;
+            for (index = 0; index < self->parameter_count; index++) {
+                free (self->parameter_names [index]);
+                if (self->parameter_values [index])
+                    free (self->parameter_values [index]);
             }
             free (self->parameter_names);
             free (self->parameter_values);
@@ -273,7 +275,6 @@ s_ztrie_compare_token (ztrie_node_t *parent, char *token, int len)
 static ztrie_node_t *
 s_ztrie_matches_token (ztrie_node_t *parent, char *token, int len)
 {
-    unsigned int i;
     char firstbyte = *token;
     ztrie_node_t *child = (ztrie_node_t *) zlistx_first (parent->children);
     while (child) {
@@ -299,9 +300,11 @@ s_ztrie_matches_token (ztrie_node_t *parent, char *token, int len)
                     if (zrex_hits (child->regex) == 1)
                         s_ztrie_node_update_param (child, 1, zrex_hit (child->regex, 0));
                     else
-                    if (zrex_hits (child->regex) > 1)
-                        for (i = 1; i < zrex_hits (child->regex); i++)
-                            s_ztrie_node_update_param (child, i, zrex_hit (child->regex, i));
+                    if (zrex_hits (child->regex) > 1) {
+                        int index;
+                        for (index = 1; index < zrex_hits (child->regex); index++)
+                            s_ztrie_node_update_param (child, index, zrex_hit (child->regex, index));
+                    }
                 }
                 free (token_term);
                 return child;
@@ -564,10 +567,11 @@ ztrie_hit_parameters (ztrie_t *self)
         zhashx_t *route_parameters = zhashx_new ();
         ztrie_node_t *node = self->match;
         while (node) {
-            for (int i = 0; i < node->parameter_count; i++)
+            int index;
+            for (index = 0; index < node->parameter_count; index++)
                 zhashx_insert (route_parameters,
-                              node->parameter_names [i],
-                              (void *) node->parameter_values [i]);
+                               node->parameter_names [index],
+                               (void *) node->parameter_values [index]);
             node = node->parent;
         }
         return route_parameters;


### PR DESCRIPTION
Specifically:

* they use inline declarations in for loops, which is not standard C
* they use the variable name 'i' in loops, which is banned

I've no idea how the inline declarations are passing. Perhaps someone
has tweaked zproject to allow this on gcc. On MSVC since we use C++
it will not be caught.

Solution: fix the sources.