### PR TITLE
use zstr_free() instead of free()

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -176,7 +176,7 @@ zcert_set_meta (zcert_t *self, const char *name, const char *format, ...)
     va_end (argptr);
     assert (value);
     zhash_insert (self->metadata, name, value);
-    free (value);
+    zstr_free (&value);
 }
 
 

--- a/src/zclass_c.gsl
+++ b/src/zclass_c.gsl
@@ -433,7 +433,7 @@ $(class.name)_set_$(name) ($(class.name)_t *self, const char *format, ...)
     assert (self);
     va_list argptr;
     va_start (argptr, format);
-    free (self->$(name));
+    zstr_free (&self->$(name));
     self->$(name) = zsys_vprintf (format, argptr);
     va_end (argptr);
 }
@@ -511,7 +511,7 @@ $(class.name)_$(name)_append ($(class.name)_t *self, const char *format, ...)
         zlist_autofree (self->$(name));
     }
     zlist_append (self->$(name), string);
-    free (string);
+    zstr_free (&string);
 }
 
 size_t
@@ -599,7 +599,7 @@ $(class.name)_$(name)_insert ($(class.name)_t *self, const char *key, const char
         zhash_autofree (self->$(name));
     }
     zhash_update (self->$(name), key, string);
-    free (string);
+    zstr_free (&string);
 }
 
 size_t

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -241,7 +241,7 @@ void
 zconfig_set_value (zconfig_t *self, const char *format, ...)
 {
     assert (self);
-    free (self->value);
+    zstr_free (&self->value);
     if (format) {
         va_list argptr;
         va_start (argptr, format);
@@ -463,7 +463,7 @@ s_config_printf (zconfig_t *self, void *arg, char *format, ...)
             fprintf ((FILE *) arg, "%s", string);
     }
     size_t size = strlen (string);
-    free (string);
+    zstr_free (&string);
     if (size > INT_MAX)
         return -1;
 
@@ -535,7 +535,7 @@ zconfig_savef (zconfig_t *self, const char *format, ...)
     va_end (argptr);
     if (filename) {
         int rc = zconfig_save (self, filename);
-        free (filename);
+        zstr_free (&filename);
         return rc;
     }
     else
@@ -898,7 +898,7 @@ zconfig_set_comment (zconfig_t *self, const char *format, ...)
         va_end (argptr);
 
         zlist_append (self->comments, string);
-        free (string);
+        zstr_free (&string);
     }
     else
         zlist_destroy (&self->comments);

--- a/src/zhash.c
+++ b/src/zhash.c
@@ -515,7 +515,7 @@ zhash_comment (zhash_t *self, const char *format, ...)
         va_end (argptr);
         if (string)
             zlist_append (self->comments, string);
-        free (string);
+        zstr_free (&string);
     }
     else
         zlist_destroy (&self->comments);

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -416,7 +416,7 @@ zmsg_pushstrf (zmsg_t *self, const char *format, ...)
 
     size_t len = strlen (string);
     zframe_t *frame = zframe_new (string, len);
-    free (string);
+    zstr_free (&string);
     if (frame) {
         self->content_size += len;
         return zlist_push (self->frames, frame);
@@ -446,7 +446,7 @@ zmsg_addstrf (zmsg_t *self, const char *format, ...)
 
     size_t len = strlen (string);
     zframe_t *frame = zframe_new (string, len);
-    free (string);
+    zstr_free (&string);
     if (frame) {
         self->content_size += len;
         return zlist_append (self->frames, frame);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -479,7 +479,7 @@ zsock_bind (zsock_t *self, const char *format, ...)
 
         rc = -1;                //  Assume we don't succeed
         while (rc == -1 && attempts--) {
-            free (endpoint);
+            zstr_free (&endpoint);
             endpoint = zsys_sprintf ("%s:%d", hostname, port);
             if (!endpoint)
                 break;
@@ -494,11 +494,11 @@ zsock_bind (zsock_t *self, const char *format, ...)
 
     //  Store successful endpoint for later reference
     if (rc >= 0) {
-        free (self->endpoint);
+        zstr_free (&self->endpoint);
         self->endpoint = endpoint;
     }
     else
-        free (endpoint);
+        zstr_free (&endpoint);
 
     zrex_destroy (&rex);
     return rc;
@@ -537,7 +537,7 @@ zsock_unbind (zsock_t *self, const char *format, ...)
         return -1;
 
     int rc = zmq_unbind (self->handle, endpoint);
-    free (endpoint);
+    zstr_free (&endpoint);
     return rc;
 #else
     return -1;
@@ -575,7 +575,7 @@ zsock_connect (zsock_t *self, const char *format, ...)
         retries--;
     }
 #endif
-    free (endpoint);
+    zstr_free (&endpoint);
     return rc;
 }
 
@@ -599,7 +599,7 @@ zsock_disconnect (zsock_t *self, const char *format, ...)
     if (!endpoint)
         return -1;
     int rc = zmq_disconnect (self->handle, endpoint);
-    free (endpoint);
+    zstr_free (&endpoint);
     return rc;
 #else
     return -1;

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -169,7 +169,7 @@ zstr_sendf (void *dest, const char *format, ...)
     va_end (argptr);
 
     int rc = s_send_string (dest, false, string);
-    free (string);
+    zstr_free (&string);
     return rc;
 }
 
@@ -194,7 +194,7 @@ zstr_sendfm (void *dest, const char *format, ...)
     va_end (argptr);
 
     int rc = s_send_string (dest, true, string);
-    free (string);
+    zstr_free (&string);
     return rc;
 }
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -651,7 +651,7 @@ zsys_dir_create (const char *pathname, ...)
         *slash = '/';
         slash = strchr (slash + 1, '/');
     }
-    free (formatted);
+    zstr_free (&formatted);
     return 0;
 }
 
@@ -674,7 +674,7 @@ zsys_dir_delete (const char *pathname, ...)
 #else
     int rc = rmdir (formatted);
 #endif
-    free (formatted);
+    zstr_free (&formatted);
     return rc;
 }
 
@@ -1509,7 +1509,7 @@ zsys_error (const char *format, ...)
     char *string = zsys_vprintf (format, argptr);
     va_end (argptr);
     s_log ('E', string);
-    free (string);
+    zstr_free (&string);
 }
 
 
@@ -1524,7 +1524,7 @@ zsys_warning (const char *format, ...)
     char *string = zsys_vprintf (format, argptr);
     va_end (argptr);
     s_log ('W', string);
-    free (string);
+    zstr_free (&string);
 }
 
 
@@ -1539,7 +1539,7 @@ zsys_notice (const char *format, ...)
     char *string = zsys_vprintf (format, argptr);
     va_end (argptr);
     s_log ('N', string);
-    free (string);
+    zstr_free (&string);
 }
 
 
@@ -1554,7 +1554,7 @@ zsys_info (const char *format, ...)
     char *string = zsys_vprintf (format, argptr);
     va_end (argptr);
     s_log ('I', string);
-    free (string);
+    zstr_free (&string);
 }
 
 
@@ -1569,7 +1569,7 @@ zsys_debug (const char *format, ...)
     char *string = zsys_vprintf (format, argptr);
     va_end (argptr);
     s_log ('D', string);
-    free (string);
+    zstr_free (&string);
 }
 
 


### PR DESCRIPTION
According to the documentation of zsys_vprintf(), one should use
zstr_free() instead of free() to free those strings.

This closes issue #1155.

Tested by compiling using `./configure`, `make`, and `make check-local`.