### PR TITLE
Problem: bindings do not run on Python 3

### DIFF
--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -122,24 +122,60 @@ class zuuid_t(Structure):
     pass # Empty - only for type checking
 zuuid_p = POINTER(zuuid_t)
 
-PyFile_FromFile_close_cb = CFUNCTYPE(c_int, FILE_p)
-PyFile_FromFile = pythonapi.PyFile_FromFile
-PyFile_FromFile.restype = py_object
-PyFile_FromFile.argtypes = [FILE_p,
-                            c_char_p,
-                            c_char_p,
-                            PyFile_FromFile_close_cb]
 def return_py_file(c_file):
-    return PyFile_FromFile(c_file, "", "r+", PyFile_FromFile_close_cb())
+    if not sys.version_info > (3,):
+        PyFile_FromFile_close_cb = CFUNCTYPE(c_int, FILE_p)
+        PyFile_FromFile = pythonapi.PyFile_FromFile
+        PyFile_FromFile.restype = py_object
+        PyFile_FromFile.argtypes = [FILE_p,
+                                    c_char_p,
+                                    c_char_p,
+                                    PyFile_FromFile_close_cb]
+        return PyFile_FromFile(c_file, "", "r+", PyFile_FromFile_close_cb())
 
-PyFile_AsFile = pythonapi.PyFile_AsFile
-PyFile_AsFile.restype = FILE_p
-PyFile_AsFile.argtypes = [py_object]
-def coerce_py_file(obj):
-    if isinstance(obj, FILE_p):
-        return obj
     else:
-        return PyFile_AsFile(obj)
+        fileno = libc.fileno
+        fileno.restype = c_int
+        fileno.argtypes = [c_void_p]
+
+        return os.fdopen(fileno(c_file), r'r+b')
+
+def coerce_py_file(obj):
+    if not sys.version_info > (3,):
+        PyFile_AsFile = pythonapi.PyFile_AsFile
+        PyFile_AsFile.restype = FILE_p
+        PyFile_AsFile.argtypes = [py_object]
+
+        if isinstance(obj, FILE_p):
+            return obj
+        else:
+            return PyFile_AsFile(obj)
+
+    # Python 3 does not provide a low level buffered I/O (FILE*) API. Had to
+    # resort to direct Standard C library calls.
+    #
+    #   https://docs.python.org/3/c-api/file.html.
+    #
+    else:
+        fdopen = libc.fdopen
+        fdopen.restype = FILE_p
+        fdopen.argtypes = [c_int, c_char_p]
+
+        setbuf = libc.setbuf
+        setbuf.restype = None
+        setbuf.argtypes = [FILE_p, c_char_p]
+
+        if isinstance(obj, FILE_p):
+            return obj
+        else:
+            fd = obj.fileno()
+            fp = fdopen(fd, obj.mode.encode())
+
+            # Make sure the file is opened in unbuffered mode. The test case
+            # "test_zmsg" of the CZMQ Python fails if this mode is not set.
+            setbuf(fp, None)
+
+            return fp
 
 
 # zactor

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -4,6 +4,14 @@ import sys, os, time
 from ctypes import *
 from czmq import *
 
+# http://python3porting.com/problems.html#common-migration-problems
+PY3 = sys.version_info > (3,)
+
+if PY3:
+    # Python 3 does not have a "cmp" builtin.
+    def cmp(a, b):
+        return (a > b) - (a < b)
+
 # Part test, part example of how to use python bindings.
 # Note the del statements are just to explicitly test functionality, it is generally not required.
 
@@ -11,21 +19,21 @@ class TestCZMQ(unittest.TestCase):
     verbose = int(os.environ.get('VERBOSE', '0'))
 
     def test_zdir(self):
-        older = Zdir('.', None)
+        older = Zdir(b'.', None)
         self.assertTrue(older)
         if self.verbose:
             older.print(0)
 
-        newer = Zdir('..', None)
+        newer = Zdir(b'..', None)
         self.assertTrue(newer)
 
-        patches = Zdir.diff(older, newer, '/')
+        patches = Zdir.diff(older, newer, b'/')
         self.assertTrue(patches)
 
         while patches.size():
             patch = ZdirPatch(patches.pop(), True)
 
-        nosuch = Zdir("does-not-exist", None)
+        nosuch = Zdir(b"does-not-exist", None)
         self.assertFalse(nosuch)
 
         # zdir_watch test:
@@ -33,34 +41,42 @@ class TestCZMQ(unittest.TestCase):
         self.assertTrue(watch)
 
         if self.verbose:
-            watch.sock().send("s", "VERBOSE")
-            self.assertEquals(watch.wait(), 0)
+            watch.sock().send(b"s", b"VERBOSE")
+            self.assertEqual(watch.wait(), 0)
 
         # need to create a file in the test directory we're watching
         # in order to ensure the directory exists
-        initfile = Zfile("./zdir-test-dir", "initial_file")
+        initfile = Zfile(b"./zdir-test-dir", b"initial_file")
         self.assertTrue(initfile)
         initfile.output()
-        initfile.handle().write("initial file\n")
+        if PY3:
+            with initfile.handle() as hdl:  # Avoid ResourceWarning: unclosed file.
+                hdl.write(b"initial file\n")
+        else:
+            initfile.handle().write(b"initial file\n")
         initfile.close()
 
         time.sleep(1.001) # wait for initial file to become 'stable'
 
-        watch.sock().send("si", "TIMEOUT", 100)
-        self.assertEquals(watch.sock().wait(), 0)
+        watch.sock().send(b"si", b"TIMEOUT", 100)
+        self.assertEqual(watch.sock().wait(), 0)
 
-        watch.sock().send("ss", "SUBSCRIBE", "zdir-test-dir")
-        self.assertEquals(watch.sock().wait(), 0)
+        watch.sock().send(b"ss", b"SUBSCRIBE", b"zdir-test-dir")
+        self.assertEqual(watch.sock().wait(), 0)
 
-        watch.sock().send("ss", "UNSUBSCRIBE", "zdir-test-dir")
-        self.assertEquals(watch.sock().wait(), 0)
+        watch.sock().send(b"ss", b"UNSUBSCRIBE", b"zdir-test-dir")
+        self.assertEqual(watch.sock().wait(), 0)
 
-        watch.sock().send("ss", "SUBSCRIBE", "zdir-test-dir")
-        self.assertEquals(watch.sock().wait(), 0)
+        watch.sock().send(b"ss", b"SUBSCRIBE", b"zdir-test-dir")
+        self.assertEqual(watch.sock().wait(), 0)
 
-        newfile = Zfile("zdir-test-dir", "test_abc")
+        newfile = Zfile(b"zdir-test-dir", b"test_abc")
         newfile.output()
-        newfile.handle().write("test file\n")
+        if PY3:
+            with newfile.handle() as hdl:  # Avoid ResourceWarning: unclosed file.
+                hdl.write(b"test file\n")
+        else:
+            newfile.handle().write(b"test file\n")
         newfile.close()
 
         #watch_poll = Zpoller(watch, None)
@@ -71,20 +87,20 @@ class TestCZMQ(unittest.TestCase):
         # wait for notification of the file being added
         path = c_char_p()
         patches = zlist_p()
-        rc = watch.sock().recv("sp", byref(path), byref(patches))
-        self.assertEquals(rc, 0)
+        rc = watch.sock().recv(b"sp", byref(path), byref(patches))
+        self.assertEqual(rc, 0)
         patches = Zlist(patches, True)
 
-        self.assertEquals(string_at(path), "zdir-test-dir")
+        self.assertEqual(string_at(path), b"zdir-test-dir")
         libc.free (path)
 
-        self.assertEquals(patches.size(), 1)
+        self.assertEqual(patches.size(), 1)
 
         patch = ZdirPatch(patches.pop(), True)
-        self.assertEquals(patch.path(), "zdir-test-dir")
+        self.assertEqual(patch.path(), b"zdir-test-dir")
 
         patch_file = patch.file()
