### PR TITLE
Problem: zsock_option.xml is not installed

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -165,6 +165,7 @@ dist_api_DATA = \
     api/zloop.xml \
     api/zmsg.xml \
     api/zpoller.xml \
+    api/zsock_option.xml \
     api/zsock.xml \
     api/zstr.xml \
     api/ztrie.xml \


### PR DESCRIPTION
Solution: use latest zproject to install this file as well