### PR TITLE
zconfig fresh/mutable fixes

### DIFF
--- a/api/zconfig.xml
+++ b/api/zconfig.xml
@@ -11,7 +11,7 @@
     -    zconfig_new (const char *name, zconfig_t *parent);
     <constructor>
         Create new config item
-        <argument name = "name" type = "string" constant = "1" />
+        <argument name = "name" type = "string" />
         <argument name = "parent" type = "zconfig" />
     </constructor>
 
@@ -21,37 +21,37 @@
 
     <method name = "name">
         Return name of config item
-        <return type = "string" fresh = "1" />
+        <return type = "string" mutable = "1" />
     </method>
 
     <method name = "value">
         Return value of config item
-        <return type = "string" fresh = "1" />
+        <return type = "string" mutable = "1" />
     </method>
 
     <method name = "put">
         Insert or update configuration key with value
-        <argument name = "path" type = "string" constant = "1" />
-        <argument name = "value" type = "string" constant = "1" />
+        <argument name = "path" type = "string" />
+        <argument name = "value" type = "string" />
     </method>
 
     <method name = "putf">
         Equivalent to zconfig_put, accepting a format specifier and variable
         argument list, instead of a single string value.
-        <argument name = "path" type = "string" constant = "1" />
+        <argument name = "path" type = "string" />
         <argument name = "format" type = "format" />
     </method>
 
     <method name = "get">
         Get value for config item into a string value; leading slash is optional
         and ignored.
-        <argument name = "path" type = "string" constant = "1" />
-        <argument name = "default value" type = "string" constant = "1" />
-        <return type = "string" fresh = "1" />
+        <argument name = "path" type = "string" />
+        <argument name = "default value" type = "string" />
+        <return type = "string" mutable = "1" />
     </method>
     <method name = "set name">
         Set config item name, name may be NULL
-        <argument name = "name" type = "string" constant = "1" />
+        <argument name = "name" type = "string" />
     </method>
 
     <method name = "set value">
@@ -74,7 +74,7 @@
 
     <method name = "locate">
         Find a config item along a path; leading slash is optional and ignored.
-        <argument name = "path" type = "string" constant = "1" />
+        <argument name = "path" type = "string" />
         <return type = "zconfig" />
     </method>
 
@@ -108,14 +108,14 @@
         Load a config tree from a specified ZPL text file; returns a zconfig_t
         reference for the root, if the file exists and is readable. Returns NULL
         if the file does not exist.
-        <argument name = "filename" type = "string" constant = "1" />
-        <return type = "zconfig" />
+        <argument name = "filename" type = "string" />
+        <return type = "zconfig" fresh = "1" />
     </method>
 
     <method name = "save">
         Save a config tree to a specified ZPL text file, where a filename
         "-" means dump to standard output.
-        <argument name = "filename" type = "string" constant = "1" />
+        <argument name = "filename" type = "string" />
         <return type = "integer" />
     </method>
 
@@ -123,7 +123,7 @@
         Equivalent to zconfig_load, taking a format string instead of a fixed
         filename.
         <argument name = "format" type = "format" />
-        <return type = "zconfig" />
+        <return type = "zconfig" fresh = "1" />
     </method>
 
     <method name = "savef">
@@ -159,8 +159,8 @@
 
     <method name = "str load" singleton = "1" >
         Load a config tree from a null-terminated string
-        <argument name = "string" type = "string" constant = "1" />
-        <return type = "zconfig" />
+        <argument name = "string" type = "string" />
+        <return type = "zconfig" fresh = "1" />
     </method>
 
     <method name = "str save">

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zconfig.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zconfig.c
@@ -30,7 +30,6 @@ Java_zconfig__1_1name (JNIEnv *env, jclass c, jlong self)
 {
     char *name_ = (char *) zconfig_name ((zconfig_t *) self);
     jstring string = (*env)->NewStringUTF (env, name_);
-    zstr_free (&name_);
     return string;
 }
 
@@ -39,7 +38,6 @@ Java_zconfig__1_1value (JNIEnv *env, jclass c, jlong self)
 {
     char *value_ = (char *) zconfig_value ((zconfig_t *) self);
     jstring string = (*env)->NewStringUTF (env, value_);
-    zstr_free (&value_);
     return string;
 }
 