-        self.assertEquals(patch_file.filename(""), "zdir-test-dir/test_abc")
+        self.assertEqual(patch_file.filename(b""), b"zdir-test-dir/test_abc")
 
         del patch
         del patches
@@ -99,20 +115,20 @@ class TestCZMQ(unittest.TestCase):
         # wait for notification of the file being removed
         path = c_char_p()
         patches = zlist_p()
-        rc = watch.sock().recv("sp", byref(path), byref(patches))
-        self.assertEquals(rc, 0)
+        rc = watch.sock().recv(b"sp", byref(path), byref(patches))
+        self.assertEqual(rc, 0)
         patches = Zlist(patches, True)
 
-        self.assertEquals(string_at(path), "zdir-test-dir")
+        self.assertEqual(string_at(path), b"zdir-test-dir")
         libc.free (path)
 
-        self.assertEquals(patches.size(), 1)
+        self.assertEqual(patches.size(), 1)
 
         patch = ZdirPatch(patches.pop(), True)
-        self.assertEquals(patch.path(), "zdir-test-dir")
+        self.assertEqual(patch.path(), b"zdir-test-dir")
 
         patch_file = patch.file()
-        self.assertEquals(patch_file.filename(""), "zdir-test-dir/test_abc")
+        self.assertEqual(patch_file.filename(b""), b"zdir-test-dir/test_abc")
 
         del patch
         del patches
@@ -121,51 +137,51 @@ class TestCZMQ(unittest.TestCase):
         del watch
 
         # clean up by removing the test directory.
-        testdir = Zdir("zdir-test-dir", None)
+        testdir = Zdir(b"zdir-test-dir", None)
         testdir.remove(True)
         del testdir
 
     def test_zdir_patch(self):
-        file = Zfile(".", "bilbo")
+        file = Zfile(b".", b"bilbo")
         self.assertTrue(file)
-        patch = ZdirPatch(".", file, 'create', "/")
+        patch = ZdirPatch(b".", file, 'create', b"/")
         self.assertTrue(patch)
         del file
 
         file = patch.file()
         self.assertTrue(file)
-        self.assertEquals(file.filename("."), "bilbo")
-        self.assertEquals(patch.vpath(), "/bilbo")
+        self.assertEqual(file.filename(b"."), b"bilbo")
+        self.assertEqual(patch.vpath(), b"/bilbo")
         del patch
 
     def test_zfile(self):
-        file = Zfile(None, "bilbo")
+        file = Zfile(None, b"bilbo")
         self.assertTrue(file)
-        self.assertEquals(file.filename("."), "bilbo")
+        self.assertEqual(file.filename(b"."), b"bilbo")
         self.assertFalse(file.is_readable())
         del file
 
         # Create a test file in some random subdirectory
-        file = Zfile("./this/is/a/test", "bilbo")
+        file = Zfile(b"./this/is/a/test", b"bilbo")
         self.assertTrue(file)
-        self.assertEquals(file.output(), 0)
+        self.assertEqual(file.output(), 0)
         #chunk = Zchunk.new(None, 100)
         #self.assertTrue(chunk)
         #chunk.fill(0, 100)
 
         # Write 100 bytes at position 1,000,000 in the file
-        #self.assertEquals(file.write(chunk, 1000000), 0)
+        #self.assertEqual(file.write(chunk, 1000000), 0)
         #del chunk
         file.close()
         self.assertTrue(file.is_readable())
-        #self.assertEquals(file.cursize(), 1000100)
+        #self.assertEqual(file.cursize(), 1000100)
         #self.assertFalse(file.is_stable())
         self.assertTrue(file.digest())
 
         # Now truncate file from outside
-        f = open('./this/is/a/test/bilbo', 'w')
+        f = open('./this/is/a/test/bilbo', 'wb')
         f.truncate()
-        f.write("Hello, World\n")
+        f.write(b"Hello, World\n")
         f.close()
         del f
 
@@ -179,113 +195,118 @@ class TestCZMQ(unittest.TestCase):
         self.assertTrue(file.is_stable())
         self.assertFalse(file.has_changed())
 
-        self.assertEquals(file.digest(), "4AB299C8AD6ED14F31923DD94F8B5F5CB89DFB54")
+        self.assertEqual(file.digest(), b"4AB299C8AD6ED14F31923DD94F8B5F5CB89DFB54")
 
         # Check we can read from file
-        self.assertEquals(file.input(), 0)
+        self.assertEqual(file.input(), 0)
         #chunk = file.read(1000100, 0)
         #self.assertTrue(chunk)
-        #self.assertEquals(chunk.size(), 13)
+        #self.assertEqual(chunk.size(), 13)
         #del chunk
         file.close()
 
         # Check we can read lines from file
-        self.assertEquals(file.input(), 0)
+        self.assertEqual(file.input(), 0)
         line = file.readln()
-        self.assertEquals(line, "Hello, World")
+        self.assertEqual(line, b"Hello, World")
         line = file.readln()
         self.assertIsNone(line)
         file.close()
 
         # Try some fun with symbolic links
-        link = Zfile("./this/is/a/test", "bilbo.ln")
+        link = Zfile(b"./this/is/a/test", b"bilbo.ln")
         self.assertTrue(link)
-        self.assertEquals(link.output(), 0)
-        link.handle().write("./this/is/a/test/bilbo\n")
+        self.assertEqual(link.output(), 0)
+        if PY3:
+            with link.handle() as hdl:  # Avoid ResourceWarning: unclosed file.
+                hdl.write(b"./this/is/a/test/bilbo\n")
+        else:
+            link.handle().write(b"./this/is/a/test/bilbo\n")
+
         del link
 
-        link = Zfile("./this/is/a/test", "bilbo.ln")
+        link = Zfile(b"./this/is/a/test", b"bilbo.ln")
         self.assertTrue(link)
         self.assertEqual(link.input(), 0)
         #chunk = link.read(1000100, 0)
         #self.assertTrue(chunk)
-        #self.assertEquals(chunk.size(), 13)
+        #self.assertEqual(chunk.size(), 13)
         #del chunk
         del link
 
         # Remove file and directory
-        dir = Zdir("./this", None)
+        dir = Zdir(b"./this", None)
         self.assertTrue(dir)
-        self.assertEquals(dir.cursize(), 26)
+        self.assertEqual(dir.cursize(), 26)
         dir.remove(True)
-        self.assertEquals(dir.cursize(), 0)
+        self.assertEqual(dir.cursize(), 0)
         del dir
 
         # Check we can no longer read from file
         self.assertTrue(file.is_readable())
         file.restat()
         self.assertFalse(file.is_readable())
-        self.assertEquals(file.input(), -1)
+        self.assertEqual(file.input(), -1)
         del file
 
     def test_zframe(self):
         # Create two PAIR sockets and connect over inproc
-        output = Zsock.new_pair ("@inproc://zframe.test")
+        output = Zsock.new_pair (b"@inproc://zframe.test")
         self.assertTrue(output)
-        input = Zsock.new_pair (">inproc://zframe.test")
+        input = Zsock.new_pair (b">inproc://zframe.test")
         self.assertTrue(input)
 
         # Send five different frames, test Zframe.MORE
-        for frame_nbr in xrange(5):
-            frame = Zframe("Hello", 5)
+        for frame_nbr in range(5):
+            frame = Zframe(b"Hello", 5)
             self.assertTrue(frame)
-            self.assertEquals(Zframe.send(frame, output, Zframe.MORE), 0)
+            self.assertEqual(Zframe.send(frame, output, Zframe.MORE), 0)
 
         # Send same frame five times, test ZFRAME_REUSE
-        frame = Zframe("Hello", 5)
+        frame = Zframe(b"Hello", 5)
         self.assertTrue(frame)
