### PR TITLE
android jni build.sh: ensure "gradle build jar" is run

### DIFF
--- a/bindings/jni/android/build.sh
+++ b/bindings/jni/android/build.sh
@@ -28,8 +28,8 @@ echo "********  Building Android native libraries"
 ( cd ../../../builds/android && ./build.sh )
 
 #   Ensure we've built JNI interface
-# echo "********  Building JNI interface & classes"
-# ( cd .. && gradle build jar )
+echo "********  Building JNI interface & classes"
+( cd .. && gradle build jar )
 
 rm -Rf build
 mkdir build


### PR DESCRIPTION
android jni build.sh: ensure "gradle build jar" is run before, otherwise compilation will fail with missing headers.