### PR TITLE
Problem: Qt bindings don't work as qzconfig has an extra comma with method reload.

### DIFF
--- a/bindings/qt/src/qzconfig.cpp
+++ b/bindings/qt/src/qzconfig.cpp
@@ -200,7 +200,7 @@ const QString QZconfig::filename ()
 //  existing data).                                                      
 int QZconfig::reload ()
 {
-    int rv = zconfig_reload (&self, );
+    int rv = zconfig_reload (&self);
     return rv;
 }
 


### PR DESCRIPTION
Solution: Re-generate with latest zproject to fix it.