### PR TITLE
Problem: .self is private so we can't use it from other packages

### DIFF
--- a/bindings/jni/build.gradle
+++ b/bindings/jni/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 }
 task generateJniHeaders(type: Exec, dependsOn: 'classes') {
     def classpath = sourceSets.main.output.classesDir
+    def appclasspath = configurations.runtime.files*.getAbsolutePath().join(":")
     def nativeIncludes = "src/native/include"
     def jniClasses = [
             'org.zeromq.czmq.Zarmour',
@@ -44,7 +45,7 @@ task generateJniHeaders(type: Exec, dependsOn: 'classes') {
             'org.zeromq.czmq.Ztrie',
             'org.zeromq.czmq.Zuuid'
     ]
-    commandLine("javah", "-d", "$nativeIncludes", "-classpath", "$classpath", *jniClasses)
+    commandLine("javah", "-d", "$nativeIncludes", "-classpath", "$classpath:$appclasspath", *jniClasses)
 }
 tasks.withType(Test) {
     systemProperty "java.library.path", "/usr/lib:/usr/local/lib:$projectDir"

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zarmour.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zarmour.java
@@ -15,7 +15,7 @@ public class Zarmour implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new zarmour.
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zconfig.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zconfig.java
@@ -15,7 +15,7 @@ public class Zconfig implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create new config item
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zdir.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zdir.java
@@ -15,7 +15,7 @@ public class Zdir implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new directory item that loads in the full tree of the specified
     path, optionally located under some parent path. If parent is "-", then 

--- a/bindings/jni/src/main/java/org/zeromq/czmq/ZdirPatch.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/ZdirPatch.java
@@ -15,7 +15,7 @@ public class ZdirPatch implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create new patch
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zfile.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zfile.java
@@ -15,7 +15,7 @@ public class Zfile implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     If file exists, populates properties. CZMQ supports portable symbolic
     links, which are files with the extension ".ln". A symbolic link is a

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zframe.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zframe.java
@@ -15,7 +15,7 @@ public class Zframe implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new frame. If size is not null, allocates the frame data
     to the specified size. If additionally, data is not null, copies 

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
@@ -15,7 +15,7 @@ public class Zhash implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new, empty hash container
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zhashx.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zhashx.java
@@ -15,7 +15,7 @@ public class Zhashx implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new, empty hash container
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
@@ -15,7 +15,7 @@ public class Ziflist implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Get a list of network interfaces currently defined on the system
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zlist.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zlist.java
@@ -15,7 +15,7 @@ public class Zlist implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new list container
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zloop.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zloop.java
@@ -15,7 +15,7 @@ public class Zloop implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new zloop reactor
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zmsg.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zmsg.java
@@ -15,7 +15,7 @@ public class Zmsg implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new empty message object
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zpoller.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zpoller.java
@@ -15,7 +15,7 @@ public class Zpoller implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create new poller; the reader can be a libzmq socket (void *), a zsock_t
     instance, or a zactor_t instance.                                       

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -15,7 +15,7 @@ public class Zsock implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new socket. Returns the new socket, or NULL if the new socket
     could not be created. Note that the symbol zsock_new (and other       

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zstr.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zstr.java
@@ -15,7 +15,7 @@ public class Zstr {
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     public Zstr () {
         self = 0;
     }

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Ztrie.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Ztrie.java
@@ -15,7 +15,7 @@ public class Ztrie implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Creates a new ztrie.
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zuuid.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zuuid.java
@@ -15,7 +15,7 @@ public class Zuuid implements AutoCloseable{
             System.exit (-1);
         }
     }
-    long self;
+    public long self;
     /*
     Create a new UUID object.
     */


### PR DESCRIPTION
Solution: make this a public property. This opens the door to
general mayhem but it lets us pass CZMQ classes to other methods
in e.g. Zyre.