### PR TITLE
Problem: no way to unset zcert metadata

### DIFF
--- a/api/zcert.xml
+++ b/api/zcert.xml
@@ -55,6 +55,11 @@
         <argument name = "format" type = "format" />
     </method>
 
+    <method name = "unset meta">
+        Unset certificate metadata.
+        <argument name = "name" type = "string" />
+    </method>
+
     <method name = "meta">
         Get metadata value from certificate; if the metadata value doesn't
         exist, returns NULL.

--- a/include/zcert.h
+++ b/include/zcert.h
@@ -57,6 +57,10 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT void
     zcert_set_meta (zcert_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
 
+//  Unset certificate metadata.
+CZMQ_EXPORT void
+    zcert_unset_meta (zcert_t *self, const char *name);
+
 //  Get metadata value from certificate; if the metadata value doesn't
 //  exist, returns NULL.                                              
 CZMQ_EXPORT char *

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -170,6 +170,7 @@ zcert_secret_txt (zcert_t *self)
 void
 zcert_set_meta (zcert_t *self, const char *name, const char *format, ...)
 {
+    assert(self);
     va_list argptr;
     va_start (argptr, format);
     char *value = zsys_vprintf (format, argptr);

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -180,6 +180,16 @@ zcert_set_meta (zcert_t *self, const char *name, const char *format, ...)
     zstr_free (&value);
 }
 
+//  --------------------------------------------------------------------------
+//  Unset certificate metadata.
+
+void
+zcert_unset_meta (zcert_t *self, const char *name)
+{
+    assert(self);
+    assert (name);
+    zhash_delete (self->metadata, name);
+}
 
 //  --------------------------------------------------------------------------
 //  Get metadata value from certificate; if the metadata value doesn't
@@ -455,6 +465,8 @@ zcert_test (bool verbose)
     zcert_set_meta (cert, "name", "Pieter Hintjens");
     zcert_set_meta (cert, "organization", "iMatix Corporation");
     zcert_set_meta (cert, "version", "%d", 1);
+    zcert_set_meta (cert, "delete_me", "now");
+    zcert_unset_meta (cert, "delete_me");
     assert (streq (zcert_meta (cert, "email"), "ph@imatix.com"));
     zlist_t *keys = zcert_meta_keys (cert);
     assert (zlist_size (keys) == 4);


### PR DESCRIPTION
Solution: add zcert_unset_meta()

This also adds a missing assert in zcert_set_meta().