### PR TITLE
Problem: zcert_save() ignores result of zcert_save_public()

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -280,12 +280,13 @@ zcert_save (zcert_t *self, const char *filename)
     assert (filename);
 
     //  Save public certificate using specified filename
-    zcert_save_public (self, filename);
+    int rc = zcert_save_public (self, filename);
+    if (rc == -1) return rc;
 
     //  Now save secret certificate using filename with "_secret" suffix
     char filename_secret [256];
     snprintf (filename_secret, 256, "%s_secret", filename);
-    int rc = zcert_save_secret (self, filename_secret);
+    rc = zcert_save_secret (self, filename_secret);
     return rc;
 }
 


### PR DESCRIPTION
This leads to being able to give the empty string as filename and it'll
create a single file "_secret".

Solution: check zcert_save_public()'s return value

This is for #1244.