### PR TITLE
Problem: many constructors are disguised in API model

### DIFF
--- a/api/zconfig.xml
+++ b/api/zconfig.xml
@@ -103,13 +103,12 @@
         <return type = "zlist" />
     </method>
 
-    <method name = "load" singleton = "1" >
+    <constructor name = "load">
         Load a config tree from a specified ZPL text file; returns a zconfig_t
         reference for the root, if the file exists and is readable. Returns NULL
         if the file does not exist.
         <argument name = "filename" type = "string" />
-        <return type = "zconfig" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "save">
         Save a config tree to a specified ZPL text file, where a filename
@@ -118,12 +117,11 @@
         <return type = "integer" />
     </method>
 
-    <method name = "loadf" singleton = "1" >
+    <constructor name = "loadf">
         Equivalent to zconfig_load, taking a format string instead of a fixed
         filename.
         <argument name = "format" type = "format" />
-        <return type = "zconfig" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "savef">
         Equivalent to zconfig_save, taking a format string instead of a fixed

--- a/api/zframe.xml
+++ b/api/zframe.xml
@@ -26,24 +26,21 @@
         Destroy a frame
     </destructor>
 
-    <method name = "new empty" singleton = "1">
+    <constructor name = "new empty">
         Create an empty (zero-sized) frame
-        <return type = "zframe" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "from" singleton = "1">
+    <constructor name = "from">
         Create a frame with a specified string content.
         <argument name = "string" type = "string" />
-        <return type = "zframe" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "recv" singleton = "1">
+    <constructor name = "recv">
         Receive frame from socket, returns zframe_t object or NULL if the recv
         was interrupted. Does a blocking recv, if you want to not block then use
         zpoller or zloop.
         <argument name = "source" type = "anything" />
-        <return type = "zframe" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "send" singleton = "1">
         Send a frame to a socket, destroy frame after sending.

--- a/api/zhash.xml
+++ b/api/zhash.xml
@@ -146,13 +146,12 @@
         <return type = "zframe" fresh = "1" />
     </method>
 
-    <method name = "unpack" singleton = "1">
+    <constructor name = "unpack">
         Unpack binary frame into a new hash table. Packed data must follow format
         defined by zhash_pack. Hash table is set to autofree. An empty frame
         unpacks to an empty hash table.
         <argument name = "frame" type = "zframe" />
-        <return type = "zhash" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "save">
         Save hash table to a text file in name=value format. Hash values must be

--- a/api/zhashx.xml
+++ b/api/zhashx.xml
@@ -203,13 +203,12 @@
         <return type = "zframe" fresh = "1" />
     </method>
 
-    <method name = "unpack" singleton = "1">
+    <constructor name = "unpack">
         Unpack binary frame into a new hash table. Packed data must follow format
         defined by zhashx_pack. Hash table is set to autofree. An empty frame
         unpacks to an empty hash table.
         <argument name = "frame" type = "zframe" />
-        <return type = "zhashx" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "dup">
         Make a copy of the list; items are duplicated if you set a duplicator

--- a/api/zmsg.xml
+++ b/api/zmsg.xml
@@ -18,14 +18,13 @@
         Destroy a message object and all frames it contains
     </destructor>
 
-    <method name = "recv" singleton = "1">
+    <constructor name = "recv">
         Receive message from socket, returns zmsg_t object or NULL if the recv
         was interrupted. Does a blocking recv. If you want to not block then use
         the zloop class or zmsg_recv_nowait or zmq_poll to check for socket input
         before receiving.
         <argument name = "source" type = "anything" />
-        <return type = "zmsg" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "send" singleton = "1">
         Send message to destination socket, and destroy the message after sending
@@ -190,13 +189,11 @@
         <return type = "integer" />
     </method>
 
-    <method name = "load">
-        Load/append an open file into message, create new message if
-        null message provided. Returns NULL if the message could not
-        be loaded.
+    <constructor name = "load">
+        Load/append an open file into new message, return the message.
+        Returns NULL if the message could not be loaded.
         <argument name = "file" type = "FILE" />
-        <return type = "zmsg" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "encode">
         Serialize multipart message to a single buffer. Use this method to send
@@ -207,14 +204,13 @@
         <return type = "size" />
     </method>
 
-    <method name = "decode" singleton = "1">
+    <constructor name = "decode">
         Decodes a serialized message buffer created by zmsg_encode () and returns
         a new zmsg_t object. Returns NULL if the buffer was badly formatted or
         there was insufficient memory to work.
         <argument name = "buffer" type = "buffer" />
         <argument name = "buffer size" type = "size" />
-        <return type = "zmsg" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "dup">
         Create copy of message, as new message object. Returns a fresh zmsg_t
@@ -235,13 +231,12 @@
         <return type = "boolean" />
     </method>
 
