### PR TITLE
Problem: zconfig_execute() doesn't fail early

### DIFF
--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -366,6 +366,8 @@ s_config_execute (zconfig_t *self, zconfig_fct handler, void *arg, int level)
 {
     assert (self);
     int size = handler (self, arg, level);
+    if (size == -1)
+        return 0; // fail early
 
     //  Process all children in one go, as a list
     zconfig_t *child = self->child;


### PR DESCRIPTION
Even if the handler returns -1, it still recursively processes every
first child of the current zconfig item.

Solution: Fail early as soon as a handler returned -1.

I'm **NOT experienced** in C. Maybe this is completely wrong. But IMHO this is correct (and it makes my CZTop Ruby binding test suite pass).