-        for frame_nbr in xrange(5):
-            self.assertEquals(Zframe.send(frame, output, Zframe.MORE + Zframe.REUSE), 0)
+        for frame_nbr in range(5):
+            self.assertEqual(Zframe.send(frame, output, Zframe.MORE + Zframe.REUSE), 0)
         self.assertTrue(frame)
         copy = frame.dup()
         self.assertTrue(frame.eq(copy))
-        self.assertEquals(copy.size(), 5)
+        self.assertEqual(copy.size(), 5)
         del copy
         self.assertFalse(frame.eq(None))
 
         # Test zframe_new_empty
         frame = Zframe.new_empty()
         self.assertTrue(frame)
-        self.assertEquals(frame.size(), 0)
+        self.assertEqual(frame.size(), 0)
         del frame
 
         # Send END frame
-        frame = Zframe("NOT", 3)
+        frame = Zframe(b"NOT", 3)
         self.assertTrue(frame)
-        frame.reset("END", 3)
+        frame.reset(b"END", 3)
         string = frame.strhex()
-        self.assertEquals(string, "454E44")
+        self.assertEqual(string, b"454E44")
         string = frame.strdup()
-        self.assertEquals(string, "END")
-        self.assertEquals(Zframe.send(frame, output, 0), 0)
+        self.assertEqual(string, b"END")
+        self.assertEqual(Zframe.send(frame, output, 0), 0)
 
         # Read and count until we receive END
         frame_nbr = 0
         while True:
             frame = Zframe.recv(input)
-            if frame.streq("END"):
+            if frame.streq(b"END"):
                 break
 
             self.assertTrue(frame.more())
             frame.set_more(0)
-            self.assertEquals(frame.more(), 0)
+            self.assertEqual(frame.more(), 0)
             frame_nbr += 1
-        self.assertEquals(frame_nbr, 10)
+        self.assertEqual(frame_nbr, 10)
 
     def test_zhash(self):
         hash = Zhash()
         self.assertTrue(hash)
-        self.assertEquals(hash.size(), 0)
+        self.assertEqual(hash.size(), 0)
         self.assertFalse(hash.first())
         self.assertFalse(hash.cursor())
 
@@ -293,93 +314,93 @@ class TestCZMQ(unittest.TestCase):
         # Note the bindings for zhash are pretty pointless for actually storing
         # things - we have to keep our ctypes buffer objects around to keep the
         # memory alive
-        buffer1 = create_string_buffer("dead beef")
-        self.assertEquals(hash.insert("DEADBEEF", buffer1), 0)
-        self.assertEquals(string_at(hash.first()), "dead beef")
-        self.assertEquals(hash.cursor(), "DEADBEEF")
+        buffer1 = create_string_buffer(b"dead beef")
+        self.assertEqual(hash.insert(b"DEADBEEF", buffer1), 0)
+        self.assertEqual(string_at(hash.first()), b"dead beef")
+        self.assertEqual(hash.cursor(), b"DEADBEEF")
 
-        buffer2 = create_string_buffer("a bad cafe")
-        self.assertEquals(hash.insert("ABADCAFE", buffer2), 0)
-        buffer3 = create_string_buffer("coded bad")
-        self.assertEquals(hash.insert("C0DEDBAD", buffer3), 0)
-        buffer4 = create_string_buffer("dead food")
-        self.assertEquals(hash.insert("DEADF00D", "dead food"), 0)
-        self.assertEquals(hash.size(), 4)
+        buffer2 = create_string_buffer(b"a bad cafe")
+        self.assertEqual(hash.insert(b"ABADCAFE", buffer2), 0)
+        buffer3 = create_string_buffer(b"coded bad")
+        self.assertEqual(hash.insert(b"C0DEDBAD", buffer3), 0)
+        buffer4 = create_string_buffer(b"dead food")
+        self.assertEqual(hash.insert(b"DEADF00D", b"dead food"), 0)
+        self.assertEqual(hash.size(), 4)
 
         # Look for existing items
-        self.assertEquals(string_at(hash.lookup("DEADBEEF")), "dead beef")
-        self.assertEquals(string_at(hash.lookup("ABADCAFE")), "a bad cafe")
-        self.assertEquals(string_at(hash.lookup("DEADF00D")), "dead food")
+        self.assertEqual(string_at(hash.lookup(b"DEADBEEF")), b"dead beef")
+        self.assertEqual(string_at(hash.lookup(b"ABADCAFE")), b"a bad cafe")
+        self.assertEqual(string_at(hash.lookup(b"DEADF00D")), b"dead food")
 
         # Look for non-existent items
-        self.assertFalse(hash.lookup("foo"))
+        self.assertFalse(hash.lookup(b"foo"))
 
         # Try to insert duplicate items
-        self.assertEquals(hash.insert("DEADBEEF", "foo"), -1)
-        self.assertEquals(string_at(hash.lookup("DEADBEEF")), "dead beef")
+        self.assertEqual(hash.insert(b"DEADBEEF", b"foo"), -1)
+        self.assertEqual(string_at(hash.lookup(b"DEADBEEF")), b"dead beef")
 
         # Some rename tests
 
         # Valid rename, key is now LIVEBEEF
-        self.assertEquals(hash.rename("DEADBEEF", "LIVEBEEF"), 0)
-        self.assertEquals(string_at(hash.lookup("LIVEBEEF")), "dead beef")
+        self.assertEqual(hash.rename(b"DEADBEEF", b"LIVEBEEF"), 0)
+        self.assertEqual(string_at(hash.lookup(b"LIVEBEEF")), b"dead beef")
 
         # Trying to rename an unknown item to a non-existent key
-        self.assertEquals(hash.rename("WHATBEEF", "NONESUCH"), -1)
+        self.assertEqual(hash.rename(b"WHATBEEF", b"NONESUCH"), -1)
 
         # Trying to rename an unknown item to an existing key
-        self.assertEquals(hash.rename("WHATBEEF", "LIVEBEEF"), -1)
-        self.assertEquals(string_at(hash.lookup("LIVEBEEF")), "dead beef")
+        self.assertEqual(hash.rename(b"WHATBEEF", b"LIVEBEEF"), -1)
+        self.assertEqual(string_at(hash.lookup(b"LIVEBEEF")), b"dead beef")
 
         # Trying to rename an existing item to another existing item
-        self.assertEquals(hash.rename("LIVEBEEF", "ABADCAFE"), -1)
-        self.assertEquals(string_at(hash.lookup("LIVEBEEF")), "dead beef")
-        self.assertEquals(string_at(hash.lookup("ABADCAFE")), "a bad cafe")
+        self.assertEqual(hash.rename(b"LIVEBEEF", b"ABADCAFE"), -1)
+        self.assertEqual(string_at(hash.lookup(b"LIVEBEEF")), b"dead beef")
+        self.assertEqual(string_at(hash.lookup(b"ABADCAFE")), b"a bad cafe")
 
         # Test keys method
         keys = hash.keys()
-        self.assertEquals(keys.size(), 4)
+        self.assertEqual(keys.size(), 4)
         del keys
 
         # Test dup method
         copy = hash.dup()
-        self.assertEquals(copy.size(), 4)
-        self.assertEquals(string_at(copy.lookup("LIVEBEEF")), "dead beef")
+        self.assertEqual(copy.size(), 4)
+        self.assertEqual(string_at(copy.lookup(b"LIVEBEEF")), b"dead beef")
         del copy
 
         # Test pack/unpack methods
         frame = hash.pack()
         copy = Zhash.unpack(frame)
         del frame
-        self.assertEquals(copy.size(), 4)
-        self.assertEquals(string_at(copy.lookup("LIVEBEEF")), "dead beef")
+        self.assertEqual(copy.size(), 4)
+        self.assertEqual(string_at(copy.lookup(b"LIVEBEEF")), b"dead beef")
         del copy
 
         # Test save and load
-        hash.comment("This is a test file")
-        hash.comment("Created by %s", "czmq_selftest")
-        hash.save(".cache")
+        hash.comment(b"This is a test file")
+        hash.comment(b"Created by %s", b"czmq_selftest")
+        hash.save(b".cache")
         copy = Zhash()
         self.assertTrue(copy)
