### PR TITLE
Include zsock_option functions into zsock.xml

### DIFF
--- a/api/zactor.xml
+++ b/api/zactor.xml
@@ -1,7 +1,7 @@
 <class name = "zactor">
     actor
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "fn">
         Actors get a pipe and arguments from caller

--- a/api/zdir.xml
+++ b/api/zdir.xml
@@ -1,7 +1,7 @@
 <class name = "zdir">
     work with file-system directories
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Create a new directory item that loads in the full tree of the specified

--- a/api/zdir_patch.xml
+++ b/api/zdir_patch.xml
@@ -1,7 +1,7 @@
 <class name = "zdir patch">
     work with directory patches
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <enum name = "op">
         <constant name = "create" value = "1" />

--- a/api/zfile.xml
+++ b/api/zfile.xml
@@ -1,7 +1,7 @@
 <class name = "zfile">
     helper functions for working with files.
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         If file exists, populates properties. CZMQ supports portable symbolic

--- a/api/zframe.xml
+++ b/api/zframe.xml
@@ -1,7 +1,7 @@
 <class name = "zframe">
     working with single message frames
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constant name = "more" value = "1" />
     <constant name = "reuse" value = "2" />

--- a/api/zhash.xml
+++ b/api/zhash.xml
@@ -1,7 +1,7 @@
 <class name = "zhash">
     generic type-free hash container (simple)
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "free_fn">
         Callback function for zhash_freefn method

--- a/api/zhashx.xml
+++ b/api/zhashx.xml
@@ -1,7 +1,7 @@
 <class name = "zhashx">
     extended generic type-free hash container
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "destructor_fn">
         Destroy an item

--- a/api/ziflist.xml
+++ b/api/ziflist.xml
@@ -1,7 +1,7 @@
 <class name = "ziflist">
     List of network interfaces available on system
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Get a list of network interfaces currently defined on the system

--- a/api/zlist.xml
+++ b/api/zlist.xml
@@ -1,7 +1,7 @@
 <class name = "zlist">
     simple generic list container
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "compare_fn">
         Comparison function e.g. for sorting and removing.

--- a/api/zloop.xml
+++ b/api/zloop.xml
@@ -1,7 +1,7 @@
 <class name = "zloop">
     event-driven reactor
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "reader_fn">
         Callback function for reactor socket activity

--- a/api/zmsg.xml
+++ b/api/zmsg.xml
@@ -1,7 +1,7 @@
 <class name = "zmsg">
     working with multipart messages
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Create a new empty message object

--- a/api/zpoller.xml
+++ b/api/zpoller.xml
@@ -1,7 +1,7 @@
 <class name = "zpoller">
     event-driven reactor
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Create new poller; the reader can be a libzmq socket (void *), a zsock_t

--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -820,4 +820,6 @@
         Self test of this class
         <argument name = "verbose" type = "boolean" />
     </method>
+
+    <include filename = "api/zsock_options.xml" />
 </class>

--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -8,7 +8,7 @@
 <class name = "zsock">
     high-level socket API that hides libzmq contexts and sockets
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Create a new socket. Returns the new socket, or NULL if the new socket

--- a/api/zsock_options.gsl
+++ b/api/zsock_options.gsl
@@ -1,0 +1,31 @@
+.output "../api/zsock_options.xml" # relative to the script in src/
+<!--
+******************************************************************
+*   GENERATED SOURCE CODE, DO NOT EDIT!!                         *
+*   TO CHANGE THIS, EDIT api/zsock.gsl AND/OR src/sockopts.xml   *
+*   AND RUN `gen sockopts` in src/.                              *
+******************************************************************
+-->
+.for version where version.major = "4" # ZMQ version 4
+.  for option
+.    option.api_name = string.replace(option.name, "_| ")
+.    if option.type = "int"
+.      option.api_type = "integer"
+.    endif
+.    option.api_type ?= option.type
+.    if regexp.match("r", option.mode)
+
+<method name = "$(option.api_name:)" polymorphic = "1">
+    Get socket option `$(option.name:)`.
+    <return type="$(option.api_type:)" />
+</method>
+.    endif
+.    if regexp.match("w", option.mode)
+
+<method name = "set $(option.api_name:)" polymorphic = "1">
+    Set socket option `$(option.name:)`.
+    <argument name = "$(option.api_name:)" type="$(option.api_type:)" />
+</method>
+.    endif
+.  endfor
+.endfor

