### PR TITLE
Problem: bindings need to know if CURVE security is available

### DIFF
--- a/api/zproc.xml
+++ b/api/zproc.xml
@@ -23,6 +23,11 @@
         <return type = "boolean" />
     </method>
 
+    <method name = "has curve" singleton = "1">
+        Returns true if the underlying libzmq supports CURVE security.
+        <return type = "boolean" />
+    </method>
+
     <method name = "hostname" singleton = "1">
         Return current host name, for use in public tcp:// endpoints.
         If the host name is not resolvable, returns NULL.

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -406,6 +406,7 @@ module CZMQ
 
       attach_function :zproc_czmq_version, [], :int, **opts
       attach_function :zproc_interrupted, [], :bool, **opts
+      attach_function :zproc_has_curve, [], :bool, **opts
       attach_function :zproc_hostname, [], :pointer, **opts
       attach_function :zproc_daemonize, [:string], :void, **opts
       attach_function :zproc_run_as, [:string, :string, :string], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -91,6 +91,14 @@ module CZMQ
         result
       end
 
+      # Returns true if the underlying libzmq supports CURVE security.
+      #
+      # @return [Boolean]
+      def self.has_curve()
+        result = ::CZMQ::FFI.zproc_has_curve()
+        result
+      end
+
       # Return current host name, for use in public tcp:// endpoints.
       # If the host name is not resolvable, returns NULL.            
       #

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -33,6 +33,10 @@ CZMQ_EXPORT int
 CZMQ_EXPORT bool
     zproc_interrupted (void);
 
+//  Returns true if the underlying libzmq supports CURVE security.
+CZMQ_EXPORT bool
+    zproc_has_curve (void);
+
 //  Return current host name, for use in public tcp:// endpoints.
 //  If the host name is not resolvable, returns NULL.            
 //  The caller is responsible for destroying the return value when finished with it.

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -42,6 +42,15 @@ zproc_interrupted (void)
     return zsys_interrupted;
 }
 
+//  --------------------------------------------------------------------------
+//  Returns true if the underlying libzmq supports CURVE security.
+
+bool
+zproc_has_curve (void)
+{
+	return zsys_has_curve ();
+}
+
 
 //  --------------------------------------------------------------------------
 //  Return current host name, for use in public tcp:// endpoints.


### PR DESCRIPTION
Solution: add zproc_has_curve()

This closes #1268.