### PR TITLE
Fix check-py failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ examples/zpubsub/zprototest/*.bnf
 examples/zpubsub/zprototest/test_publisher
 examples/zpubsub/zprototest/test_subscriber
 src/test_zgossip
+.test_zproxy/
 .deps
 .libs
 .cproject

--- a/api/zframe.xml
+++ b/api/zframe.xml
@@ -47,16 +47,6 @@
         <return type = "integer" />
     </method>
 
-    <method  name = "send reply" singleton = "1">
-        Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-        Return -1 on error, 0 on success.
-        <argument name = "self_p" type = "zframe" by_reference = "1" />
-        <argument name = "source msg" type = "zframe" />
-        <argument name = "dest" type = "anything" />
-        <argument name = "flags" type = "integer" />
-        <return type = "integer" />
-    </method>
-
     <method name = "size">
         Return number of bytes in frame data
         <return type = "size" />

--- a/bindings/jni/src/main/c/org_zeromq_Zframe.c
+++ b/bindings/jni/src/main/c/org_zeromq_Zframe.c
@@ -28,11 +28,6 @@ JNIEXPORT void JNICALL Java_org_zeromq_Zframe_recv (JNIEnv *env, jobject thisObj
 JNIEXPORT void JNICALL Java_org_zeromq_Zframe_send (JNIEnv *env, jobject thisObj) {
 }
 
-//  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-//  Return -1 on error, 0 on success.                                                                           
-JNIEXPORT void JNICALL Java_org_zeromq_Zframe_sendReply (JNIEnv *env, jobject thisObj) {
-}
-
 //  Return number of bytes in frame data
 JNIEXPORT void JNICALL Java_org_zeromq_Zframe_size (JNIEnv *env, jobject thisObj) {
 }

--- a/bindings/jni/src/main/java/org/zeromq/Zframe.java
+++ b/bindings/jni/src/main/java/org/zeromq/Zframe.java
@@ -7,7 +7,6 @@ public class Zframe {
     public native Zframe from (String String);
     public native Zframe recv (void Source);
     public native int send (Zframe SelfP, void Dest, int Flags);
-    public native int sendReply (Zframe SelfP, Zframe SourceMsg, void Dest, int Flags);
     public native long size ();
     public native byte [] data ();
     public native Zframe dup ();

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -718,8 +718,6 @@ lib.zframe_recv.restype = zframe_p
 lib.zframe_recv.argtypes = [c_void_p]
 lib.zframe_send.restype = c_int
 lib.zframe_send.argtypes = [POINTER(zframe_p), c_void_p, c_int]
-lib.zframe_send_reply.restype = c_int
-lib.zframe_send_reply.argtypes = [POINTER(zframe_p), zframe_p, c_void_p, c_int]
 lib.zframe_size.restype = c_size_t
 lib.zframe_size.argtypes = [zframe_p]
 lib.zframe_data.restype = POINTER(c_byte)
@@ -807,12 +805,6 @@ zpoller or zloop."""
         """Send a frame to a socket, destroy frame after sending.
 Return -1 on error, 0 on success."""
         return lib.zframe_send(byref(zframe_p.from_param(self_p)), dest, flags)
-
-    @staticmethod
-    def send_reply(self_p, source_msg, dest, flags):
-        """Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-Return -1 on error, 0 on success."""
-        return lib.zframe_send_reply(byref(zframe_p.from_param(self_p)), source_msg, dest, flags)
 
     def size(self):
         """Return number of bytes in frame data"""

--- a/bindings/qml/src/QmlZframe.cpp
+++ b/bindings/qml/src/QmlZframe.cpp
@@ -143,13 +143,6 @@ int QmlZframeAttached::send (QmlZframe *selfP, void *dest, int flags) {
 };
 
 ///
-//  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-//  Return -1 on error, 0 on success.                                                                           
-int QmlZframeAttached::sendReply (QmlZframe *selfP, QmlZframe *sourceMsg, void *dest, int flags) {
-    return zframe_send_reply (&selfP->self, sourceMsg->self, dest, flags);
-};
-
-///
 //  Probe the supplied object, and report if it looks like a zframe_t.
 bool QmlZframeAttached::is (void *self) {
     return zframe_is (self);

--- a/bindings/qml/src/QmlZframe.h
+++ b/bindings/qml/src/QmlZframe.h
@@ -103,10 +103,6 @@ public slots:
     //  Return -1 on error, 0 on success.                     
     int send (QmlZframe *selfP, void *dest, int flags);
 
-    //  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-    //  Return -1 on error, 0 on success.                                                                           
-    int sendReply (QmlZframe *selfP, QmlZframe *sourceMsg, void *dest, int flags);
-
     //  Probe the supplied object, and report if it looks like a zframe_t.
     bool is (void *self);
 

--- a/bindings/qt/src/qzframe.cpp
+++ b/bindings/qt/src/qzframe.cpp
@@ -67,15 +67,6 @@ int QZframe::send (void *dest, int flags)
 }
 
 ///
-//  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-//  Return -1 on error, 0 on success.                                                                           
-int QZframe::sendReply (QZframe *sourceMsg, void *dest, int flags)
-{
-    int rv = zframe_send_reply (&self, sourceMsg->self, dest, flags);
-    return rv;
-}
-
-///
 //  Return number of bytes in frame data
 size_t QZframe::size ()
 {

--- a/bindings/qt/src/qzframe.h
+++ b/bindings/qt/src/qzframe.h
@@ -40,10 +40,6 @@ public:
     //  Return -1 on error, 0 on success.                     
     int send (void *dest, int flags);
 
-    //  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-    //  Return -1 on error, 0 on success.                                                                           
-    int sendReply (QZframe *sourceMsg, void *dest, int flags);
-
     //  Return number of bytes in frame data
     size_t size ();
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -109,7 +109,6 @@ module CZMQ
       attach_function :zframe_from, [:string], :pointer, **opts
       attach_function :zframe_recv, [:pointer], :pointer, **opts
       attach_function :zframe_send, [:pointer, :pointer, :int], :int, **opts
-      attach_function :zframe_send_reply, [:pointer, :pointer, :pointer, :int], :int, **opts
       attach_function :zframe_size, [:pointer], :size_t, **opts
       attach_function :zframe_data, [:pointer], :pointer, **opts
       attach_function :zframe_dup, [:pointer], :pointer, **opts

--- a/bindings/ruby/lib/czmq/ffi/zframe.rb
+++ b/bindings/ruby/lib/czmq/ffi/zframe.rb
@@ -102,16 +102,6 @@ module CZMQ
         result
       end
       
-      # Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-      # Return -1 on error, 0 on success.                                                                           
-      def self.send_reply self_p, source_msg, dest, flags
-        self_p = self_p.__ptr_give_ref
-        source_msg = source_msg.__ptr if source_msg
-        flags = Integer(flags)
-        result = ::CZMQ::FFI.zframe_send_reply self_p, source_msg, dest, flags
-        result
-      end
-      
       # Return number of bytes in frame data
       def size
         raise DestroyedError unless @ptr

--- a/doc/zframe.txt
+++ b/doc/zframe.txt
@@ -44,11 +44,6 @@ CZMQ_EXPORT zframe_t *
 CZMQ_EXPORT int
     zframe_send (zframe_t **self_p, void *dest, int flags);
 
-//  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-//  Return -1 on error, 0 on success.                                                                           
-CZMQ_EXPORT int
-    zframe_send_reply (zframe_t **self_p, zframe_t *source_msg, void *dest, int flags);
-
 //  Return number of bytes in frame data
 CZMQ_EXPORT size_t
     zframe_size (zframe_t *self);
@@ -205,36 +200,40 @@ assert (frame_nbr == 10);
 zsock_destroy (&input);
 zsock_destroy (&output);
 
-#if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 2
-
+#if defined (ZMQ_SERVER)
 //  Create server and client sockets and connect over inproc
-zsock_t *server = zsock_new_server ("@inproc://zframe-server.test");
+zsock_t *server = zsock_new_server ("inproc://zframe-server.test");
 assert (server);
-zsock_t *client = zsock_new_client (">inproc://zframe-server.test");
+zsock_t *client = zsock_new_client ("inproc://zframe-server.test");
 assert (client);
 
-//  Send message from client to server
-frame = zframe_new ("Hello", 5);
-assert (frame);
-rc = zframe_send (&frame, client, 0);
+//  Send request from client to server
+zframe_t *request = zframe_new ("Hello", 5);
+assert (request);
+rc = zframe_send (&request, client, 0);
+assert (rc == 0);
+assert (!request);
+
+//  Read request and send reply
+request = zframe_recv (server);
+assert (request);
+assert (zframe_streq (request, "Hello"));
+assert (zframe_routing_id (request));
+
+zframe_t *reply = zframe_new ("World", 5);
+assert (reply);
+zframe_set_routing_id (reply, zframe_routing_id (request));
+rc = zframe_send (&reply, server, 0);
 assert (rc == 0);
 
-//  Read message
-frame = zframe_recv (server);
-assert (zframe_streq (frame, "Hello"));
-zframe_t *reply_frame = zframe_new("Reply", 5);
-rc = zframe_send_reply(&reply_frame, frame, server, 0);
-assert(rc == 0);
-zframe_destroy(&frame);
-
 //  Read reply
-frame = zframe_recv (client);
-assert (zframe_streq (frame, "Reply"));
-zframe_destroy(&frame);
+reply = zframe_recv (client);
+assert (zframe_streq (reply, "World"));
+assert (zframe_routing_id (reply) == 0);
+zframe_destroy (&reply);
 
 zsock_destroy (&client);
 zsock_destroy (&server);
-
 #endif
 
 ----

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -57,11 +57,6 @@ CZMQ_EXPORT zframe_t *
 CZMQ_EXPORT int
     zframe_send (zframe_t **self_p, void *dest, int flags);
 
-//  Send a reply frame to a server socket, copy the routing id from source message, destroy frame after sending.
-//  Return -1 on error, 0 on success.                                                                           
-CZMQ_EXPORT int
-    zframe_send_reply (zframe_t **self_p, zframe_t *source_msg, void *dest, int flags);
-
 //  Return number of bytes in frame data
 CZMQ_EXPORT size_t
     zframe_size (zframe_t *self);


### PR DESCRIPTION
@hintjens - PR #1139 removed the implementation of zframe_send_reply, but it was left in the api XML and so in the generated bindings and headers. This causes check-py to fail.

This PR removes the definition from the XML of zframe and regenerates the bindings accordingly. Is this the right thing to do, or is the implementation just out temporarily? Please decline if that's the case :-)

I've also updated the documentation. Are the .doc files somehow autogenerated or should they be updated manually?