### PR TITLE
Problem: Latest zproject assumes that API includes are relative to API file

### DIFF
--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -358,5 +358,5 @@
         <return type = "anything" />
     </method>
 
-    <include filename = "api/zsock_option.xml" />
+    <include filename = "zsock_option.xml" />
 </class>


### PR DESCRIPTION
Solution: Further zproject assues that includes are withing API directory. Thus make path from api/zsock.xml to api/zsock_options.xml realtive to api/zsock.xml.