### PR TITLE
Fix libzmq2 build and add zsock_t resolve test

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1685,6 +1685,12 @@ zsock_test (bool verbose)
     zmq_close (zmq_sock);
     zmq_ctx_term (zmq_ctx);
 
+    //  Test resolve zsock
+    zsock_t *resolve = zsock_new_pub("@tcp://127.0.0.1:5561");
+    assert (resolve);
+    assert (zsock_resolve (resolve) == resolve->handle);
+    zsock_destroy (&resolve);
+
     //  Test resolve FD
     SOCKET fd = zsock_fd (reader);
     assert (zsock_resolve ((void *) &fd) == NULL);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1673,7 +1673,11 @@ zsock_test (bool verbose)
     zmsg_destroy (&msg);
 
     //  Test resolve libzmq socket
+#if (ZMQ_VERSION >= ZMQ_MAKE_VERSION (3, 2, 0))
     void *zmq_ctx = zmq_ctx_new ();
+#else
+    void *zmq_ctx = zmq_ctx_new (1);
+#endif
     assert (zmq_ctx);
     void *zmq_sock = zmq_socket (zmq_ctx, ZMQ_PUB);
     assert (zmq_sock);


### PR DESCRIPTION
Should the mapping of zmq_ctx_new to zmq_init in czmq_prelude.h pass some default value of io_threads maybe? Otherwise it just won't compile without changing the user's code.