### PR TITLE
Problem: doc for zsock_brecv is inaccurate

### DIFF
--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -280,8 +280,11 @@
         reduce memory allocations. The pattern argument is a string that defines
         the type of each argument. See zsock_bsend for the supported argument
         types. All arguments must be pointers; this call sets them to point to
-        values held on a per-socket basis. Do not modify or destroy the returned
-        values. Returns 0 if successful, or -1 if it failed to read a message.
+        values held on a per-socket basis.
+        Note that zsock_brecv creates the returned objects, and the caller must
+        destroy them when finished with them. The supplied pointers do not need
+        to be initialized. Returns 0 if successful, or -1 if it failed to read
+        a message.
         <argument name = "picture" type = "string" variadic = "1" />
         <return type = "integer" />
     </method>

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -255,8 +255,11 @@ CZMQ_EXPORT int
 //  reduce memory allocations. The pattern argument is a string that defines
 //  the type of each argument. See zsock_bsend for the supported argument   
 //  types. All arguments must be pointers; this call sets them to point to  
-//  values held on a per-socket basis. Do not modify or destroy the returned
-//  values. Returns 0 if successful, or -1 if it failed to read a message.  
+//  values held on a per-socket basis.                                      
+//  Note that zsock_brecv creates the returned objects, and the caller must 
+//  destroy them when finished with them. The supplied pointers do not need 
+//  to be initialized. Returns 0 if successful, or -1 if it failed to read  
+//  a message.                                                              
 CZMQ_EXPORT int
     zsock_brecv (void *self, const char *picture, ...);
 

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1319,8 +1319,11 @@ zsock_bsend (void *self, const char *picture, ...)
 //  reduce memory allocations. The pattern argument is a string that defines
 //  the type of each argument. See zsock_bsend for the supported argument
 //  types. All arguments must be pointers; this call sets them to point to
-//  values held on a per-socket basis. Do not modify or destroy the returned
-//  values. Returns 0 if successful, or -1 if it failed to read a message.
+//  values held on a per-socket basis.
+//  Note that zsock_brecv creates the returned objects, and the caller must
+//  destroy them when finished with them. The supplied pointers do not need
+//  to be initialized. Returns 0 if successful, or -1 if it failed to read
+//  a message.
 
 //  This is the largest size we allow for an incoming longstr or chunk (1M)
 #define MAX_ALLOC_SIZE      1024 * 1024


### PR DESCRIPTION
Returned objects are owned by caller, who must destroy them.

Solution: fix this.

Fixes #1223