### PR TITLE
Problem: czmq_selftest block-local variable fails for MSVC

### DIFF
--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -140,8 +140,8 @@ test_available (const char *testname)
 static inline void
 test_runall (bool verbose)
 {
-    printf ("Running czmq selftests...\n");
     test_item_t *item;
+    printf ("Running czmq selftests...\n");
     for (item = all_tests; item->test; item++)
         item->test (verbose);
 


### PR DESCRIPTION
A printf statement occurred before the block-local variable. MSVC
failed to compile. Swapping the order fixes the problem.