### PR TITLE
problem: zpoller test can fail if libzmq is not up to date

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -493,7 +493,7 @@ zpoller_test (bool verbose)
     assert (!zpoller_terminated (poller));
     zsys_interrupted = 0;
 
-#ifdef ZMQ_THREAD_SAFE
+#ifdef ZMQ_HAVE_POLLER
 
     //  Check thread safe sockets
     zpoller_destroy (&poller);


### PR DESCRIPTION
Making sure zmq_poller is available before checking server and client sockets