-        copy.load(".cache")
-        self.assertEquals(string_at(copy.lookup("LIVEBEEF")), "dead beef")
+        copy.load(b".cache")
+        self.assertEqual(string_at(copy.lookup(b"LIVEBEEF")), b"dead beef")
         del copy
-        os.remove(".cache")
+        os.remove(b".cache")
 
         # Delete a item
-        hash.delete("LIVEBEEF")
-        self.assertFalse(hash.lookup("LIVEBEEF"))
-        self.assertEquals(hash.size(), 3)
+        hash.delete(b"LIVEBEEF")
+        self.assertFalse(hash.lookup(b"LIVEBEEF"))
+        self.assertEqual(hash.size(), 3)
 
         # Test autofree automatically copies and frees string values
         # This means the python string doesn't need to persist, like above
         hash = Zhash()
         self.assertTrue(hash)
         hash.autofree()
-        self.assertEquals(hash.insert("key1", "This is a string"), 0)
-        self.assertEquals(hash.insert("key2", "Ring a ding ding"), 0)
-        self.assertEquals(string_at(hash.lookup("key1")), "This is a string")
-        self.assertEquals(string_at(hash.lookup("key2")), "Ring a ding ding")
+        self.assertEqual(hash.insert(b"key1", b"This is a string"), 0)
+        self.assertEqual(hash.insert(b"key2", b"Ring a ding ding"), 0)
+        self.assertEqual(string_at(hash.lookup(b"key1")), b"This is a string")
+        self.assertEqual(string_at(hash.lookup(b"key2")), b"Ring a ding ding")
         del hash
 
     def test_zlist(self):
@@ -394,105 +415,105 @@ class TestCZMQ(unittest.TestCase):
 
         list = Zlist()
         self.assertTrue(list)
-        self.assertEquals(list.size(), 0)
+        self.assertEqual(list.size(), 0)
 
         # Three items we'll use as test data
         # List items are void *, not particularly strings
-        cheese = create_string_buffer("boursin")
-        bread = create_string_buffer("baguette")
-        wine = create_string_buffer("bordeaux")
+        cheese = create_string_buffer(b"boursin")
+        bread = create_string_buffer(b"baguette")
+        wine = create_string_buffer(b"bordeaux")
 
         list.append(cheese)
-        self.assertEquals(list.size(), 1)
+        self.assertEqual(list.size(), 1)
         list.append(bread)
-        self.assertEquals(list.size(), 2)
+        self.assertEqual(list.size(), 2)
         list.append(wine)
-        self.assertEquals(list.size(), 3)
+        self.assertEqual(list.size(), 3)
 
-        self.assertEquals(list.head().value, addressof(cheese))
-        self.assertEquals(list.next().value, addressof(cheese))
+        self.assertEqual(list.head().value, addressof(cheese))
+        self.assertEqual(list.next().value, addressof(cheese))
 
-        self.assertEquals(list.first().value, addressof(cheese))
-        self.assertEquals(list.tail().value, addressof(wine))
-        self.assertEquals(list.next().value, addressof(bread))
+        self.assertEqual(list.first().value, addressof(cheese))
+        self.assertEqual(list.tail().value, addressof(wine))
+        self.assertEqual(list.next().value, addressof(bread))
 
-        self.assertEquals(list.first().value, addressof(cheese))
-        self.assertEquals(list.next().value, addressof(bread))
-        self.assertEquals(list.next().value, addressof(wine))
+        self.assertEqual(list.first().value, addressof(cheese))
+        self.assertEqual(list.next().value, addressof(bread))
+        self.assertEqual(list.next().value, addressof(wine))
         self.assertFalse(list.next())
         # After we reach end of list, next wraps around
-        self.assertEquals(list.next().value, addressof(cheese))
-        self.assertEquals(list.size(), 3)
+        self.assertEqual(list.next().value, addressof(cheese))
+        self.assertEqual(list.size(), 3)
 
         list.remove(wine)
-        self.assertEquals(list.size(), 2)
+        self.assertEqual(list.size(), 2)
 
-        self.assertEquals(list.first().value, addressof(cheese))
+        self.assertEqual(list.first().value, addressof(cheese))
         list.remove(cheese)
-        self.assertEquals(list.size(), 1)
-        self.assertEquals(list.first().value, addressof(bread))
+        self.assertEqual(list.size(), 1)
+        self.assertEqual(list.first().value, addressof(bread))
 
         list.remove(bread)
-        self.assertEquals(list.size(), 0)
+        self.assertEqual(list.size(), 0)
 
         list.append(cheese)
         list.append(bread)
-        self.assertEquals(list.last().value, addressof(bread))
+        self.assertEqual(list.last().value, addressof(bread))
         list.remove(bread)
-        self.assertEquals(list.last().value, addressof(cheese))
+        self.assertEqual(list.last().value, addressof(cheese))
         list.remove(cheese)
         self.assertFalse(list.last())
 
         list.push(cheese)
-        self.assertEquals(list.size(), 1)
-        self.assertEquals(list.first().value, addressof(cheese))
+        self.assertEqual(list.size(), 1)
+        self.assertEqual(list.first().value, addressof(cheese))
 
         list.push(bread)
-        self.assertEquals(list.size(), 2)
-        self.assertEquals(list.first().value, addressof(bread))
-        self.assertEquals(list.item().value, addressof(bread))
+        self.assertEqual(list.size(), 2)
+        self.assertEqual(list.first().value, addressof(bread))
+        self.assertEqual(list.item().value, addressof(bread))
 
         list.append(wine)
-        self.assertEquals(list.size(), 3)
-        self.assertEquals(list.first().value, addressof(bread))
+        self.assertEqual(list.size(), 3)
+        self.assertEqual(list.first().value, addressof(bread))
 
         sub_list = list.dup()
         self.assertTrue(sub_list)
-        self.assertEquals(sub_list.size(), 3)
+        self.assertEqual(sub_list.size(), 3)
 
         list.sort(zlist_compare)
-        self.assertEquals(list.pop().value, addressof(bread))
-        self.assertEquals(list.pop().value, addressof(wine))
-        self.assertEquals(list.pop().value, addressof(cheese))
-        self.assertEquals(list.size(), 0)
+        self.assertEqual(list.pop().value, addressof(bread))
+        self.assertEqual(list.pop().value, addressof(wine))
+        self.assertEqual(list.pop().value, addressof(cheese))
+        self.assertEqual(list.size(), 0)
 
-        self.assertEquals(sub_list.size(), 3)
+        self.assertEqual(sub_list.size(), 3)
         list.push(sub_list)
         sub_list_2 = sub_list.dup()
         list.append(sub_list_2)
 
         ret = list.freefn(sub_list, zlist_free, False)
         sub_list.allow_destruct = False # Can't double-free
-        self.assertEquals(ret.value, cast(sub_list._as_parameter_, c_void_p).value)
+        self.assertEqual(ret.value, cast(sub_list._as_parameter_, c_void_p).value)
 
         ret = list.freefn(sub_list_2, zlist_free, True)
         sub_list_2.allow_destruct = False # Can't double-free
-        self.assertEquals(ret.value, cast(sub_list_2._as_parameter_, c_void_p).value)
+        self.assertEqual(ret.value, cast(sub_list_2._as_parameter_, c_void_p).value)
         del list
 
         # Test autofree functionality
         list = Zlist()
         self.assertTrue(list)
         list.autofree()
-        list.push("bread")
-        list.append("cheese")
-        self.assertEquals(list.size(), 2)
-        self.assertEquals(string_at(list.first()), "bread")
+        list.push(b"bread")
+        list.append(b"cheese")
+        self.assertEqual(list.size(), 2)
+        self.assertEqual(string_at(list.first()), b"bread")
         item = list.pop()
-        self.assertEquals(string_at(item), "bread")
+        self.assertEqual(string_at(item), b"bread")
         libc.free(item)
         item = list.pop()