-    <method name = "new signal" singleton = "1">
+    <constructor name = "new signal">
         Generate a signal message encoding the given status. A signal is a short
         message carrying a 1-byte success/failure code (by convention, 0 means
         OK). Signals are encoded to be distinguishable from "normal" messages.
         <argument name = "status" type = "byte" />
-        <return type = "zmsg" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "signal">
         Return signal value, 0 or greater, if message is a signal, -1 if not.

--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -25,91 +25,77 @@
         zsock_new method.
     </destructor>
 
-    <method name = "new pub" singleton = "1">
+    <constructor name = "new pub">
         Create a PUB socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new sub" singleton = "1">
+    <constructor name = "new sub">
         Create a SUB socket, and optionally subscribe to some prefix string. Default
         action is connect.
         <argument name = "endpoint" type = "string" />
         <argument name = "subscribe" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new req" singleton = "1">
+    <constructor name = "new req">
         Create a REQ socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new rep" singleton = "1">
+    <constructor name = "new rep">
         Create a REP socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new dealer" singleton = "1">
+    <constructor name = "new dealer">
         Create a DEALER socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new router" singleton = "1">
+    <constructor name = "new router">
         Create a ROUTER socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new push" singleton = "1">
+    <constructor name = "new push">
         Create a PUSH socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new pull" singleton = "1">
+    <constructor name = "new pull">
         Create a PULL socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new xpub" singleton = "1">
+    <constructor name = "new xpub">
         Create an XPUB socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new xsub" singleton = "1">
+    <constructor name = "new xsub">
         Create an XSUB socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new pair" singleton = "1">
+    <constructor name = "new pair">
         Create a PAIR socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new stream" singleton = "1">
+    <constructor name = "new stream">
         Create a STREAM socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new server" singleton = "1">
+    <constructor name = "new server">
         Create a SERVER socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
-    <method name = "new client" singleton = "1">
+    <constructor name = "new client">
         Create a CLIENT socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
-        <return type = "zsock" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "bind">
         Bind a socket to a formatted endpoint. For tcp:// endpoints, supports

--- a/api/zuuid.xml
+++ b/api/zuuid.xml
@@ -18,11 +18,10 @@
         Destroy a specified UUID object.
     </destructor>
 
-    <method name = "new from" singleton = "1">
+    <constructor name = "new from">
         Create UUID object from supplied ZUUID_LEN-octet value.
         <argument name = "source" type = "buffer" />
