### PR TITLE
Problem: "interface" is a reserved word

### DIFF
--- a/api/zproc.xml
+++ b/api/zproc.xml
@@ -68,7 +68,7 @@
         <argument name = "max_sockets" type = "size" />
     </method>
 
-    <method name = "set interface" singleton = "1">
+    <method name = "set biface" singleton = "1">
         Set network interface name to use for broadcasts, particularly zbeacon.
         This lets the interface be configured for test environments where required.
         For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is
@@ -78,7 +78,7 @@
         <argument name = "value" type = "string" />
     </method>
 
-    <method name = "interface" singleton = "1">
+    <method name = "biface" singleton = "1">
         Return network interface to use for broadcasts, or "" if none was set.
         <return type = "string" />
     </method>

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zcert.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zcert.c
@@ -71,6 +71,14 @@ Java_org_zeromq_czmq_Zcert__1_1setMeta (JNIEnv *env, jclass c, jlong self, jstri
     (*env)->ReleaseStringUTFChars (env, format, format_);
 }
 
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zcert__1_1unsetMeta (JNIEnv *env, jclass c, jlong self, jstring name)
+{
+    char *name_ = (char *) (*env)->GetStringUTFChars (env, name, NULL);
+    zcert_unset_meta ((zcert_t *) (intptr_t) self, name_);
+    (*env)->ReleaseStringUTFChars (env, name, name_);
+}
+
 JNIEXPORT jstring JNICALL
 Java_org_zeromq_czmq_Zcert__1_1meta (JNIEnv *env, jclass c, jlong self, jstring name)
 {

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
@@ -65,80 +65,42 @@ Java_org_zeromq_czmq_Zproc__1_1setMaxSockets (JNIEnv *env, jclass c, jlong max_s
     zproc_set_max_sockets ((size_t) max_sockets);
 }
 
-JNIEXPORT jlong JNICALL
-Java_org_zeromq_czmq_Zproc__1_1maxSockets (JNIEnv *env, jclass c)
-{
-    jlong max_sockets_ = (jlong) zproc_max_sockets ();
-    return max_sockets_;
-}
-
 JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1setLinger (JNIEnv *env, jclass c, jlong linger)
-{
-    zproc_set_linger ((size_t) linger);
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1setSndhwm (JNIEnv *env, jclass c, jlong sndhwm)
-{
-    zproc_set_sndhwm ((size_t) sndhwm);
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1setRcvhwm (JNIEnv *env, jclass c, jlong rcvhwm)
-{
-    zproc_set_rcvhwm ((size_t) rcvhwm);
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1setIpv6 (JNIEnv *env, jclass c, jboolean ipv6)
-{
-    zproc_set_ipv6 ((bool) ipv6);
-}
-
-JNIEXPORT jboolean JNICALL
-Java_org_zeromq_czmq_Zproc__1_1ipv6 (JNIEnv *env, jclass c)
-{
-    jboolean ipv6_ = (jboolean) zproc_ipv6 ();
-    return ipv6_;
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1setInterface (JNIEnv *env, jclass c, jstring value)
+Java_org_zeromq_czmq_Zproc__1_1setBiface (JNIEnv *env, jclass c, jstring value)
 {
     char *value_ = (char *) (*env)->GetStringUTFChars (env, value, NULL);
-    zproc_set_interface (value_);
+    zproc_set_biface (value_);
     (*env)->ReleaseStringUTFChars (env, value, value_);
 }
 
 JNIEXPORT jstring JNICALL
-Java_org_zeromq_czmq_Zproc__1_1interface (JNIEnv *env, jclass c)
+Java_org_zeromq_czmq_Zproc__1_1biface (JNIEnv *env, jclass c)
 {
-    char *interface_ = (char *) zproc_interface ();
-    jstring return_string_ = (*env)->NewStringUTF (env, interface_);
+    char *biface_ = (char *) zproc_biface ();
+    jstring return_string_ = (*env)->NewStringUTF (env, biface_);
     return return_string_;
 }
 
 JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1logSetIdent (JNIEnv *env, jclass c, jstring value)
+Java_org_zeromq_czmq_Zproc__1_1setLogIdent (JNIEnv *env, jclass c, jstring value)
 {
     char *value_ = (char *) (*env)->GetStringUTFChars (env, value, NULL);
-    zproc_log_set_ident (value_);
+    zproc_set_log_ident (value_);
     (*env)->ReleaseStringUTFChars (env, value, value_);
 }
 
 JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1logSetSender (JNIEnv *env, jclass c, jstring endpoint)
+Java_org_zeromq_czmq_Zproc__1_1setLogSender (JNIEnv *env, jclass c, jstring endpoint)
 {
     char *endpoint_ = (char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
-    zproc_log_set_sender (endpoint_);
+    zproc_set_log_sender (endpoint_);
     (*env)->ReleaseStringUTFChars (env, endpoint, endpoint_);
 }
 
 JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zproc__1_1logSetSystem (JNIEnv *env, jclass c, jboolean logsystem)
+Java_org_zeromq_czmq_Zproc__1_1setLogSystem (JNIEnv *env, jclass c, jboolean logsystem)
 {
-    zproc_log_set_system ((bool) logsystem);
+    zproc_set_log_system ((bool) logsystem);
 }
 
 JNIEXPORT void JNICALL

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
@@ -72,6 +72,13 @@ public class Zcert implements AutoCloseable{
         __setMeta (self, name, format);
     }
     /*
+    Unset certificate metadata.
+    */
+    native static void __unsetMeta (long self, String name);
+    public void unsetMeta (String name) {
+        __unsetMeta (self, name);
+    }
+    /*
     Get metadata value from certificate; if the metadata value doesn't
     exist, returns NULL.                                              
     */

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -87,65 +87,6 @@ public class Zproc {
         __setMaxSockets (maxSockets);
     }
     /*
-    Return maximum number of ZeroMQ sockets that the system will support.
-    */
-    native static long __maxSockets ();
-    public long maxSockets () {
-        return __maxSockets ();
-    }
-    /*
-    Configure the default linger timeout in msecs for new zsock instances. 
-    You can also set this separately on each zsock_t instance. The default 
-    linger time is zero, i.e. any pending messages will be dropped. If the 
-    environment variable ZSYS_LINGER is defined, that provides the default.
-    Note that process exit will typically be delayed by the linger time.   
-    */
-    native static void __setLinger (long linger);
-    public void setLinger (long linger) {
-        __setLinger (linger);
-    }
-    /*
-    Configure the default outgoing pipe limit (HWM) for new zsock instances.
-    You can also set this separately on each zsock_t instance. The default  
-    HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-    zero means no limit, i.e. infinite memory consumption.                  
-    */
-    native static void __setSndhwm (long sndhwm);
-    public void setSndhwm (long sndhwm) {
-        __setSndhwm (sndhwm);
-    }
-    /*
-    Configure the default incoming pipe limit (HWM) for new zsock instances.
-    You can also set this separately on each zsock_t instance. The default  
-    HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-    zero means no limit, i.e. infinite memory consumption.                  
-    */
-    native static void __setRcvhwm (long rcvhwm);
-    public void setRcvhwm (long rcvhwm) {
-        __setRcvhwm (rcvhwm);
-    }
-    /*
-    Configure use of IPv6 for new zsock instances. By default sockets accept   
-    and make only IPv4 connections. When you enable IPv6, sockets will accept  
-    and connect to both IPv4 and IPv6 peers. You can override the setting on   
-    each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-    environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-    default. Note: has no effect on ZMQ v2.                                    
-    */
-    native static void __setIpv6 (boolean ipv6);
-    public void setIpv6 (boolean ipv6) {
-        __setIpv6 (ipv6);
-    }
-    /*
-    Return use of IPv6 for zsock instances.
-    */
-    native static boolean __ipv6 ();
-    public boolean ipv6 () {
-        return __ipv6 ();
-    }
-    /*
     Set network interface name to use for broadcasts, particularly zbeacon.    
     This lets the interface be configured for test environments where required.
     For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
@@ -153,25 +94,25 @@ public class Zproc {
     variable ZSYS_INTERFACE is set, use that as the default interface name.    
     Setting the interface to "*" means "use all available interfaces".         
     */
-    native static void __setInterface (String value);
-    public void setInterface (String value) {
-        __setInterface (value);
+    native static void __setBiface (String value);
+    public void setBiface (String value) {
+        __setBiface (value);
     }
     /*
     Return network interface to use for broadcasts, or "" if none was set.
     */
-    native static String __interface ();
-    public String interface () {
-        return __interface ();
+    native static String __biface ();
+    public String biface () {
+        return __biface ();
     }
     /*
     Set log identity, which is a string that prefixes all log messages sent
     by this process. The log identity defaults to the environment variable 
     ZSYS_LOGIDENT, if that is set.                                         
     */
-    native static void __logSetIdent (String value);
-    public void logSetIdent (String value) {
-        __logSetIdent (value);
+    native static void __setLogIdent (String value);
+    public void setLogIdent (String value) {
+        __setLogIdent (value);
     }
     /*
     Sends log output to a PUB socket bound to the specified endpoint. To   
@@ -182,17 +123,17 @@ public class Zproc {
     bind the same sender to multiple endpoints. To disable the sender, call
     this method with a null argument.                                      
     */
-    native static void __logSetSender (String endpoint);
-    public void logSetSender (String endpoint) {
-        __logSetSender (endpoint);
+    native static void __setLogSender (String endpoint);
+    public void setLogSender (String endpoint) {
+        __setLogSender (endpoint);
     }
     /*
     Enable or disable logging to the system facility (syslog on POSIX boxes,
     event log on Windows). By default this is disabled.                     
     */
-    native static void __logSetSystem (boolean logsystem);
-    public void logSetSystem (boolean logsystem) {
-        __logSetSystem (logsystem);
+    native static void __setLogSystem (boolean logsystem);
+    public void setLogSystem (boolean logsystem) {
+        __setLogSystem (logsystem);
     }
     /*
     Log error condition - highest priority

--- a/bindings/python/czmq.py
+++ b/bindings/python/czmq.py
@@ -450,6 +450,8 @@ lib.zcert_secret_txt.restype = c_char_p
 lib.zcert_secret_txt.argtypes = [zcert_p]
 lib.zcert_set_meta.restype = None
 lib.zcert_set_meta.argtypes = [zcert_p, c_char_p, c_char_p]
+lib.zcert_unset_meta.restype = None
+lib.zcert_unset_meta.argtypes = [zcert_p, c_char_p]
 lib.zcert_meta.restype = c_char_p
 lib.zcert_meta.argtypes = [zcert_p, c_char_p]
 lib.zcert_meta_keys.restype = zlist_p
@@ -547,6 +549,10 @@ class Zcert(object):
     def set_meta(self, name, format, *args):
         """Set certificate metadata from formatted string."""
         return lib.zcert_set_meta(self._as_parameter_, name, format, *args)
+
+    def unset_meta(self, name):
+        """Unset certificate metadata."""
+        return lib.zcert_unset_meta(self._as_parameter_, name)
 
     def meta(self, name):
         """Get metadata value from certificate; if the metadata value doesn't
@@ -2989,28 +2995,16 @@ lib.zproc_set_io_threads.restype = None
 lib.zproc_set_io_threads.argtypes = [c_size_t]
 lib.zproc_set_max_sockets.restype = None
 lib.zproc_set_max_sockets.argtypes = [c_size_t]
-lib.zproc_max_sockets.restype = c_size_t
-lib.zproc_max_sockets.argtypes = []
-lib.zproc_set_linger.restype = None
-lib.zproc_set_linger.argtypes = [c_size_t]
-lib.zproc_set_sndhwm.restype = None
-lib.zproc_set_sndhwm.argtypes = [c_size_t]
-lib.zproc_set_rcvhwm.restype = None
-lib.zproc_set_rcvhwm.argtypes = [c_size_t]
-lib.zproc_set_ipv6.restype = None
-lib.zproc_set_ipv6.argtypes = [c_bool]
-lib.zproc_ipv6.restype = c_bool
-lib.zproc_ipv6.argtypes = []
-lib.zproc_set_interface.restype = None
-lib.zproc_set_interface.argtypes = [c_char_p]
-lib.zproc_interface.restype = c_char_p
-lib.zproc_interface.argtypes = []
-lib.zproc_log_set_ident.restype = None
-lib.zproc_log_set_ident.argtypes = [c_char_p]
-lib.zproc_log_set_sender.restype = None
-lib.zproc_log_set_sender.argtypes = [c_char_p]
-lib.zproc_log_set_system.restype = None
-lib.zproc_log_set_system.argtypes = [c_bool]
+lib.zproc_set_biface.restype = None
+lib.zproc_set_biface.argtypes = [c_char_p]
+lib.zproc_biface.restype = c_char_p
+lib.zproc_biface.argtypes = []
+lib.zproc_set_log_ident.restype = None
+lib.zproc_set_log_ident.argtypes = [c_char_p]
+lib.zproc_set_log_sender.restype = None
+lib.zproc_set_log_sender.argtypes = [c_char_p]
+lib.zproc_set_log_system.restype = None
+lib.zproc_set_log_system.argtypes = [c_bool]
 lib.zproc_log_error.restype = None
 lib.zproc_log_error.argtypes = [c_char_p]
 lib.zproc_log_warning.restype = None
@@ -3092,76 +3086,29 @@ Note that this method is valid only before any socket is created."""
         return lib.zproc_set_max_sockets(max_sockets)
 
     @staticmethod
-    def max_sockets():
-        """Return maximum number of ZeroMQ sockets that the system will support."""
-        return lib.zproc_max_sockets()
-
-    @staticmethod
-    def set_linger(linger):
-        """Configure the default linger timeout in msecs for new zsock instances.
-You can also set this separately on each zsock_t instance. The default
-linger time is zero, i.e. any pending messages will be dropped. If the
-environment variable ZSYS_LINGER is defined, that provides the default.
-Note that process exit will typically be delayed by the linger time."""
-        return lib.zproc_set_linger(linger)
-
-    @staticmethod
-    def set_sndhwm(sndhwm):
-        """Configure the default outgoing pipe limit (HWM) for new zsock instances.
-You can also set this separately on each zsock_t instance. The default
-HWM is 1,000, on all versions of ZeroMQ. If the environment variable
-ZSYS_SNDHWM is defined, that provides the default. Note that a value of
-zero means no limit, i.e. infinite memory consumption."""
-        return lib.zproc_set_sndhwm(sndhwm)
-
-    @staticmethod
-    def set_rcvhwm(rcvhwm):
-        """Configure the default incoming pipe limit (HWM) for new zsock instances.
-You can also set this separately on each zsock_t instance. The default
-HWM is 1,000, on all versions of ZeroMQ. If the environment variable
-ZSYS_RCVHWM is defined, that provides the default. Note that a value of
-zero means no limit, i.e. infinite memory consumption."""
-        return lib.zproc_set_rcvhwm(rcvhwm)
-
-    @staticmethod
-    def set_ipv6(ipv6):
-        """Configure use of IPv6 for new zsock instances. By default sockets accept
-and make only IPv4 connections. When you enable IPv6, sockets will accept
-and connect to both IPv4 and IPv6 peers. You can override the setting on
-each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the
-default. Note: has no effect on ZMQ v2."""
-        return lib.zproc_set_ipv6(ipv6)
-
-    @staticmethod
-    def ipv6():
-        """Return use of IPv6 for zsock instances."""
-        return lib.zproc_ipv6()
-
-    @staticmethod
-    def set_interface(value):
+    def set_biface(value):
         """Set network interface name to use for broadcasts, particularly zbeacon.
 This lets the interface be configured for test environments where required.
 For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is
 the default when there is no specified interface. If the environment
 variable ZSYS_INTERFACE is set, use that as the default interface name.
 Setting the interface to "*" means "use all available interfaces"."""
-        return lib.zproc_set_interface(value)
+        return lib.zproc_set_biface(value)
 
     @staticmethod
-    def interface():
+    def biface():
         """Return network interface to use for broadcasts, or "" if none was set."""
-        return lib.zproc_interface()
+        return lib.zproc_biface()
 
     @staticmethod
-    def log_set_ident(value):
+    def set_log_ident(value):
         """Set log identity, which is a string that prefixes all log messages sent
 by this process. The log identity defaults to the environment variable
 ZSYS_LOGIDENT, if that is set."""
-        return lib.zproc_log_set_ident(value)
+        return lib.zproc_set_log_ident(value)
 
     @staticmethod
-    def log_set_sender(endpoint):
+    def set_log_sender(endpoint):
         """Sends log output to a PUB socket bound to the specified endpoint. To
 collect such log output, create a SUB socket, subscribe to the traffic
 you care about, and connect to the endpoint. Log traffic is sent as a
@@ -3169,13 +3116,13 @@ single string frame, in the same format as when sent to stdout. The
 log system supports a single sender; multiple calls to this method will
 bind the same sender to multiple endpoints. To disable the sender, call
 this method with a null argument."""
-        return lib.zproc_log_set_sender(endpoint)
+        return lib.zproc_set_log_sender(endpoint)
 
     @staticmethod
-    def log_set_system(logsystem):
+    def set_log_system(logsystem):
         """Enable or disable logging to the system facility (syslog on POSIX boxes,
 event log on Windows). By default this is disabled."""
-        return lib.zproc_log_set_system(logsystem)
+        return lib.zproc_set_log_system(logsystem)
 
     @staticmethod
     def log_error(format, *args):

--- a/bindings/qml/src/QmlZcert.cpp
+++ b/bindings/qml/src/QmlZcert.cpp
@@ -39,6 +39,12 @@ void QmlZcert::setMeta (const QString &name, const QString &format) {
 };
 
 ///
+//  Unset certificate metadata.
+void QmlZcert::unsetMeta (const QString &name) {
+    zcert_unset_meta (self, name.toUtf8().data());
+};
+
+///
 //  Get metadata value from certificate; if the metadata value doesn't
 //  exist, returns NULL.                                              
 const QString QmlZcert::meta (const QString &name) {

--- a/bindings/qml/src/QmlZcert.h
+++ b/bindings/qml/src/QmlZcert.h
@@ -43,6 +43,9 @@ public slots:
     //  Set certificate metadata from formatted string.
     void setMeta (const QString &name, const QString &format);
 
+    //  Unset certificate metadata.
+    void unsetMeta (const QString &name);
+
     //  Get metadata value from certificate; if the metadata value doesn't
     //  exist, returns NULL.                                              
     const QString meta (const QString &name);

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -81,81 +81,28 @@ void QmlZprocAttached::setMaxSockets (size_t maxSockets) {
 };
 
 ///
-//  Return maximum number of ZeroMQ sockets that the system will support.
-size_t QmlZprocAttached::maxSockets () {
-    return zproc_max_sockets ();
-};
-
-///
-//  Configure the default linger timeout in msecs for new zsock instances. 
-//  You can also set this separately on each zsock_t instance. The default 
-//  linger time is zero, i.e. any pending messages will be dropped. If the 
-//  environment variable ZSYS_LINGER is defined, that provides the default.
-//  Note that process exit will typically be delayed by the linger time.   
-void QmlZprocAttached::setLinger (size_t linger) {
-    zproc_set_linger (linger);
-};
-
-///
-//  Configure the default outgoing pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-void QmlZprocAttached::setSndhwm (size_t sndhwm) {
-    zproc_set_sndhwm (sndhwm);
-};
-
-///
-//  Configure the default incoming pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-void QmlZprocAttached::setRcvhwm (size_t rcvhwm) {
-    zproc_set_rcvhwm (rcvhwm);
-};
-
-///
-//  Configure use of IPv6 for new zsock instances. By default sockets accept   
-//  and make only IPv4 connections. When you enable IPv6, sockets will accept  
-//  and connect to both IPv4 and IPv6 peers. You can override the setting on   
-//  each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-//  environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-//  default. Note: has no effect on ZMQ v2.                                    
-void QmlZprocAttached::setIpv6 (bool ipv6) {
-    zproc_set_ipv6 (ipv6);
-};
-
-///
-//  Return use of IPv6 for zsock instances.
-bool QmlZprocAttached::ipv6 () {
-    return zproc_ipv6 ();
-};
-
-///
 //  Set network interface name to use for broadcasts, particularly zbeacon.    
 //  This lets the interface be configured for test environments where required.
 //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
 //  the default when there is no specified interface. If the environment       
 //  variable ZSYS_INTERFACE is set, use that as the default interface name.    
 //  Setting the interface to "*" means "use all available interfaces".         
-void QmlZprocAttached::setInterface (const QString &value) {
-    zproc_set_interface (value.toUtf8().data());
+void QmlZprocAttached::setBiface (const QString &value) {
+    zproc_set_biface (value.toUtf8().data());
 };
 
 ///
 //  Return network interface to use for broadcasts, or "" if none was set.
-const QString QmlZprocAttached::interface () {
-    return QString (zproc_interface ());
+const QString QmlZprocAttached::biface () {
+    return QString (zproc_biface ());
 };
 
 ///
 //  Set log identity, which is a string that prefixes all log messages sent
 //  by this process. The log identity defaults to the environment variable 
 //  ZSYS_LOGIDENT, if that is set.                                         
-void QmlZprocAttached::logSetIdent (const QString &value) {
-    zproc_log_set_ident (value.toUtf8().data());
+void QmlZprocAttached::setLogIdent (const QString &value) {
+    zproc_set_log_ident (value.toUtf8().data());
 };
 
 ///
@@ -166,15 +113,15 @@ void QmlZprocAttached::logSetIdent (const QString &value) {
 //  log system supports a single sender; multiple calls to this method will
 //  bind the same sender to multiple endpoints. To disable the sender, call
 //  this method with a null argument.                                      
-void QmlZprocAttached::logSetSender (const QString &endpoint) {
-    zproc_log_set_sender (endpoint.toUtf8().data());
+void QmlZprocAttached::setLogSender (const QString &endpoint) {
+    zproc_set_log_sender (endpoint.toUtf8().data());
 };
 
 ///
 //  Enable or disable logging to the system facility (syslog on POSIX boxes,
 //  event log on Windows). By default this is disabled.                     
-void QmlZprocAttached::logSetSystem (bool logsystem) {
-    zproc_log_set_system (logsystem);
+void QmlZprocAttached::setLogSystem (bool logsystem) {
+    zproc_set_log_system (logsystem);
 };
 
 ///

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -82,56 +82,21 @@ public slots:
     //  Note that this method is valid only before any socket is created.    
     void setMaxSockets (size_t maxSockets);
 
-    //  Return maximum number of ZeroMQ sockets that the system will support.
-    size_t maxSockets ();
-
-    //  Configure the default linger timeout in msecs for new zsock instances. 
-    //  You can also set this separately on each zsock_t instance. The default 
-    //  linger time is zero, i.e. any pending messages will be dropped. If the 
-    //  environment variable ZSYS_LINGER is defined, that provides the default.
-    //  Note that process exit will typically be delayed by the linger time.   
-    void setLinger (size_t linger);
-
-    //  Configure the default outgoing pipe limit (HWM) for new zsock instances.
-    //  You can also set this separately on each zsock_t instance. The default  
-    //  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    //  ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-    //  zero means no limit, i.e. infinite memory consumption.                  
-    void setSndhwm (size_t sndhwm);
-
-    //  Configure the default incoming pipe limit (HWM) for new zsock instances.
-    //  You can also set this separately on each zsock_t instance. The default  
-    //  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    //  ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-    //  zero means no limit, i.e. infinite memory consumption.                  
-    void setRcvhwm (size_t rcvhwm);
-
-    //  Configure use of IPv6 for new zsock instances. By default sockets accept   
-    //  and make only IPv4 connections. When you enable IPv6, sockets will accept  
-    //  and connect to both IPv4 and IPv6 peers. You can override the setting on   
-    //  each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-    //  environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-    //  default. Note: has no effect on ZMQ v2.                                    
-    void setIpv6 (bool ipv6);
-
-    //  Return use of IPv6 for zsock instances.
-    bool ipv6 ();
-
     //  Set network interface name to use for broadcasts, particularly zbeacon.    
     //  This lets the interface be configured for test environments where required.
     //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
     //  the default when there is no specified interface. If the environment       
     //  variable ZSYS_INTERFACE is set, use that as the default interface name.    
     //  Setting the interface to "*" means "use all available interfaces".         
-    void setInterface (const QString &value);
+    void setBiface (const QString &value);
 
     //  Return network interface to use for broadcasts, or "" if none was set.
-    const QString interface ();
+    const QString biface ();
 
     //  Set log identity, which is a string that prefixes all log messages sent
     //  by this process. The log identity defaults to the environment variable 
     //  ZSYS_LOGIDENT, if that is set.                                         
-    void logSetIdent (const QString &value);
+    void setLogIdent (const QString &value);
 
     //  Sends log output to a PUB socket bound to the specified endpoint. To   
     //  collect such log output, create a SUB socket, subscribe to the traffic 
@@ -140,11 +105,11 @@ public slots:
     //  log system supports a single sender; multiple calls to this method will
     //  bind the same sender to multiple endpoints. To disable the sender, call
     //  this method with a null argument.                                      
-    void logSetSender (const QString &endpoint);
+    void setLogSender (const QString &endpoint);
 
     //  Enable or disable logging to the system facility (syslog on POSIX boxes,
     //  event log on Windows). By default this is disabled.                     
-    void logSetSystem (bool logsystem);
+    void setLogSystem (bool logsystem);
 
     //  Log error condition - highest priority
     void logError (const QString &format);

--- a/bindings/qt/src/qzcert.cpp
+++ b/bindings/qt/src/qzcert.cpp
@@ -84,6 +84,14 @@ void QZcert::setMeta (const QString &name, const QString &param)
 }
 
 ///
+//  Unset certificate metadata.
+void QZcert::unsetMeta (const QString &name)
+{
+    zcert_unset_meta (self, name.toUtf8().data());
+    
+}
+
+///
 //  Get metadata value from certificate; if the metadata value doesn't
 //  exist, returns NULL.                                              
 const QString QZcert::meta (const QString &name)

--- a/bindings/qt/src/qzcert.h
+++ b/bindings/qt/src/qzcert.h
@@ -44,6 +44,9 @@ public:
     //  Set certificate metadata from formatted string.
     void setMeta (const QString &name, const QString &param);
 
+    //  Unset certificate metadata.
+    void unsetMeta (const QString &name);
+
     //  Get metadata value from certificate; if the metadata value doesn't
     //  exist, returns NULL.                                              
     const QString meta (const QString &name);

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -95,88 +95,23 @@ void QZproc::setMaxSockets (size_t maxSockets)
 }
 
 ///
-//  Return maximum number of ZeroMQ sockets that the system will support.
-size_t QZproc::maxSockets ()
-{
-    size_t rv = zproc_max_sockets ();
-    return rv;
-}
-
-///
-//  Configure the default linger timeout in msecs for new zsock instances. 
-//  You can also set this separately on each zsock_t instance. The default 
-//  linger time is zero, i.e. any pending messages will be dropped. If the 
-//  environment variable ZSYS_LINGER is defined, that provides the default.
-//  Note that process exit will typically be delayed by the linger time.   
-void QZproc::setLinger (size_t linger)
-{
-    zproc_set_linger (linger);
-    
-}
-
-///
-//  Configure the default outgoing pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-void QZproc::setSndhwm (size_t sndhwm)
-{
-    zproc_set_sndhwm (sndhwm);
-    
-}
-
-///
-//  Configure the default incoming pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-void QZproc::setRcvhwm (size_t rcvhwm)
-{
-    zproc_set_rcvhwm (rcvhwm);
-    
-}
-
-///
-//  Configure use of IPv6 for new zsock instances. By default sockets accept   
-//  and make only IPv4 connections. When you enable IPv6, sockets will accept  
-//  and connect to both IPv4 and IPv6 peers. You can override the setting on   
-//  each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-//  environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-//  default. Note: has no effect on ZMQ v2.                                    
-void QZproc::setIpv6 (bool ipv6)
-{
-    zproc_set_ipv6 (ipv6);
-    
-}
-
-///
-//  Return use of IPv6 for zsock instances.
-bool QZproc::ipv6 ()
-{
-    bool rv = zproc_ipv6 ();
-    return rv;
-}
-
-///
 //  Set network interface name to use for broadcasts, particularly zbeacon.    
 //  This lets the interface be configured for test environments where required.
 //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
 //  the default when there is no specified interface. If the environment       
 //  variable ZSYS_INTERFACE is set, use that as the default interface name.    
 //  Setting the interface to "*" means "use all available interfaces".         
-void QZproc::setInterface (const QString &value)
+void QZproc::setBiface (const QString &value)
 {
-    zproc_set_interface (value.toUtf8().data());
+    zproc_set_biface (value.toUtf8().data());
     
 }
 
 ///
 //  Return network interface to use for broadcasts, or "" if none was set.
-const QString QZproc::interface ()
+const QString QZproc::biface ()
 {
-    const QString rv = QString (zproc_interface ());
+    const QString rv = QString (zproc_biface ());
     return rv;
 }
 
@@ -184,9 +119,9 @@ const QString QZproc::interface ()
 //  Set log identity, which is a string that prefixes all log messages sent
 //  by this process. The log identity defaults to the environment variable 
 //  ZSYS_LOGIDENT, if that is set.                                         
-void QZproc::logSetIdent (const QString &value)
+void QZproc::setLogIdent (const QString &value)
 {
-    zproc_log_set_ident (value.toUtf8().data());
+    zproc_set_log_ident (value.toUtf8().data());
     
 }
 
@@ -198,18 +133,18 @@ void QZproc::logSetIdent (const QString &value)
 //  log system supports a single sender; multiple calls to this method will
 //  bind the same sender to multiple endpoints. To disable the sender, call
 //  this method with a null argument.                                      
-void QZproc::logSetSender (const QString &endpoint)
+void QZproc::setLogSender (const QString &endpoint)
 {
-    zproc_log_set_sender (endpoint.toUtf8().data());
+    zproc_set_log_sender (endpoint.toUtf8().data());
     
 }
 
 ///
 //  Enable or disable logging to the system facility (syslog on POSIX boxes,
 //  event log on Windows). By default this is disabled.                     
-void QZproc::logSetSystem (bool logsystem)
+void QZproc::setLogSystem (bool logsystem)
 {
-    zproc_log_set_system (logsystem);
+    zproc_set_log_system (logsystem);
     
 }
 

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -59,56 +59,21 @@ public:
     //  Note that this method is valid only before any socket is created.    
     static void setMaxSockets (size_t maxSockets);
 
-    //  Return maximum number of ZeroMQ sockets that the system will support.
-    static size_t maxSockets ();
-
-    //  Configure the default linger timeout in msecs for new zsock instances. 
-    //  You can also set this separately on each zsock_t instance. The default 
-    //  linger time is zero, i.e. any pending messages will be dropped. If the 
-    //  environment variable ZSYS_LINGER is defined, that provides the default.
-    //  Note that process exit will typically be delayed by the linger time.   
-    static void setLinger (size_t linger);
-
-    //  Configure the default outgoing pipe limit (HWM) for new zsock instances.
-    //  You can also set this separately on each zsock_t instance. The default  
-    //  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    //  ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-    //  zero means no limit, i.e. infinite memory consumption.                  
-    static void setSndhwm (size_t sndhwm);
-
-    //  Configure the default incoming pipe limit (HWM) for new zsock instances.
-    //  You can also set this separately on each zsock_t instance. The default  
-    //  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-    //  ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-    //  zero means no limit, i.e. infinite memory consumption.                  
-    static void setRcvhwm (size_t rcvhwm);
-
-    //  Configure use of IPv6 for new zsock instances. By default sockets accept   
-    //  and make only IPv4 connections. When you enable IPv6, sockets will accept  
-    //  and connect to both IPv4 and IPv6 peers. You can override the setting on   
-    //  each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-    //  environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-    //  default. Note: has no effect on ZMQ v2.                                    
-    static void setIpv6 (bool ipv6);
-
-    //  Return use of IPv6 for zsock instances.
-    static bool ipv6 ();
-
     //  Set network interface name to use for broadcasts, particularly zbeacon.    
     //  This lets the interface be configured for test environments where required.
     //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
     //  the default when there is no specified interface. If the environment       
     //  variable ZSYS_INTERFACE is set, use that as the default interface name.    
     //  Setting the interface to "*" means "use all available interfaces".         
-    static void setInterface (const QString &value);
+    static void setBiface (const QString &value);
 
     //  Return network interface to use for broadcasts, or "" if none was set.
-    static const QString interface ();
+    static const QString biface ();
 
     //  Set log identity, which is a string that prefixes all log messages sent
     //  by this process. The log identity defaults to the environment variable 
     //  ZSYS_LOGIDENT, if that is set.                                         
-    static void logSetIdent (const QString &value);
+    static void setLogIdent (const QString &value);
 
     //  Sends log output to a PUB socket bound to the specified endpoint. To   
     //  collect such log output, create a SUB socket, subscribe to the traffic 
@@ -117,11 +82,11 @@ public:
     //  log system supports a single sender; multiple calls to this method will
     //  bind the same sender to multiple endpoints. To disable the sender, call
     //  this method with a null argument.                                      
-    static void logSetSender (const QString &endpoint);
+    static void setLogSender (const QString &endpoint);
 
     //  Enable or disable logging to the system facility (syslog on POSIX boxes,
     //  event log on Windows). By default this is disabled.                     
-    static void logSetSystem (bool logsystem);
+    static void setLogSystem (bool logsystem);
 
     //  Log error condition - highest priority
     static void logError (const QString &param);

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -411,17 +411,11 @@ module CZMQ
       attach_function :zproc_run_as, [:string, :string, :string], :void, **opts
       attach_function :zproc_set_io_threads, [:size_t], :void, **opts
       attach_function :zproc_set_max_sockets, [:size_t], :void, **opts
-      attach_function :zproc_max_sockets, [], :size_t, **opts
-      attach_function :zproc_set_linger, [:size_t], :void, **opts
-      attach_function :zproc_set_sndhwm, [:size_t], :void, **opts
-      attach_function :zproc_set_rcvhwm, [:size_t], :void, **opts
-      attach_function :zproc_set_ipv6, [:bool], :void, **opts
-      attach_function :zproc_ipv6, [], :bool, **opts
-      attach_function :zproc_set_interface, [:string], :void, **opts
-      attach_function :zproc_interface, [], :string, **opts
-      attach_function :zproc_log_set_ident, [:string], :void, **opts
-      attach_function :zproc_log_set_sender, [:string], :void, **opts
-      attach_function :zproc_log_set_system, [:bool], :void, **opts
+      attach_function :zproc_set_biface, [:string], :void, **opts
+      attach_function :zproc_biface, [], :string, **opts
+      attach_function :zproc_set_log_ident, [:string], :void, **opts
+      attach_function :zproc_set_log_sender, [:string], :void, **opts
+      attach_function :zproc_set_log_system, [:bool], :void, **opts
       attach_function :zproc_log_error, [:string, :varargs], :void, **opts
       attach_function :zproc_log_warning, [:string, :varargs], :void, **opts
       attach_function :zproc_log_notice, [:string, :varargs], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -158,79 +158,6 @@ module CZMQ
         result
       end
 
-      # Return maximum number of ZeroMQ sockets that the system will support.
-      #
-      # @return [Integer]
-      def self.max_sockets()
-        result = ::CZMQ::FFI.zproc_max_sockets()
-        result
-      end
-
-      # Configure the default linger timeout in msecs for new zsock instances. 
-      # You can also set this separately on each zsock_t instance. The default 
-      # linger time is zero, i.e. any pending messages will be dropped. If the 
-      # environment variable ZSYS_LINGER is defined, that provides the default.
-      # Note that process exit will typically be delayed by the linger time.   
-      #
-      # @param linger [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_linger(linger)
-        linger = Integer(linger)
-        result = ::CZMQ::FFI.zproc_set_linger(linger)
-        result
-      end
-
-      # Configure the default outgoing pipe limit (HWM) for new zsock instances.
-      # You can also set this separately on each zsock_t instance. The default  
-      # HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-      # ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-      # zero means no limit, i.e. infinite memory consumption.                  
-      #
-      # @param sndhwm [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_sndhwm(sndhwm)
-        sndhwm = Integer(sndhwm)
-        result = ::CZMQ::FFI.zproc_set_sndhwm(sndhwm)
-        result
-      end
-
-      # Configure the default incoming pipe limit (HWM) for new zsock instances.
-      # You can also set this separately on each zsock_t instance. The default  
-      # HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-      # ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-      # zero means no limit, i.e. infinite memory consumption.                  
-      #
-      # @param rcvhwm [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_rcvhwm(rcvhwm)
-        rcvhwm = Integer(rcvhwm)
-        result = ::CZMQ::FFI.zproc_set_rcvhwm(rcvhwm)
-        result
-      end
-
-      # Configure use of IPv6 for new zsock instances. By default sockets accept   
-      # and make only IPv4 connections. When you enable IPv6, sockets will accept  
-      # and connect to both IPv4 and IPv6 peers. You can override the setting on   
-      # each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-      # environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-      # default. Note: has no effect on ZMQ v2.                                    
-      #
-      # @param ipv6 [Boolean]
-      # @return [void]
-      def self.set_ipv6(ipv6)
-        ipv6 = !(0==ipv6||!ipv6) # boolean
-        result = ::CZMQ::FFI.zproc_set_ipv6(ipv6)
-        result
-      end
-
-      # Return use of IPv6 for zsock instances.
-      #
-      # @return [Boolean]
-      def self.ipv6()
-        result = ::CZMQ::FFI.zproc_ipv6()
-        result
-      end
-
       # Set network interface name to use for broadcasts, particularly zbeacon.    
       # This lets the interface be configured for test environments where required.
       # For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
@@ -240,16 +167,16 @@ module CZMQ
       #
       # @param value [String, #to_s, nil]
       # @return [void]
-      def self.set_interface(value)
-        result = ::CZMQ::FFI.zproc_set_interface(value)
+      def self.set_biface(value)
+        result = ::CZMQ::FFI.zproc_set_biface(value)
         result
       end
 
       # Return network interface to use for broadcasts, or "" if none was set.
       #
       # @return [String]
-      def self.interface()
-        result = ::CZMQ::FFI.zproc_interface()
+      def self.biface()
+        result = ::CZMQ::FFI.zproc_biface()
         result
       end
 
@@ -259,8 +186,8 @@ module CZMQ
       #
       # @param value [String, #to_s, nil]
       # @return [void]
-      def self.log_set_ident(value)
-        result = ::CZMQ::FFI.zproc_log_set_ident(value)
+      def self.set_log_ident(value)
+        result = ::CZMQ::FFI.zproc_set_log_ident(value)
         result
       end
 
@@ -274,8 +201,8 @@ module CZMQ
       #
       # @param endpoint [String, #to_s, nil]
       # @return [void]
-      def self.log_set_sender(endpoint)
-        result = ::CZMQ::FFI.zproc_log_set_sender(endpoint)
+      def self.set_log_sender(endpoint)
+        result = ::CZMQ::FFI.zproc_set_log_sender(endpoint)
         result
       end
 
@@ -284,9 +211,9 @@ module CZMQ
       #
       # @param logsystem [Boolean]
       # @return [void]
-      def self.log_set_system(logsystem)
+      def self.set_log_system(logsystem)
         logsystem = !(0==logsystem||!logsystem) # boolean
-        result = ::CZMQ::FFI.zproc_log_set_system(logsystem)
+        result = ::CZMQ::FFI.zproc_set_log_system(logsystem)
         result
       end
 

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -72,47 +72,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zproc_set_max_sockets (size_t max_sockets);
 
-//  Return maximum number of ZeroMQ sockets that the system will support.
-CZMQ_EXPORT size_t
-    zproc_max_sockets (void);
-
-//  Configure the default linger timeout in msecs for new zsock instances. 
-//  You can also set this separately on each zsock_t instance. The default 
-//  linger time is zero, i.e. any pending messages will be dropped. If the 
-//  environment variable ZSYS_LINGER is defined, that provides the default.
-//  Note that process exit will typically be delayed by the linger time.   
-CZMQ_EXPORT void
-    zproc_set_linger (size_t linger);
-
-//  Configure the default outgoing pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_SNDHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-CZMQ_EXPORT void
-    zproc_set_sndhwm (size_t sndhwm);
-
-//  Configure the default incoming pipe limit (HWM) for new zsock instances.
-//  You can also set this separately on each zsock_t instance. The default  
-//  HWM is 1,000, on all versions of ZeroMQ. If the environment variable    
-//  ZSYS_RCVHWM is defined, that provides the default. Note that a value of 
-//  zero means no limit, i.e. infinite memory consumption.                  
-CZMQ_EXPORT void
-    zproc_set_rcvhwm (size_t rcvhwm);
-
-//  Configure use of IPv6 for new zsock instances. By default sockets accept   
-//  and make only IPv4 connections. When you enable IPv6, sockets will accept  
-//  and connect to both IPv4 and IPv6 peers. You can override the setting on   
-//  each zsock_t instance. The default is IPv4 only (ipv6 set to false). If the
-//  environment variable ZSYS_IPV6 is defined (as 1 or 0), this provides the   
-//  default. Note: has no effect on ZMQ v2.                                    
-CZMQ_EXPORT void
-    zproc_set_ipv6 (bool ipv6);
-
-//  Return use of IPv6 for zsock instances.
-CZMQ_EXPORT bool
-    zproc_ipv6 (void);
-
 //  Set network interface name to use for broadcasts, particularly zbeacon.    
 //  This lets the interface be configured for test environments where required.
 //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is  
@@ -120,17 +79,17 @@ CZMQ_EXPORT bool
 //  variable ZSYS_INTERFACE is set, use that as the default interface name.    
 //  Setting the interface to "*" means "use all available interfaces".         
 CZMQ_EXPORT void
-    zproc_set_interface (const char *value);
+    zproc_set_biface (const char *value);
 
 //  Return network interface to use for broadcasts, or "" if none was set.
 CZMQ_EXPORT const char *
-    zproc_interface (void);
+    zproc_biface (void);
 
 //  Set log identity, which is a string that prefixes all log messages sent
 //  by this process. The log identity defaults to the environment variable 
 //  ZSYS_LOGIDENT, if that is set.                                         
 CZMQ_EXPORT void
-    zproc_log_set_ident (const char *value);
+    zproc_set_log_ident (const char *value);
 
 //  Sends log output to a PUB socket bound to the specified endpoint. To   
 //  collect such log output, create a SUB socket, subscribe to the traffic 
@@ -140,12 +99,12 @@ CZMQ_EXPORT void
 //  bind the same sender to multiple endpoints. To disable the sender, call
 //  this method with a null argument.                                      
 CZMQ_EXPORT void
-    zproc_log_set_sender (const char *endpoint);
+    zproc_set_log_sender (const char *endpoint);
 
 //  Enable or disable logging to the system facility (syslog on POSIX boxes,
 //  event log on Windows). By default this is disabled.                     
 CZMQ_EXPORT void
-    zproc_log_set_system (bool logsystem);
+    zproc_set_log_system (bool logsystem);
 
 //  Log error condition - highest priority
 CZMQ_EXPORT void

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -121,7 +121,7 @@ zproc_set_max_sockets (size_t max_sockets)
 //  Setting the interface to "*" means "use all available interfaces".         
 
 void
-zproc_set_interface (const char *value)
+zproc_set_biface (const char *value)
 {
     zsys_set_interface (value);
 }
@@ -131,7 +131,7 @@ zproc_set_interface (const char *value)
 //  Return network interface to use for broadcasts, or "" if none was set.
 
 const char *
-zproc_interface (void)
+zproc_biface (void)
 {
     return zsys_interface ();
 }


### PR DESCRIPTION
This prohibits any method with that name.

Solution: use "biface" for "broadcast interface" in the zproc class.