@@ -70,7 +68,6 @@ Java_zconfig__1_1get (JNIEnv *env, jclass c, jlong self, jstring path, jstring d
     char *default_value_ = (char *) (*env)->GetStringUTFChars (env, default_value, NULL);
     char *get_ = (char *) zconfig_get ((zconfig_t *) self, path_, default_value_);
     jstring string = (*env)->NewStringUTF (env, get_);
-    zstr_free (&get_);
     (*env)->ReleaseStringUTFChars (env, path, path_);
     (*env)->ReleaseStringUTFChars (env, default_value, default_value_);
     return string;

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -429,15 +429,15 @@ lib.zconfig_new.restype = zconfig_p
 lib.zconfig_new.argtypes = [c_char_p, zconfig_p]
 lib.zconfig_destroy.restype = None
 lib.zconfig_destroy.argtypes = [POINTER(zconfig_p)]
-lib.zconfig_name.restype = POINTER(c_char)
+lib.zconfig_name.restype = c_char_p
 lib.zconfig_name.argtypes = [zconfig_p]
-lib.zconfig_value.restype = POINTER(c_char)
+lib.zconfig_value.restype = c_char_p
 lib.zconfig_value.argtypes = [zconfig_p]
 lib.zconfig_put.restype = None
 lib.zconfig_put.argtypes = [zconfig_p, c_char_p, c_char_p]
 lib.zconfig_putf.restype = None
 lib.zconfig_putf.argtypes = [zconfig_p, c_char_p, c_char_p]
-lib.zconfig_get.restype = POINTER(c_char)
+lib.zconfig_get.restype = c_char_p
 lib.zconfig_get.argtypes = [zconfig_p, c_char_p, c_char_p]
 lib.zconfig_set_name.restype = None
 lib.zconfig_set_name.argtypes = [zconfig_p, c_char_p]
@@ -521,11 +521,11 @@ class Zconfig(object):
 
     def name(self):
         """Return name of config item"""
-        return return_fresh_string(lib.zconfig_name(self._as_parameter_))
+        return lib.zconfig_name(self._as_parameter_)
 
     def value(self):
         """Return value of config item"""
-        return return_fresh_string(lib.zconfig_value(self._as_parameter_))
+        return lib.zconfig_value(self._as_parameter_)
 
     def put(self, path, value):
         """Insert or update configuration key with value"""
@@ -539,7 +539,7 @@ argument list, instead of a single string value."""
     def get(self, path, default_value):
         """Get value for config item into a string value; leading slash is optional
 and ignored."""
-        return return_fresh_string(lib.zconfig_get(self._as_parameter_, path, default_value))
+        return lib.zconfig_get(self._as_parameter_, path, default_value)
 
     def set_name(self, name):
         """Set config item name, name may be NULL"""
@@ -588,7 +588,7 @@ deleted."""
         """Load a config tree from a specified ZPL text file; returns a zconfig_t
 reference for the root, if the file exists and is readable. Returns NULL
 if the file does not exist."""
-        return Zconfig(lib.zconfig_load(filename), False)
+        return Zconfig(lib.zconfig_load(filename), True)
 
     def save(self, filename):
         """Save a config tree to a specified ZPL text file, where a filename
@@ -599,7 +599,7 @@ if the file does not exist."""
     def loadf(format, *args):
         """Equivalent to zconfig_load, taking a format string instead of a fixed
 filename."""
-        return Zconfig(lib.zconfig_loadf(format, *args), False)
+        return Zconfig(lib.zconfig_loadf(format, *args), True)
 
     def savef(self, format, *args):
         """Equivalent to zconfig_save, taking a format string instead of a fixed
@@ -629,7 +629,7 @@ existing data)."""
     @staticmethod
     def str_load(string):
         """Load a config tree from a null-terminated string"""
-        return Zconfig(lib.zconfig_str_load(string), False)
+        return Zconfig(lib.zconfig_str_load(string), True)
 
     def str_save(self):
         """Save a config tree to a new null terminated string"""

--- a/bindings/qml/src/QmlZconfig.cpp
+++ b/bindings/qml/src/QmlZconfig.cpp
@@ -10,20 +10,14 @@
 
 ///
 //  Return name of config item
-QString QmlZconfig::name () {
-    char *retStr_ = zconfig_name (self);
-    QString retQStr_ = QString (retStr_);
-    free (retStr_);
-    return retQStr_;
+const QString QmlZconfig::name () {
+    return QString (zconfig_name (self));
 };
 
 ///
 //  Return value of config item
-QString QmlZconfig::value () {
-    char *retStr_ = zconfig_value (self);
-    QString retQStr_ = QString (retStr_);
-    free (retStr_);
-    return retQStr_;
+const QString QmlZconfig::value () {
+    return QString (zconfig_value (self));
 };
 
 ///
@@ -42,11 +36,8 @@ void QmlZconfig::putf (const QString &path, const QString &format) {
 ///
 //  Get value for config item into a string value; leading slash is optional
 //  and ignored.                                                            
-QString QmlZconfig::get (const QString &path, const QString &defaultValue) {
-    char *retStr_ = zconfig_get (self, path.toUtf8().data(), defaultValue.toUtf8().data());
-    QString retQStr_ = QString (retStr_);
-    free (retStr_);
-    return retQStr_;
+const QString QmlZconfig::get (const QString &path, const QString &defaultValue) {
+    return QString (zconfig_get (self, path.toUtf8().data(), defaultValue.toUtf8().data()));
 };
 
 ///

--- a/bindings/qml/src/QmlZconfig.h
+++ b/bindings/qml/src/QmlZconfig.h
@@ -29,10 +29,10 @@ public:
     
 public slots:
     //  Return name of config item
-    QString name ();
+    const QString name ();
 
     //  Return value of config item
-    QString value ();
+    const QString value ();
 
     //  Insert or update configuration key with value
     void put (const QString &path, const QString &value);
@@ -43,7 +43,7 @@ public slots:
 
     //  Get value for config item into a string value; leading slash is optional
     //  and ignored.                                                            
-    QString get (const QString &path, const QString &defaultValue);
+    const QString get (const QString &path, const QString &defaultValue);
 
     //  Set config item name, name may be NULL
     void setName (const QString &name);

--- a/bindings/qt/src/qzconfig.cpp
+++ b/bindings/qt/src/qzconfig.cpp
@@ -31,21 +31,17 @@ QZconfig::~QZconfig ()
 
 ///
 //  Return name of config item
-QString QZconfig::name ()
+const QString QZconfig::name ()
 {
-    char *retStr_ = zconfig_name (self);
-    QString rv = QString (retStr_);
-    free (retStr_);;
+    const QString rv = QString (zconfig_name (self));
     return rv;
 }
 
 ///
 //  Return value of config item
-QString QZconfig::value ()
+const QString QZconfig::value ()
 {
-    char *retStr_ = zconfig_value (self);
-    QString rv = QString (retStr_);
-    free (retStr_);;
+    const QString rv = QString (zconfig_value (self));
     return rv;
 }
 
@@ -69,11 +65,9 @@ void QZconfig::putf (const QString &path, const QString &param)
 ///
 //  Get value for config item into a string value; leading slash is optional
 //  and ignored.                                                            
-QString QZconfig::get (const QString &path, const QString &defaultValue)
+const QString QZconfig::get (const QString &path, const QString &defaultValue)
 {
-    char *retStr_ = zconfig_get (self, path.toUtf8().data(), defaultValue.toUtf8().data());
-    QString rv = QString (retStr_);
-    free (retStr_);;
+    const QString rv = QString (zconfig_get (self, path.toUtf8().data(), defaultValue.toUtf8().data()));
     return rv;
 }
 

--- a/bindings/qt/src/qzconfig.h
+++ b/bindings/qt/src/qzconfig.h
@@ -24,10 +24,10 @@ public:
     ~QZconfig ();
 
     //  Return name of config item
-    QString name ();
+    const QString name ();
 
     //  Return value of config item
-    QString value ();
+    const QString value ();
 
     //  Insert or update configuration key with value
     void put (const QString &path, const QString &value);
@@ -38,7 +38,7 @@ public:
 
     //  Get value for config item into a string value; leading slash is optional
     //  and ignored.                                                            
-    QString get (const QString &path, const QString &defaultValue);
+    const QString get (const QString &path, const QString &defaultValue);
 
     //  Set config item name, name may be NULL
     void setName (const QString &name);

--- a/bindings/ruby/lib/czmq/ffi/zconfig.rb
+++ b/bindings/ruby/lib/czmq/ffi/zconfig.rb
@@ -94,7 +94,6 @@ module CZMQ
         raise DestroyedError unless @ptr
         self_p = @ptr
         result = ::CZMQ::FFI.zconfig_name(self_p)
-        result = ::FFI::AutoPointer.new(result, LibC.method(:free))
         result
       end
 
@@ -103,7 +102,6 @@ module CZMQ
         raise DestroyedError unless @ptr
         self_p = @ptr
         result = ::CZMQ::FFI.zconfig_value(self_p)
-        result = ::FFI::AutoPointer.new(result, LibC.method(:free))
         result
       end
 
@@ -136,7 +134,6 @@ module CZMQ
         path = String(path)
         default_value = String(default_value)
         result = ::CZMQ::FFI.zconfig_get(self_p, path, default_value)
-        result = ::FFI::AutoPointer.new(result, LibC.method(:free))
         result
       end
 
@@ -234,7 +231,7 @@ module CZMQ
       def self.load(filename)
         filename = String(filename)
         result = ::CZMQ::FFI.zconfig_load(filename)
-        result = Zconfig.__new result, false
+        result = Zconfig.__new result, true
         result
       end
 
@@ -253,7 +250,7 @@ module CZMQ
       def self.loadf(format, *args)
         format = String(format)
         result = ::CZMQ::FFI.zconfig_loadf(format, *args)
-        result = Zconfig.__new result, false
+        result = Zconfig.__new result, true
         result
       end
 
@@ -303,7 +300,7 @@ module CZMQ
       def self.str_load(string)
         string = String(string)
         result = ::CZMQ::FFI.zconfig_str_load(string)
-        result = Zconfig.__new result, false
+        result = Zconfig.__new result, true
         result
       end
 

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -34,12 +34,10 @@ CZMQ_EXPORT void
     zconfig_destroy (zconfig_t **self_p);
 
 //  Return name of config item
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT char *
     zconfig_name (zconfig_t *self);
 
 //  Return value of config item
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT char *
     zconfig_value (zconfig_t *self);
 
@@ -54,7 +52,6 @@ CZMQ_EXPORT void
 
 //  Get value for config item into a string value; leading slash is optional
 //  and ignored.                                                            
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT char *
     zconfig_get (zconfig_t *self, const char *path, const char *default_value);
 
@@ -103,6 +100,7 @@ CZMQ_EXPORT zlist_t *
 //  Load a config tree from a specified ZPL text file; returns a zconfig_t  
 //  reference for the root, if the file exists and is readable. Returns NULL
 //  if the file does not exist.                                             
+//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zconfig_t *
     zconfig_load (const char *filename);
 
@@ -113,6 +111,7 @@ CZMQ_EXPORT int
 
 //  Equivalent to zconfig_load, taking a format string instead of a fixed
 //  filename.                                                            
+//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zconfig_t *
     zconfig_loadf (const char *format, ...) CHECK_PRINTF (1);
 
@@ -140,6 +139,7 @@ CZMQ_EXPORT zchunk_t *
     zconfig_chunk_save (zconfig_t *self);
 
 //  Load a config tree from a null-terminated string
+//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zconfig_t *
     zconfig_str_load (const char *string);
 


### PR DESCRIPTION
When writing the API file, I only looked at the documentation and assumed that all `char *` are fresh when in fact some of them are simply mutable.

I also missed that zconfig_load(), zconfig_loadf(), and zconfig_savef(), of course, return fresh objects.

This also removes the attribute `constant = "1"` from some of the arguments, which is useless now.