### PR TITLE
Problem: zcert_set_meta() doesn't assert enough

### DIFF
--- a/src/zcert.c
+++ b/src/zcert.c
@@ -171,6 +171,8 @@ void
 zcert_set_meta (zcert_t *self, const char *name, const char *format, ...)
 {
     assert(self);
+    assert(name);
+    assert(format);
     va_list argptr;
     va_start (argptr, format);
     char *value = zsys_vprintf (format, argptr);


### PR DESCRIPTION
Solution: assert name and format as well

As discussed on #1246.