### PR TITLE
Problem: Define for server and client socket is unnecessary

### DIFF
--- a/include/zsock.h
+++ b/include/zsock.h
@@ -391,15 +391,11 @@ CZMQ_EXPORT zsock_t *
 CZMQ_EXPORT zsock_t *
     zsock_new_stream_checked (const char *endpoint, const char *filename, size_t line_nbr);
 
-#if ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 2
-
 CZMQ_EXPORT zsock_t *
     zsock_new_server_checked (const char *endpoint, const char *filename, size_t line_nbr);
 
 CZMQ_EXPORT zsock_t *
     zsock_new_client_checked (const char *endpoint, const char *filename, size_t line_nbr);
-
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Solution: We can safely remove it as the libzmq version is carefully handled in the source file.