-        <return type = "zuuid" fresh = "1" />
-    </method>
+    </constructor>
 
     <method name = "set">
         Set UUID to new supplied ZUUID_LEN-octet value.

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -29,6 +29,17 @@ typedef int (zconfig_fct) (
 CZMQ_EXPORT zconfig_t *
     zconfig_new (const char *name, zconfig_t *parent);
 
+//  Load a config tree from a specified ZPL text file; returns a zconfig_t  
+//  reference for the root, if the file exists and is readable. Returns NULL
+//  if the file does not exist.                                             
+CZMQ_EXPORT zconfig_t *
+    zconfig_load (const char *filename);
+
+//  Equivalent to zconfig_load, taking a format string instead of a fixed
+//  filename.                                                            
+CZMQ_EXPORT zconfig_t *
+    zconfig_loadf (const char *format, ...) CHECK_PRINTF (1);
+
 //  Destroy a config item and all its children
 CZMQ_EXPORT void
     zconfig_destroy (zconfig_t **self_p);
@@ -97,23 +108,10 @@ CZMQ_EXPORT void
 CZMQ_EXPORT zlist_t *
     zconfig_comments (zconfig_t *self);
 
-//  Load a config tree from a specified ZPL text file; returns a zconfig_t  
-//  reference for the root, if the file exists and is readable. Returns NULL
-//  if the file does not exist.                                             
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zconfig_t *
-    zconfig_load (const char *filename);
-
 //  Save a config tree to a specified ZPL text file, where a filename
 //  "-" means dump to standard output.                               
 CZMQ_EXPORT int
     zconfig_save (zconfig_t *self, const char *filename);
-
-//  Equivalent to zconfig_load, taking a format string instead of a fixed
-//  filename.                                                            
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zconfig_t *
-    zconfig_loadf (const char *format, ...) CHECK_PRINTF (1);
 
 //  Equivalent to zconfig_save, taking a format string instead of a fixed
 //  filename.                                                            

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -31,26 +31,23 @@ extern "C" {
 CZMQ_EXPORT zframe_t *
     zframe_new (const void *data, size_t size);
 
-//  Destroy a frame
-CZMQ_EXPORT void
-    zframe_destroy (zframe_t **self_p);
-
 //  Create an empty (zero-sized) frame
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zframe_t *
     zframe_new_empty ();
 
 //  Create a frame with a specified string content.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zframe_t *
     zframe_from (const char *string);
 
 //  Receive frame from socket, returns zframe_t object or NULL if the recv  
 //  was interrupted. Does a blocking recv, if you want to not block then use
 //  zpoller or zloop.                                                       
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zframe_t *
     zframe_recv (void *source);
+
+//  Destroy a frame
+CZMQ_EXPORT void
+    zframe_destroy (zframe_t **self_p);
 
 //  Send a frame to a socket, destroy frame after sending.
 //  Return -1 on error, 0 on success.                     

--- a/include/zhash.h
+++ b/include/zhash.h
@@ -33,6 +33,12 @@ typedef int (zhash_foreach_fn) (
 CZMQ_EXPORT zhash_t *
     zhash_new ();
 
+//  Unpack binary frame into a new hash table. Packed data must follow format
+//  defined by zhash_pack. Hash table is set to autofree. An empty frame     
+//  unpacks to an empty hash table.                                          
+CZMQ_EXPORT zhash_t *
+    zhash_unpack (zframe_t *frame);
+
 //  Destroy a hash container and all items in it
 CZMQ_EXPORT void
     zhash_destroy (zhash_t **self_p);
@@ -140,13 +146,6 @@ CZMQ_EXPORT void
 //  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zframe_t *
     zhash_pack (zhash_t *self);
-
-//  Unpack binary frame into a new hash table. Packed data must follow format
-//  defined by zhash_pack. Hash table is set to autofree. An empty frame     
-//  unpacks to an empty hash table.                                          
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zhash_t *
-    zhash_unpack (zframe_t *frame);
 
 //  Save hash table to a text file in name=value format. Hash values must be
 //  printable strings; keys may not contain '=' character. Returns 0 if OK, 

--- a/include/zhashx.h
+++ b/include/zhashx.h
@@ -50,6 +50,12 @@ typedef int (zhashx_foreach_fn) (
 CZMQ_EXPORT zhashx_t *
     zhashx_new ();
 
+//  Unpack binary frame into a new hash table. Packed data must follow format
+//  defined by zhashx_pack. Hash table is set to autofree. An empty frame    
+//  unpacks to an empty hash table.                                          
+CZMQ_EXPORT zhashx_t *
+    zhashx_unpack (zframe_t *frame);
+
 //  Destroy a hash container and all items in it
 CZMQ_EXPORT void
     zhashx_destroy (zhashx_t **self_p);
@@ -185,13 +191,6 @@ CZMQ_EXPORT int
 //  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zframe_t *
     zhashx_pack (zhashx_t *self);
-
-//  Unpack binary frame into a new hash table. Packed data must follow format
-//  defined by zhashx_pack. Hash table is set to autofree. An empty frame    
-//  unpacks to an empty hash table.                                          
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zhashx_t *
-    zhashx_unpack (zframe_t *frame);
 
 //  Make a copy of the list; items are duplicated if you set a duplicator 
 //  for the list, otherwise not. Copying a null reference returns a null  

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -25,17 +25,33 @@ extern "C" {
 CZMQ_EXPORT zmsg_t *
     zmsg_new ();
 
-//  Destroy a message object and all frames it contains
-CZMQ_EXPORT void
-    zmsg_destroy (zmsg_t **self_p);
-
 //  Receive message from socket, returns zmsg_t object or NULL if the recv   
 //  was interrupted. Does a blocking recv. If you want to not block then use 
 //  the zloop class or zmsg_recv_nowait or zmq_poll to check for socket input
 //  before receiving.                                                        
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zmsg_t *
     zmsg_recv (void *source);
+
+//  Load/append an open file into new message, return the message.
+//  Returns NULL if the message could not be loaded.              
+CZMQ_EXPORT zmsg_t *
+    zmsg_load (FILE *file);
+
+//  Decodes a serialized message buffer created by zmsg_encode () and returns
+//  a new zmsg_t object. Returns NULL if the buffer was badly formatted or   
+//  there was insufficient memory to work.                                   
+CZMQ_EXPORT zmsg_t *
+    zmsg_decode (const byte *buffer, size_t buffer_size);
+
+//  Generate a signal message encoding the given status. A signal is a short
+//  message carrying a 1-byte success/failure code (by convention, 0 means  
+//  OK). Signals are encoded to be distinguishable from "normal" messages.  
+CZMQ_EXPORT zmsg_t *
+    zmsg_new_signal (byte status);
+
+//  Destroy a message object and all frames it contains
+CZMQ_EXPORT void
+    zmsg_destroy (zmsg_t **self_p);
 
 //  Send message to destination socket, and destroy the message after sending
 //  it successfully. If the message has no frames, sends nothing but destroys
@@ -164,26 +180,12 @@ CZMQ_EXPORT zframe_t *
 CZMQ_EXPORT int
     zmsg_save (zmsg_t *self, FILE *file);
 
-//  Load/append an open file into message, create new message if
-//  null message provided. Returns NULL if the message could not
-//  be loaded.                                                  
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zmsg_t *
-    zmsg_load (zmsg_t *self, FILE *file);
-
 //  Serialize multipart message to a single buffer. Use this method to send  
 //  structured messages across transports that do not support multipart data.
 //  Allocates and returns a new buffer containing the serialized message.    
 //  To decode a serialized message buffer, use zmsg_decode ().               
 CZMQ_EXPORT size_t
     zmsg_encode (zmsg_t *self, byte **buffer);
-
-//  Decodes a serialized message buffer created by zmsg_encode () and returns
-//  a new zmsg_t object. Returns NULL if the buffer was badly formatted or   
-//  there was insufficient memory to work.                                   
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zmsg_t *
-    zmsg_decode (const byte *buffer, size_t buffer_size);
 
 //  Create copy of message, as new message object. Returns a fresh zmsg_t
 //  object. If message is null, or memory was exhausted, returns null.   
@@ -201,13 +203,6 @@ CZMQ_EXPORT void
 //  other message. As with zframe_eq, return false if either message is NULL.
 CZMQ_EXPORT bool
     zmsg_eq (zmsg_t *self, zmsg_t *other);
-
-//  Generate a signal message encoding the given status. A signal is a short
-//  message carrying a 1-byte success/failure code (by convention, 0 means  
-//  OK). Signals are encoded to be distinguishable from "normal" messages.  
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zmsg_t *
-    zmsg_new_signal (byte status);
 
 //  Return signal value, 0 or greater, if message is a signal, -1 if not.
 CZMQ_EXPORT int

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -36,81 +36,67 @@ extern "C" {
 CZMQ_EXPORT zsock_t *
     zsock_new (int type);
 
-//  Destroy the socket. You must use this for any socket created via the
-//  zsock_new method.                                                   
-CZMQ_EXPORT void
-    zsock_destroy (zsock_t **self_p);
-
 //  Create a PUB socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_pub (const char *endpoint);
 
 //  Create a SUB socket, and optionally subscribe to some prefix string. Default
 //  action is connect.                                                          
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_sub (const char *endpoint, const char *subscribe);
 
 //  Create a REQ socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_req (const char *endpoint);
 
 //  Create a REP socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_rep (const char *endpoint);
 
 //  Create a DEALER socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_dealer (const char *endpoint);
 
 //  Create a ROUTER socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_router (const char *endpoint);
 
 //  Create a PUSH socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_push (const char *endpoint);
 
 //  Create a PULL socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_pull (const char *endpoint);
 
 //  Create an XPUB socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_xpub (const char *endpoint);
 
 //  Create an XSUB socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_xsub (const char *endpoint);
 
 //  Create a PAIR socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_pair (const char *endpoint);
 
 //  Create a STREAM socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_stream (const char *endpoint);
 
 //  Create a SERVER socket. Default action is bind.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_server (const char *endpoint);
 
 //  Create a CLIENT socket. Default action is connect.
-//  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT zsock_t *
     zsock_new_client (const char *endpoint);
+
+//  Destroy the socket. You must use this for any socket created via the
+//  zsock_new method.                                                   
+CZMQ_EXPORT void
+    zsock_destroy (zsock_t **self_p);
 
 //  Bind a socket to a formatted endpoint. For tcp:// endpoints, supports   
 //  ephemeral ports, if you specify the port number as "*". By default      

--- a/include/zuuid.h
+++ b/include/zuuid.h
@@ -28,14 +28,13 @@ extern "C" {
 CZMQ_EXPORT zuuid_t *
     zuuid_new ();
 
+//  Create UUID object from supplied ZUUID_LEN-octet value.
+CZMQ_EXPORT zuuid_t *
+    zuuid_new_from (const byte *source);
+
 //  Destroy a specified UUID object.
 CZMQ_EXPORT void
     zuuid_destroy (zuuid_t **self_p);
-
-//  Create UUID object from supplied ZUUID_LEN-octet value.
-//  The caller is responsible for destroying the return value when finished with it.
-CZMQ_EXPORT zuuid_t *
-    zuuid_new_from (const byte *source);
 
 //  Set UUID to new supplied ZUUID_LEN-octet value.
 CZMQ_EXPORT void


### PR DESCRIPTION
Solution: expose all singletons that return fresh instances as
constructors.

Note: this changed the signature for zmsg_load(), which was a
mix of constructor and method.

Fixes #949
Among other things.

Breaks the JNI and Python binding generators, probably.