### PR TITLE
Fixing zloop_start so that it terminates when ticket handler returns -1

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -779,9 +779,9 @@ zloop_start (zloop_t *self)
                 zsys_debug ("zloop: call ticket handler");
             if (!ticket->deleted
             && ticket->handler (self, 0, ticket->arg) == -1) {
-				rc = -1;	//  Trigger exit from zloop_start
+                rc = -1;    //  Trigger exit from zloop_start
                 break;      //  Ticket handler signaled break
-			}
+            }
             zlistx_delete (self->tickets, ticket->list_handle);
             ticket = (s_ticket_t *) zlistx_next (self->tickets);
         }

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -778,8 +778,10 @@ zloop_start (zloop_t *self)
             if (self->verbose)
                 zsys_debug ("zloop: call ticket handler");
             if (!ticket->deleted
-            && ticket->handler (self, 0, ticket->arg) == -1)
+            && ticket->handler (self, 0, ticket->arg) == -1) {
+				rc = -1;	//  Trigger exit from zloop_start
                 break;      //  Ticket handler signaled break
+			}
             zlistx_delete (self->tickets, ticket->list_handle);
             ticket = (s_ticket_t *) zlistx_next (self->tickets);
         }


### PR DESCRIPTION
This fixes issue #1278 by making the ticket handler return code detection exactly similar to what is done for a timer handler when -1 is returned.  This ensures that a -1 returned by a ticket handler does cause zloop_start to terminate as described in its API.

Verified on an Ubuntu 14.04LTS (x64) system.  Without the fix, a ticket handler returning -1 does not cause zloop_start to terminate.  With the fix in place, a ticket handler returning -1 does indeed cause zloop_start to terminate and its return code is -1.  This behavior now matches the API documentation.