### PR TITLE
Problem: typo in zarmour enum constant

### DIFF
--- a/api/zarmour.xml
+++ b/api/zarmour.xml
@@ -17,7 +17,7 @@
         <constant name = "mode base32 hex" value = "3">
             Extended hex base 32
         </constant>
-        <constant name = "mode base16 hex" value = "4">
+        <constant name = "mode base16" value = "4">
             Standard base 16
         </constant>
         <constant name = "mode z85"        value = "5">


### PR DESCRIPTION
Solution: Fix it.

See #1185.