### PR TITLE
Problem: libzmq master changed zmq_poller_close -> destroy

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -71,7 +71,7 @@ zpoller_destroy (zpoller_t **self_p)
     assert (self_p);
     if (*self_p) {
         zpoller_t *self = *self_p;
-        zmq_poller_close (self->zmq_poller);
+        zmq_poller_destroy (&self->zmq_poller);
         free (self);
         *self_p = NULL;
     }


### PR DESCRIPTION
Solution: fix here. CZMQ build will be broken until both patches
are merged.