-        self.assertEquals(string_at(item), "cheese")
+        self.assertEqual(string_at(item), b"cheese")
         libc.free(item)
 
     def test_zloop(self):
@@ -503,7 +524,7 @@ class TestCZMQ(unittest.TestCase):
         cancel_timer_event = zloop_timer_fn(_cancel_timer_event)
 
         def _timer_event(loop, timer_id, arg):
-            output.send('s', "PING")
+            output.send(b's', b"PING")
             return 0
         timer_event = zloop_timer_fn(_timer_event)
 
@@ -519,9 +540,9 @@ class TestCZMQ(unittest.TestCase):
         timer_event3 = zloop_timer_fn(_timer_event3)
 
         # Create two PAIR sockets and connect over inproc
-        output = Zsock.new_pair("@inproc://zloop.test")
+        output = Zsock.new_pair(b"@inproc://zloop.test")
         self.assertTrue(output)
-        input = Zsock.new_pair(">inproc://zloop.test")
+        input = Zsock.new_pair(b">inproc://zloop.test")
         self.assertTrue(input)
 
         loop = Zloop()
@@ -542,7 +563,7 @@ class TestCZMQ(unittest.TestCase):
         ticket3 = loop.ticket(timer_event, None)
 
         # When we get the ping message, end the reactor
-        self.assertEquals(loop.reader(input, socket_event, None), 0)
+        self.assertEqual(loop.reader(input, socket_event, None), 0)
         loop.reader_set_tolerant(input)
         loop.start()
 
@@ -575,56 +596,56 @@ class TestCZMQ(unittest.TestCase):
 
     def test_zmsg(self):
         # Create two PAIR sockets and connect over inproc
-        output = Zsock.new_pair("@inproc://zmsg.test")
+        output = Zsock.new_pair(b"@inproc://zmsg.test")
         self.assertTrue(output)
-        input = Zsock.new_pair(">inproc://zmsg.test")
-        self.assertTrue(input)
+        input_ = Zsock.new_pair(b">inproc://zmsg.test")
+        self.assertTrue(input_)
 
         # Test send and receive of single-frame message
         msg = Zmsg()
         self.assertTrue(msg)
-        frame = Zframe("Hello", 5)
+        frame = Zframe(b"Hello", 5)
         self.assertTrue(frame)
         msg.prepend(frame)
-        self.assertEquals(msg.size(), 1)
-        self.assertEquals(msg.content_size(), 5)
-        self.assertEquals(Zmsg.send(msg, output), 0)
+        self.assertEqual(msg.size(), 1)
+        self.assertEqual(msg.content_size(), 5)
+        self.assertEqual(Zmsg.send(msg, output), 0)
         self.assertFalse(msg)
 
-        msg = Zmsg.recv(input)
+        msg = Zmsg.recv(input_)
         self.assertTrue(msg)
-        self.assertEquals(msg.size(), 1)
-        self.assertEquals(msg.content_size(), 5)
+        self.assertEqual(msg.size(), 1)
+        self.assertEqual(msg.content_size(), 5)
         del msg
 
         # Test send and receive of multi-frame message
         msg = Zmsg()
         self.assertTrue(msg)
