### PR TITLE
Problem: unsafe use of format

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -237,7 +237,7 @@ zcert_load (const char *filename)
             zconfig_t *metadata = zconfig_locate (root, "/metadata");
             zconfig_t *item = metadata? zconfig_child (metadata): NULL;
             while (item) {
-                zcert_set_meta (self, zconfig_name (item), zconfig_value (item));
+                zcert_set_meta (self, zconfig_name (item), "%s", zconfig_value (item));
                 item = zconfig_next (item);
             }
         }

--- a/src/zmakecert.c
+++ b/src/zmakecert.c
@@ -30,7 +30,7 @@ s_get_meta (zcert_t *cert, char *prompt, char *name)
     if (strlen (value) && value [strlen (value) - 1] == '\n')
         value [strlen (value) - 1] = 0;
     if (*value)
-        zcert_set_meta (cert, name, value);
+        zcert_set_meta (cert, name, "%s", value);
     return 0;
 }
 
@@ -46,7 +46,7 @@ int main (void)
         
     char *timestr = zclock_timestr ();
     zcert_set_meta (cert, "created-by", "CZMQ zmakecert");
-    zcert_set_meta (cert, "date-created", timestr);
+    zcert_set_meta (cert, "date-created", "%s", timestr);
     free (timestr);
     zcert_dump (cert);
     zcert_save (cert, "mycert.txt");


### PR DESCRIPTION
Solution: provide string literals as format

This closes #1230.