--- a/api/zsock_options.xml
+++ b/api/zsock_options.xml
@@ -1,0 +1,463 @@
+<!--
+******************************************************************
+*   GENERATED SOURCE CODE, DO NOT EDIT!!                         *
+*   TO CHANGE THIS, EDIT api/zsock.gsl AND/OR src/sockopts.xml   *
+*   AND RUN `gen sockopts` in src/.                              *
+******************************************************************
+-->
+<methods>
+<method name = "tos" polymorphic = "1">
+    Get socket option `tos`.
+    <return type="integer" />
+</method>
+
+<method name = "set tos" polymorphic = "1">
+    Set socket option `tos`.
+    <argument name = "tos" type="integer" />
+</method>
+
+<method name = "set router handover" polymorphic = "1">
+    Set socket option `router_handover`.
+    <argument name = "router handover" type="integer" />
+</method>
+
+<method name = "set router mandatory" polymorphic = "1">
+    Set socket option `router_mandatory`.
+    <argument name = "router mandatory" type="integer" />
+</method>
+
+<method name = "set probe router" polymorphic = "1">
+    Set socket option `probe_router`.
+    <argument name = "probe router" type="integer" />
+</method>
+
+<method name = "set req relaxed" polymorphic = "1">
+    Set socket option `req_relaxed`.
+    <argument name = "req relaxed" type="integer" />
+</method>
+
+<method name = "set req correlate" polymorphic = "1">
+    Set socket option `req_correlate`.
+    <argument name = "req correlate" type="integer" />
+</method>
+
+<method name = "set conflate" polymorphic = "1">
+    Set socket option `conflate`.
+    <argument name = "conflate" type="integer" />
+</method>
+
+<method name = "zap domain" polymorphic = "1">
+    Get socket option `zap_domain`.
+    <return type="string" />
+</method>
+
+<method name = "set zap domain" polymorphic = "1">
+    Set socket option `zap_domain`.
+    <argument name = "zap domain" type="string" />
+</method>
+
+<method name = "mechanism" polymorphic = "1">
+    Get socket option `mechanism`.
+    <return type="integer" />
+</method>
+
+<method name = "plain server" polymorphic = "1">
+    Get socket option `plain_server`.
+    <return type="integer" />
+</method>
+
+<method name = "set plain server" polymorphic = "1">
+    Set socket option `plain_server`.
+    <argument name = "plain server" type="integer" />
+</method>
+
+<method name = "plain username" polymorphic = "1">
+    Get socket option `plain_username`.
+    <return type="string" />
+</method>
+
+<method name = "set plain username" polymorphic = "1">
+    Set socket option `plain_username`.
+    <argument name = "plain username" type="string" />
+</method>
+
+<method name = "plain password" polymorphic = "1">
+    Get socket option `plain_password`.
+    <return type="string" />
+</method>
+
+<method name = "set plain password" polymorphic = "1">
+    Set socket option `plain_password`.
+    <argument name = "plain password" type="string" />
+</method>
+
+<method name = "curve server" polymorphic = "1">
+    Get socket option `curve_server`.
+    <return type="integer" />
+</method>
+
+<method name = "set curve server" polymorphic = "1">
+    Set socket option `curve_server`.
+    <argument name = "curve server" type="integer" />
+</method>
+
+<method name = "curve publickey" polymorphic = "1">
+    Get socket option `curve_publickey`.
+    <return type="key" />
+</method>
+
+<method name = "set curve publickey" polymorphic = "1">
+    Set socket option `curve_publickey`.
+    <argument name = "curve publickey" type="key" />
+</method>
+
+<method name = "curve secretkey" polymorphic = "1">
+    Get socket option `curve_secretkey`.
+    <return type="key" />
+</method>
+
+<method name = "set curve secretkey" polymorphic = "1">
+    Set socket option `curve_secretkey`.
+    <argument name = "curve secretkey" type="key" />
+</method>
+
+<method name = "curve serverkey" polymorphic = "1">
+    Get socket option `curve_serverkey`.
+    <return type="key" />
+</method>
+
+<method name = "set curve serverkey" polymorphic = "1">
+    Set socket option `curve_serverkey`.
+    <argument name = "curve serverkey" type="key" />
+</method>
+
+<method name = "gssapi server" polymorphic = "1">
+    Get socket option `gssapi_server`.
+    <return type="integer" />
+</method>
+
+<method name = "set gssapi server" polymorphic = "1">
+    Set socket option `gssapi_server`.
+    <argument name = "gssapi server" type="integer" />
+</method>
+
+<method name = "gssapi plaintext" polymorphic = "1">
+    Get socket option `gssapi_plaintext`.
+    <return type="integer" />
+</method>
+
+<method name = "set gssapi plaintext" polymorphic = "1">
+    Set socket option `gssapi_plaintext`.
+    <argument name = "gssapi plaintext" type="integer" />
+</method>
+
+<method name = "gssapi principal" polymorphic = "1">
+    Get socket option `gssapi_principal`.
+    <return type="string" />
+</method>
+
+<method name = "set gssapi principal" polymorphic = "1">
+    Set socket option `gssapi_principal`.
+    <argument name = "gssapi principal" type="string" />
+</method>
+
+<method name = "gssapi service principal" polymorphic = "1">
+    Get socket option `gssapi_service_principal`.
+    <return type="string" />
+</method>
+
+<method name = "set gssapi service principal" polymorphic = "1">
+    Set socket option `gssapi_service_principal`.
+    <argument name = "gssapi service principal" type="string" />
+</method>
+
+<method name = "ipv6" polymorphic = "1">
+    Get socket option `ipv6`.
+    <return type="integer" />
+</method>
+
+<method name = "set ipv6" polymorphic = "1">
+    Set socket option `ipv6`.
+    <argument name = "ipv6" type="integer" />
+</method>
+
+<method name = "immediate" polymorphic = "1">
+    Get socket option `immediate`.
+    <return type="integer" />
+</method>
+
+<method name = "set immediate" polymorphic = "1">
+    Set socket option `immediate`.
+    <argument name = "immediate" type="integer" />
+</method>
+
+<method name = "set router raw" polymorphic = "1">
+    Set socket option `router_raw`.
+    <argument name = "router raw" type="integer" />
+</method>
+
+<method name = "ipv4only" polymorphic = "1">
+    Get socket option `ipv4only`.
+    <return type="integer" />
+</method>
+
+<method name = "set ipv4only" polymorphic = "1">
+    Set socket option `ipv4only`.
+    <argument name = "ipv4only" type="integer" />
+</method>
+
+<method name = "set delay attach on connect" polymorphic = "1">
+    Set socket option `delay_attach_on_connect`.
+    <argument name = "delay attach on connect" type="integer" />
+</method>
+
+<method name = "type" polymorphic = "1">
+    Get socket option `type`.
+    <return type="integer" />
+</method>
+
+<method name = "sndhwm" polymorphic = "1">
+    Get socket option `sndhwm`.
+    <return type="integer" />
+</method>
+
+<method name = "set sndhwm" polymorphic = "1">
+    Set socket option `sndhwm`.
+    <argument name = "sndhwm" type="integer" />
+</method>
+
+<method name = "rcvhwm" polymorphic = "1">
+    Get socket option `rcvhwm`.
+    <return type="integer" />
+</method>
+
+<method name = "set rcvhwm" polymorphic = "1">
+    Set socket option `rcvhwm`.
+    <argument name = "rcvhwm" type="integer" />
+</method>
+
+<method name = "affinity" polymorphic = "1">
+    Get socket option `affinity`.
+    <return type="uint64" />
+</method>
+
+<method name = "set affinity" polymorphic = "1">
+    Set socket option `affinity`.
+    <argument name = "affinity" type="uint64" />
+</method>
+
+<method name = "set subscribe" polymorphic = "1">
+    Set socket option `subscribe`.
+    <argument name = "subscribe" type="string" />
+</method>
+
+<method name = "set unsubscribe" polymorphic = "1">
+    Set socket option `unsubscribe`.
+    <argument name = "unsubscribe" type="string" />
+</method>
+
+<method name = "identity" polymorphic = "1">
+    Get socket option `identity`.
+    <return type="string" />
+</method>
+
+<method name = "set identity" polymorphic = "1">
+    Set socket option `identity`.
+    <argument name = "identity" type="string" />
+</method>
+
+<method name = "rate" polymorphic = "1">
+    Get socket option `rate`.
+    <return type="integer" />
+</method>
+
+<method name = "set rate" polymorphic = "1">
+    Set socket option `rate`.
+    <argument name = "rate" type="integer" />
+</method>
+
+<method name = "recovery ivl" polymorphic = "1">
+    Get socket option `recovery_ivl`.
+    <return type="integer" />
+</method>
+
+<method name = "set recovery ivl" polymorphic = "1">
+    Set socket option `recovery_ivl`.
+    <argument name = "recovery ivl" type="integer" />
+</method>
+
+<method name = "sndbuf" polymorphic = "1">
+    Get socket option `sndbuf`.
+    <return type="integer" />
+</method>
+
+<method name = "set sndbuf" polymorphic = "1">
+    Set socket option `sndbuf`.
+    <argument name = "sndbuf" type="integer" />
+</method>
+
+<method name = "rcvbuf" polymorphic = "1">
+    Get socket option `rcvbuf`.
+    <return type="integer" />
+</method>
+
+<method name = "set rcvbuf" polymorphic = "1">
+    Set socket option `rcvbuf`.
+    <argument name = "rcvbuf" type="integer" />
+</method>
+
+<method name = "linger" polymorphic = "1">
+    Get socket option `linger`.
+    <return type="integer" />
+</method>
+
+<method name = "set linger" polymorphic = "1">
+    Set socket option `linger`.
+    <argument name = "linger" type="integer" />
+</method>
+
+<method name = "reconnect ivl" polymorphic = "1">
+    Get socket option `reconnect_ivl`.
+    <return type="integer" />
+</method>
+
+<method name = "set reconnect ivl" polymorphic = "1">
+    Set socket option `reconnect_ivl`.
+    <argument name = "reconnect ivl" type="integer" />
+</method>
+
+<method name = "reconnect ivl max" polymorphic = "1">
+    Get socket option `reconnect_ivl_max`.
+    <return type="integer" />
+</method>
+
+<method name = "set reconnect ivl max" polymorphic = "1">
+    Set socket option `reconnect_ivl_max`.
+    <argument name = "reconnect ivl max" type="integer" />
+</method>
+
+<method name = "backlog" polymorphic = "1">
+    Get socket option `backlog`.
+    <return type="integer" />
+</method>
+
+<method name = "set backlog" polymorphic = "1">
+    Set socket option `backlog`.
+    <argument name = "backlog" type="integer" />
+</method>
+
+<method name = "maxmsgsize" polymorphic = "1">
+    Get socket option `maxmsgsize`.
+    <return type="int64" />
+</method>
+
+<method name = "set maxmsgsize" polymorphic = "1">
+    Set socket option `maxmsgsize`.
+    <argument name = "maxmsgsize" type="int64" />
+</method>
+
+<method name = "multicast hops" polymorphic = "1">
+    Get socket option `multicast_hops`.
+    <return type="integer" />
+</method>
+
+<method name = "set multicast hops" polymorphic = "1">
+    Set socket option `multicast_hops`.
+    <argument name = "multicast hops" type="integer" />
+</method>
+
+<method name = "rcvtimeo" polymorphic = "1">
+    Get socket option `rcvtimeo`.
+    <return type="integer" />
+</method>
+
+<method name = "set rcvtimeo" polymorphic = "1">
+    Set socket option `rcvtimeo`.
+    <argument name = "rcvtimeo" type="integer" />
+</method>
+
+<method name = "sndtimeo" polymorphic = "1">
+    Get socket option `sndtimeo`.
+    <return type="integer" />
+</method>
+
+<method name = "set sndtimeo" polymorphic = "1">
+    Set socket option `sndtimeo`.
+    <argument name = "sndtimeo" type="integer" />
+</method>
+
+<method name = "set xpub verbose" polymorphic = "1">
+    Set socket option `xpub_verbose`.
+    <argument name = "xpub verbose" type="integer" />
+</method>
+
+<method name = "tcp keepalive" polymorphic = "1">
+    Get socket option `tcp_keepalive`.
+    <return type="integer" />
+</method>
+
+<method name = "set tcp keepalive" polymorphic = "1">
+    Set socket option `tcp_keepalive`.
+    <argument name = "tcp keepalive" type="integer" />
+</method>
+
+<method name = "tcp keepalive idle" polymorphic = "1">
+    Get socket option `tcp_keepalive_idle`.
+    <return type="integer" />
+</method>
+
+<method name = "set tcp keepalive idle" polymorphic = "1">
+    Set socket option `tcp_keepalive_idle`.
+    <argument name = "tcp keepalive idle" type="integer" />
+</method>
+
+<method name = "tcp keepalive cnt" polymorphic = "1">
+    Get socket option `tcp_keepalive_cnt`.
+    <return type="integer" />
+</method>
+
+<method name = "set tcp keepalive cnt" polymorphic = "1">
+    Set socket option `tcp_keepalive_cnt`.
+    <argument name = "tcp keepalive cnt" type="integer" />
+</method>
+
+<method name = "tcp keepalive intvl" polymorphic = "1">
+    Get socket option `tcp_keepalive_intvl`.
+    <return type="integer" />
+</method>
+
+<method name = "set tcp keepalive intvl" polymorphic = "1">
+    Set socket option `tcp_keepalive_intvl`.
+    <argument name = "tcp keepalive intvl" type="integer" />
+</method>
+
+<method name = "tcp accept filter" polymorphic = "1">
+    Get socket option `tcp_accept_filter`.
+    <return type="string" />
+</method>
+
+<method name = "set tcp accept filter" polymorphic = "1">
+    Set socket option `tcp_accept_filter`.
+    <argument name = "tcp accept filter" type="string" />
+</method>
+
+<method name = "rcvmore" polymorphic = "1">
+    Get socket option `rcvmore`.
+    <return type="integer" />
+</method>
+
+<method name = "fd" polymorphic = "1">
+    Get socket option `fd`.
+    <return type="socket" />
+</method>
+
+<method name = "events" polymorphic = "1">
+    Get socket option `events`.
+    <return type="integer" />
+</method>
+
+<method name = "last endpoint" polymorphic = "1">
+    Get socket option `last_endpoint`.
+    <return type="string" />
+</method>
+</methods>

--- a/api/zstr.xml
+++ b/api/zstr.xml
@@ -1,7 +1,7 @@
 <class name = "zstr">
     sending and receiving strings
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor exclude = "1" />
 

--- a/api/ztrie.xml
+++ b/api/ztrie.xml
@@ -1,7 +1,7 @@
 <class name = "ztrie">
     simple trie for tokenizable strings
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <callback_type name = "destroy_data_fn">
         Callback function for ztrie_node to destroy node data.

--- a/api/zuuid.xml
+++ b/api/zuuid.xml
@@ -1,7 +1,7 @@
 <class name = "zuuid">
     UUID support class
 
-    <include filename = "../license.xml" />
+    <include filename = "license.xml" />
 
     <constructor>
         Constructor

--- a/src/sockopts.gsl
+++ b/src/sockopts.gsl
@@ -31,4 +31,4 @@ endfor
 .endtemplate
 .gsl from "zsockopt.gsl"
 .gsl from "zsock_option.gsl"
-.gsl from "../api/zsock.gsl"
+.gsl from "../api/zsock_options.gsl"


### PR DESCRIPTION
This also fixes paths to the license file and actually turns on the `<include>` tag within class API XML files.

This is related to #1164.