-        self.assertEquals(msg.addmem("Frame0", 6), 0)
-        self.assertEquals(msg.addmem("Frame1", 6), 0)
-        self.assertEquals(msg.addmem("Frame2", 6), 0)
-        self.assertEquals(msg.addmem("Frame3", 6), 0)
-        self.assertEquals(msg.addmem("Frame4", 6), 0)
-        self.assertEquals(msg.addmem("Frame5", 6), 0)
-        self.assertEquals(msg.addmem("Frame6", 6), 0)
-        self.assertEquals(msg.addmem("Frame7", 6), 0)
-        self.assertEquals(msg.addmem("Frame8", 6), 0)
-        self.assertEquals(msg.addmem("Frame9", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame0", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame1", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame2", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame3", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame4", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame5", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame6", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame7", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame8", 6), 0)
+        self.assertEqual(msg.addmem(b"Frame9", 6), 0)
         copy = msg.dup()
         self.assertTrue(copy)
-        self.assertEquals(Zmsg.send(copy, output), 0)
-        self.assertEquals(Zmsg.send(msg, output), 0)
+        self.assertEqual(Zmsg.send(copy, output), 0)
+        self.assertEqual(Zmsg.send(msg, output), 0)
 
-        copy = Zmsg.recv(input)
+        copy = Zmsg.recv(input_)
         self.assertTrue(copy)
-        self.assertEquals(copy.size(), 10)
-        self.assertEquals(copy.content_size(), 60)
+        self.assertEqual(copy.size(), 10)
+        self.assertEqual(copy.content_size(), 60)
         del copy
 
-        msg = Zmsg.recv(input)
+        msg = Zmsg.recv(input_)
         self.assertTrue(msg)
-        self.assertEquals(msg.size(), 10)
-        self.assertEquals(msg.content_size(), 60)
+        self.assertEqual(msg.size(), 10)
+        self.assertEqual(msg.content_size(), 60)
 
         # create empty file for null test
         f = open('zmsg.test', 'w')
@@ -638,11 +659,11 @@ class TestCZMQ(unittest.TestCase):
 
         # Save to a file, read back
         f = open("zmsg.test", "w")
-        self.assertEquals(msg.save(f), 0)
+        self.assertEqual(msg.save(f), 0)
         f.close()
 
         f = open ("zmsg.test", "r")
-        self.assertEquals(msg.save(f), -1)
+        self.assertEqual(msg.save(f), -1)
         f.close()
         del msg
 
@@ -651,48 +672,48 @@ class TestCZMQ(unittest.TestCase):
         self.assertTrue(msg)
         f.close()
         os.remove ("zmsg.test")
-        self.assertEquals(msg.size(), 10)
-        self.assertEquals(msg.content_size(), 60)
+        self.assertEqual(msg.size(), 10)
+        self.assertEqual(msg.content_size(), 60)
 
         # Remove all frames except first and last
-        for frame_nbr in xrange(8):
+        for frame_nbr in range(8):
             msg.first()
             frame = msg.next()
             msg.remove(frame)
 
         # Test message frame manipulation
-        self.assertEquals(msg.size(), 2)
+        self.assertEqual(msg.size(), 2)
         frame = msg.last()
-        self.assertTrue(frame.streq("Frame9"))
-        self.assertEquals(msg.content_size(), 12)
-        frame = Zframe("Address", 7)
+        self.assertTrue(frame.streq(b"Frame9"))
+        self.assertEqual(msg.content_size(), 12)
+        frame = Zframe(b"Address", 7)
         self.assertTrue(frame)
         msg.prepend(frame)
-        self.assertEquals(msg.size(), 3)
-        self.assertEquals(msg.addstr("Body"), 0)
-        self.assertEquals(msg.size(), 4)
+        self.assertEqual(msg.size(), 3)
+        self.assertEqual(msg.addstr(b"Body"), 0)
+        self.assertEqual(msg.size(), 4)
         frame = msg.pop()
         del frame
-        self.assertEquals(msg.size(), 3)
+        self.assertEqual(msg.size(), 3)
         body = msg.popstr()
-        self.assertEquals(body, "Frame0")
+        self.assertEqual(body, b"Frame0")
         del msg
 
         # Test encoding/decoding
         msg = Zmsg()
         self.assertTrue(msg)
         blank = create_string_buffer(100000)
-        self.assertEquals(msg.addmem(blank, 0), 0)
-        self.assertEquals(msg.addmem(blank, 1), 0)
-        self.assertEquals(msg.addmem(blank, 253), 0)
-        self.assertEquals(msg.addmem(blank, 254), 0)
-        self.assertEquals(msg.addmem(blank, 255), 0)
-        self.assertEquals(msg.addmem(blank, 256), 0)
-        self.assertEquals(msg.addmem(blank, 65535), 0)
-        self.assertEquals(msg.addmem(blank, 65536), 0)
-        self.assertEquals(msg.addmem(blank, 65537), 0)
+        self.assertEqual(msg.addmem(blank, 0), 0)
+        self.assertEqual(msg.addmem(blank, 1), 0)
+        self.assertEqual(msg.addmem(blank, 253), 0)
+        self.assertEqual(msg.addmem(blank, 254), 0)
+        self.assertEqual(msg.addmem(blank, 255), 0)
+        self.assertEqual(msg.addmem(blank, 256), 0)
+        self.assertEqual(msg.addmem(blank, 65535), 0)
+        self.assertEqual(msg.addmem(blank, 65536), 0)
+        self.assertEqual(msg.addmem(blank, 65537), 0)
         del blank
-        self.assertEquals(msg.size(), 9)
+        self.assertEqual(msg.size(), 9)
         buffer = POINTER(c_byte)()
         buffer_size = msg.encode(buffer)
         del msg
@@ -705,16 +726,16 @@ class TestCZMQ(unittest.TestCase):
         msg = Zmsg()
         self.assertTrue(msg)
         submsg = Zmsg()
-        msg.pushstr("matr")
-        submsg.pushstr("joska")
-        self.assertEquals(msg.addmsg(submsg), 0)
+        msg.pushstr(b"matr")
+        submsg.pushstr(b"joska")
+        self.assertEqual(msg.addmsg(submsg), 0)
         self.assertFalse(submsg)
         submsg = msg.popmsg()
         self.assertFalse(submsg)   # string "matr" is not encoded zmsg_t, so was discarded
         submsg = msg.popmsg()
         self.assertTrue(submsg)
         body = submsg.popstr()
-        self.assertEquals(body, "joska")
+        self.assertEqual(body, b"joska")
         del submsg
         frame = msg.pop()
         self.assertFalse(frame)
@@ -722,13 +743,13 @@ class TestCZMQ(unittest.TestCase):
 
         # Test comparison of two messages
         msg = Zmsg()
-        msg.addstr("One")
-        msg.addstr("Two")
-        msg.addstr("Three")
+        msg.addstr(b"One")
+        msg.addstr(b"Two")
+        msg.addstr(b"Three")
         msg_other = Zmsg()
-        msg_other.addstr("One")
-        msg_other.addstr("Two")
-        msg_other.addstr("One-Hundred")
+        msg_other.addstr(b"One")
+        msg_other.addstr(b"Two")
+        msg_other.addstr(b"One-Hundred")
         msg_dup = msg.dup()
         empty_msg = Zmsg()
         empty_msg_2 = Zmsg()
@@ -743,32 +764,32 @@ class TestCZMQ(unittest.TestCase):
 
         # Test signal messages
         msg = Zmsg.new_signal(0)
-        self.assertEquals(msg.signal(), 0)
+        self.assertEqual(msg.signal(), 0)
         del msg
         msg = Zmsg.new_signal(-1)
-        self.assertEquals(msg.signal(), 255)
+        self.assertEqual(msg.signal(), 255)
         del msg
 
         # Now try methods on an empty message
         msg = Zmsg()
         self.assertTrue(msg)
-        self.assertEquals(msg.size(), 0)
+        self.assertEqual(msg.size(), 0)
         self.assertFalse(msg.first())
         self.assertFalse(msg.last())
         self.assertFalse(msg.next())
         self.assertFalse(msg.pop())
         # Sending an empty message is valid and destroys the message
-        self.assertEquals(Zmsg.send(msg, output), 0)
+        self.assertEqual(Zmsg.send(msg, output), 0)
         self.assertFalse(msg)
 
     def test_zsock(self):
-        writer = Zsock.new_push ("@tcp://127.0.0.1:5560")
+        writer = Zsock.new_push (b"@tcp://127.0.0.1:5560")
         self.assertTrue(writer)
         self.assertTrue(Zsock.resolve(writer) != writer)
-        self.assertEquals(writer.type_str(), "PUSH")
+        self.assertEqual(writer.type_str(), b"PUSH")
 
         # Check unbind
-        self.assertEquals(writer.unbind("tcp://127.0.0.1:%d", 5560), 0)
+        self.assertEqual(writer.unbind(b"tcp://127.0.0.1:%d", 5560), 0)
 
         # In some cases and especially when running under Valgrind, doing
         # a bind immediately after an unbind causes an EADDRINUSE error.
@@ -776,68 +797,68 @@ class TestCZMQ(unittest.TestCase):
         time.sleep(0.1)
 
         # Bind again
-        self.assertEquals(writer.bind("tcp://127.0.0.1:%d", 5560), 5560)
-        self.assertEquals(writer.endpoint(), "tcp://127.0.0.1:5560")
+        self.assertEqual(writer.bind(b"tcp://127.0.0.1:%d", 5560), 5560)
+        self.assertEqual(writer.endpoint(), b"tcp://127.0.0.1:5560")
 #endif
 
-        reader = Zsock.new_pull (">tcp://127.0.0.1:5560")
+        reader = Zsock.new_pull (b">tcp://127.0.0.1:5560")
         self.assertTrue(reader)
         self.assertTrue(Zsock.resolve(reader) != reader)
-        self.assertEquals(reader.type_str(), "PULL")
+        self.assertEqual(reader.type_str(), b"PULL")
 
         # Basic Hello, World
-        writer.send('s', "Hello, World")
+        writer.send(b's', b"Hello, World")
         msg = Zmsg.recv(reader)
         self.assertTrue(msg)
         string = msg.popstr()
-        self.assertEquals(string, "Hello, World")
+        self.assertEqual(string, b"Hello, World")
         del msg
 
         # Test resolve FD
         #fd = Zsock.fd(reader)
-        #self.assertEquals(zsock_resolve (fd), None)
+        #self.assertEqual(zsock_resolve (fd), None)
 
         # Test binding to ephemeral ports, sequential and random
         DYNAMIC_FIRST = 0xc000
         DYNAMIC_LAST = 0xffff
-        port = writer.bind("tcp://127.0.0.1:*")
+        port = writer.bind(b"tcp://127.0.0.1:*")
         self.assertTrue(port >= DYNAMIC_FIRST and port <= DYNAMIC_LAST)
-        port = writer.bind("tcp://127.0.0.1:*[50000-]")
+        port = writer.bind(b"tcp://127.0.0.1:*[50000-]")
         self.assertTrue(port >= 50000 and port <= DYNAMIC_LAST)
-        port = writer.bind("tcp://127.0.0.1:*[-50001]")
+        port = writer.bind(b"tcp://127.0.0.1:*[-50001]")
         self.assertTrue(port >= DYNAMIC_FIRST and port <= 50001)
-        port = writer.bind("tcp://127.0.0.1:*[60000-60050]")
+        port = writer.bind(b"tcp://127.0.0.1:*[60000-60050]")
         self.assertTrue(port >= 60000 and port <= 60050)
 
-        port = writer.bind("tcp://127.0.0.1:!")
+        port = writer.bind(b"tcp://127.0.0.1:!")
         self.assertTrue(port >= DYNAMIC_FIRST and port <= DYNAMIC_LAST)
-        port = writer.bind("tcp://127.0.0.1:![50000-]")
+        port = writer.bind(b"tcp://127.0.0.1:![50000-]")
         self.assertTrue(port >= 50000 and port <= DYNAMIC_LAST)
-        port = writer.bind("tcp://127.0.0.1:![-50001]")
+        port = writer.bind(b"tcp://127.0.0.1:![-50001]")
         self.assertTrue(port >= DYNAMIC_FIRST and port <= 50001)
-        port = writer.bind("tcp://127.0.0.1:![60000-60050]")
+        port = writer.bind(b"tcp://127.0.0.1:![60000-60050]")
         self.assertTrue(port >= 60000 and port <= 60050)
 
         # Test zsock_attach method
-        server = Zsock.new_dealer("")
+        server = Zsock.new_dealer(b"")
         self.assertTrue(server)
-        self.assertEquals(server.attach("@inproc://myendpoint,tcp://127.0.0.1:5556,inproc://others", True), 0)
-        self.assertEquals(server.attach("", False), 0)
-        self.assertEquals(server.attach(None, True), 0)
-        self.assertEquals(server.attach(">a,@b, c,, ", False), -1)
+        self.assertEqual(server.attach(b"@inproc://myendpoint,tcp://127.0.0.1:5556,inproc://others", True), 0)
+        self.assertEqual(server.attach(b"", False), 0)
+        self.assertEqual(server.attach(None, True), 0)
+        self.assertEqual(server.attach(b">a,@b, c,, ", False), -1)
         del server
 
         # Test zsock_endpoint method
-        self.assertEquals(writer.bind("inproc://test.%s", "writer"), 0)
-        self.assertEquals(writer.endpoint(), "inproc://test.writer")
+        self.assertEqual(writer.bind(b"inproc://test.%s", b"writer"), 0)
+        self.assertEqual(writer.endpoint(), b"inproc://test.writer")
 
         # Test error state when connecting to an invalid socket type
         # ('txp://' instead of 'tcp://', typo intentional)
-        self.assertEquals(reader.connect("txp://127.0.0.1:5560"), -1)
+        self.assertEqual(reader.connect(b"txp://127.0.0.1:5560"), -1)
 
         # Test signal/wait methods
-        self.assertEquals(writer.signal(123), 0)
-        self.assertEquals(reader.wait(), 123)
+        self.assertEqual(writer.signal(123), 0)
+        self.assertEqual(reader.wait(), 123)
 
         # Test zsock_send/recv pictures
         number1 = 123
@@ -845,24 +866,24 @@ class TestCZMQ(unittest.TestCase):
         number4 = 123 * 123 * 123
         number8 = 123 * 123 * 123 * 123
 
-        #chunk = zchunk_new ("HELLO", 5)
+        #chunk = zchunk_new (b"HELLO", 5)
         #self.assertTrue(chunk)
-        frame = Zframe("WORLD", 5)
+        frame = Zframe(b"WORLD", 5)
         self.assertTrue(frame)
         #hash = zhashx_new ()
         #self.assertTrue(hash)
         #hash.autofree()
-        #hash.insert("1", "value A")
-        #hash.insert("2", "value B")
-        original = create_string_buffer("pointer")
+        #hash.insert(b"1", b"value A")
+        #hash.insert(b"2", b"value B")
+        original = create_string_buffer(b"pointer")
 
         # Test zsock_recv into each supported type
-        #writer.send("i1248zsbcfhp",
+        #writer.send(b"i1248zsbcfhp",
         #            -12345, number1, number2, number4, number8,
-        #            "This is a string", "ABCDE", 5, chunk, frame, hash, original)
-        writer.send("i1248zsbfp",
+        #            b"This is a string", b"ABCDE", 5, chunk, frame, hash, original)
+        writer.send(b"i1248zsbfp",
                     -12345, number1, number2, number4, c_longlong(number8),
-                    "This is a string", "ABCDE", 5, frame, original)
+                    b"This is a string", b"ABCDE", 5, frame, original)
         del frame
         #del chunk
         #del hash
@@ -879,30 +900,30 @@ class TestCZMQ(unittest.TestCase):
         frame = Zframe(c_void_p(), True)
         #hash = POINTER(zhashx_p)
         pointer = c_void_p()
-        #rc = reader.recv("i1248zsbcfhp",
+        #rc = reader.recv(b"i1248zsbcfhp",
         #                 byref(integer), byref(number1), byref(number2), byref(number4), byref(number8),
         #                 byref(string), byref(data), byref(size), byref(chunk), byref(frame), byref(hash), byref(pointer))
-        rc = reader.recv("i1248zsbfp",
+        rc = reader.recv(b"i1248zsbfp",
                          byref(integer), byref(number1), byref(number2), byref(number4), byref(number8),
                          byref(string), byref(data), byref(size), byref(frame._as_parameter_), byref(pointer))
-        self.assertEquals(rc, 0)
-        self.assertEquals(integer.value, -12345)
-        self.assertEquals(number1.value, 123)
-        self.assertEquals(number2.value, 123 * 123)
-        self.assertEquals(number4.value, 123 * 123 * 123)
-        self.assertEquals(number8.value, 123 * 123 * 123 * 123)
-        self.assertEquals(string_at(string), "This is a string")
-        self.assertEquals(string_at(data, size.value), "ABCDE")
-        self.assertEquals(size.value, 5)
-        #self.assertEquals(memcmp (chunk.data(), "HELLO", 5), 0)
-        #self.assertEquals(chunk.size(), 5)
-        self.assertTrue(frame.streq("WORLD"))
-        self.assertEquals(frame.size(), 5)
-        #value = string_at(hash.lookup("1"))
-        #self.assertEquals(value, "value A")
-        #value = string_at(hash.lookup("2"))
-        #self.assertEquals(value, "value B")
-        self.assertEquals(addressof(original), pointer.value)
+        self.assertEqual(rc, 0)
+        self.assertEqual(integer.value, -12345)
+        self.assertEqual(number1.value, 123)
+        self.assertEqual(number2.value, 123 * 123)
+        self.assertEqual(number4.value, 123 * 123 * 123)
+        self.assertEqual(number8.value, 123 * 123 * 123 * 123)
+        self.assertEqual(string_at(string), b"This is a string")
+        self.assertEqual(string_at(data, size.value), b"ABCDE")
+        self.assertEqual(size.value, 5)
+        #self.assertEqual(memcmp (chunk.data(), b"HELLO", 5), 0)
+        #self.assertEqual(chunk.size(), 5)
+        self.assertTrue(frame.streq(b"WORLD"))
+        self.assertEqual(frame.size(), 5)
+        #value = string_at(hash.lookup(b"1"))
+        #self.assertEqual(value, b"value A")
+        #value = string_at(hash.lookup(b"2"))
+        #self.assertEqual(value, b"value B")
+        self.assertEqual(addressof(original), pointer.value)
         libc.free (string)
         libc.free (data)
         del frame
@@ -912,73 +933,73 @@ class TestCZMQ(unittest.TestCase):
         # Test zsock_recv of short message this lets us return a failure
         # with a status code and then nothing else the receiver will get
         # the status code and None/zero for all other values
-        writer.send("i", -1)
-        #reader.recv("izsbcfp",
+        writer.send(b"i", -1)
+        #reader.recv(b"izsbcfp",
         #    byref(integer), byref(string), byref(data), byref(size), byref(chunk), byref(frame), byref(pointer))
         frame = Zframe(c_void_p(), True)
-        reader.recv("izsbfp",
+        reader.recv(b"izsbfp",
             byref(integer), byref(string), byref(data), byref(size), byref(frame._as_parameter_), byref(pointer))
-        self.assertEquals(integer.value, -1)
-        self.assertEquals(string.value, None)
+        self.assertEqual(integer.value, -1)
+        self.assertEqual(string.value, None)
         self.assertFalse(data)
-        self.assertEquals(size.value, 0)
-        #self.assertEquals(chunk, None)
+        self.assertEqual(size.value, 0)
+        #self.assertEqual(chunk, None)
         self.assertFalse(frame)
-        self.assertEquals(pointer.value, None)
+        self.assertEqual(pointer.value, None)
 
         msg = Zmsg()
-        msg.addstr("frame 1")
-        msg.addstr("frame 2")
-        writer.send("szm", "header", msg)
+        msg.addstr(b"frame 1")
+        msg.addstr(b"frame 2")
+        writer.send(b"szm", b"header", msg)
         del msg
 
         msg = Zmsg(c_void_p(), True)
-        reader.recv("szm", byref(string), byref(msg._as_parameter_))
+        reader.recv(b"szm", byref(string), byref(msg._as_parameter_))
 
-        self.assertEquals(string_at(string), "header")
-        self.assertEquals(msg.size(), 2)
-        self.assertEquals(msg.popstr(), "frame 1")
-        self.assertEquals(msg.popstr(), "frame 2")
+        self.assertEqual(string_at(string), b"header")
+        self.assertEqual(msg.size(), 2)
+        self.assertEqual(msg.popstr(), b"frame 1")
+        self.assertEqual(msg.popstr(), b"frame 2")
         #zstr_free (byref(string))
         libc.free(string)
         del msg
 
         # Test zsock_recv with null arguments
-        #chunk = zchunk_new ("HELLO", 5)
+        #chunk = zchunk_new (b"HELLO", 5)
         #self.assertTrue(chunk)
-        frame = Zframe("WORLD", 5)
+        frame = Zframe(b"WORLD", 5)
         self.assertTrue(frame)
-        #writer.send("izsbcfp",
-        #            -12345, "This is a string", "ABCDE", 5, chunk, frame, original)
-        writer.send("izsbfp",
-                    -12345, "This is a string", "ABCDE", 5, frame, original)
+        #writer.send(b"izsbcfp",
+        #            -12345, b"This is a string", b"ABCDE", 5, chunk, frame, original)
+        writer.send(b"izsbfp",
+                    -12345, b"This is a string", b"ABCDE", 5, frame, original)
         del frame
         #del chunk
-        #reader.recv("izsbcfp", byref(integer), None, None, None, byref(chunk), None, None)
-        reader.recv("izsbcfp", byref(integer), None, None, None, None, None, None)
-        self.assertEquals(integer.value, -12345)
-        #self.assertEquals(chunk.data(), "HELLO", 5), 0)
-        #self.assertEquals(chunk.size(), 5)
+        #reader.recv(b"izsbcfp", byref(integer), None, None, None, byref(chunk), None, None)
+        reader.recv(b"izsbcfp", byref(integer), None, None, None, None, None, None)
+        self.assertEqual(integer.value, -12345)
+        #self.assertEqual(chunk.data(), b"HELLO", 5), 0)
+        #self.assertEqual(chunk.size(), 5)
         #del chunk
 
         # Test zsock_bsend/brecv pictures with binary encoding
-        frame = Zframe("Hello", 5)
-        #chunk = Zchunk("World", 5)
+        frame = Zframe(b"Hello", 5)
+        #chunk = Zchunk(b"World", 5)
 
         msg = Zmsg()
-        msg.addstr("Hello")
-        msg.addstr("World")
+        msg.addstr(b"Hello")
+        msg.addstr(b"World")
 
-        #writer.bsend("1248sSpcfm",
+        #writer.bsend(b"1248sSpcfm",
         #             number1, number2, number4, number8,
-        #             "Hello, World",
-        #             "Goodbye cruel World!",
+        #             b"Hello, World",
+        #             b"Goodbye cruel World!",
         #             original,
         #             chunk, frame, msg)
-        writer.bsend("1248sSpfm",
+        writer.bsend(b"1248sSpfm",
                      number1, number2, number4, number8,
-                     "Hello, World",
-                     "Goodbye cruel World!",
+                     b"Hello, World",
+                     b"Goodbye cruel World!",
                      original,
                      frame, msg)
         #del chunk
@@ -988,23 +1009,23 @@ class TestCZMQ(unittest.TestCase):
         frame = Zframe(c_void_p(), True)
         msg = Zmsg(c_void_p(), True)
         longstr = c_char_p()
-        #reader.brecv("1248sSpcfm",
+        #reader.brecv(b"1248sSpcfm",
         #             byref(number1), byref(number2), byref(number4), byref(number8),
         #             byref(string), byref(longstr),
         #             byref(pointer),
         #             byref(chunk), byref(frame._as_parameter_), byref(msg._as_parameter_))
-        reader.brecv("1248sSpfm",
+        reader.brecv(b"1248sSpfm",
                      byref(number1), byref(number2), byref(number4), byref(number8),
                      byref(string), byref(longstr),
                      byref(pointer),
                      byref(frame._as_parameter_), byref(msg._as_parameter_))
-        self.assertEquals(number1.value, 123)
-        self.assertEquals(number2.value, 123 * 123)
-        self.assertEquals(number4.value, 123 * 123 * 123)
-        self.assertEquals(number8.value, 123 * 123 * 123 * 123)
-        self.assertEquals(string_at(string), "Hello, World")
-        self.assertEquals(string_at(longstr), "Goodbye cruel World!")
-        self.assertEquals(pointer.value, addressof(original))
+        self.assertEqual(number1.value, 123)
+        self.assertEqual(number2.value, 123 * 123)
+        self.assertEqual(number4.value, 123 * 123 * 123)
+        self.assertEqual(number8.value, 123 * 123 * 123 * 123)
+        self.assertEqual(string_at(string), b"Hello, World")
+        self.assertEqual(string_at(longstr), b"Goodbye cruel World!")
+        self.assertEqual(pointer.value, addressof(original))
         libc.free(longstr)
         #zstr_free (byref(longstr))
         #del chunk
@@ -1012,10 +1033,10 @@ class TestCZMQ(unittest.TestCase):
         del msg
 
         # Check that we can send a zproto format message
-        #writer.bsend("1111sS4", 0xAA, 0xA0, 0x02, 0x01, "key", "value", 1234)
+        #writer.bsend(b"1111sS4", 0xAA, 0xA0, 0x02, 0x01, b"key", b"value", 1234)
         #gossip = zgossip_msg_new ()
         #gossip.recv(reader)
-        #self.assertEquals(gossip.id(), ZGOSSIP_MSG_PUBLISH)
+        #self.assertEqual(gossip.id(), ZGOSSIP_MSG_PUBLISH)
         #del gossip
 
     def test_zactor(self):
@@ -1023,7 +1044,7 @@ class TestCZMQ(unittest.TestCase):
             # Do some initialization
             pipe = Zsock(pipe, False) # We don't own the pipe, so False.
             arg = string_at(arg)
-            self.assertEquals(arg, "Hello, World")
+            self.assertEqual(arg, b"Hello, World")
             pipe.signal(0) # startup ok
 
             terminated = False
@@ -1033,26 +1054,26 @@ class TestCZMQ(unittest.TestCase):
                     break # Interrupted
 
                 command = msg.popstr()
-                if command == "$TERM":
+                if command == b"$TERM":
                     # All actors must handle $TERM in this way
                     terminated = True
-                elif command == "ECHO":
+                elif command == b"ECHO":
                     # This is an example command for our test actor
                     Zmsg.send(msg, pipe)
                 else:
-                    self.fail("Unexpected message " + command)
+                    self.fail(b"Unexpected message " + command)
         echo_actor = zactor_fn(_echo_actor) # ctypes function reference must live as long as the actor.
 
-        arg_buffer = create_string_buffer("Hello, World") # argument buffer must live as long as the actor.
+        arg_buffer = create_string_buffer(b"Hello, World") # argument buffer must live as long as the actor.
         actor = Zactor(echo_actor, arg_buffer)
         self.assertTrue(actor)
 
-        actor.sock().send("ss", "ECHO", "This is a string");
+        actor.sock().send(b"ss", b"ECHO", b"This is a string");
 
         result = c_char_p()
-        actor.sock().recv("s", byref(result))
+        actor.sock().recv(b"s", byref(result))
 
-        self.assertEquals(string_at(result), "This is a string")
+        self.assertEqual(string_at(result), b"This is a string")
 
         libc.free(result)
 


### PR DESCRIPTION
The actual problem is that Python 3 does not provide a low level
buffered I/O (FILE*) API, specifically "pythonapi.PyFile_FromFile" and
"pythonapi.PyFile_AsFile". Merely importing "czmq" on Python 3 gives
"AttributeError: … symbol not found".

Solution: use the Standard C library functions on Python 3. Also, adjust
the test battery to run on Python 3.