### PR TITLE
Problem: Android build is too slow

### DIFF
--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -59,8 +59,8 @@ fi
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
     (cd "${cache}/czmq" && ./autogen.sh \
-        && ./configure "${ANDROID_BUILD_OPTS[@]}" \
-        && make \
+        && ./configure "${ANDROID_BUILD_OPTS[@]}" --without-documentation \
+        && make -j 4 \
         && make install) || exit 1
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -223,20 +223,29 @@ czmq_on_android="no"
 # Host specific checks
 AC_CANONICAL_HOST
 
-# Determine whether or not documentation should be built and installed.
-czmq_build_doc="yes"
-czmq_install_man="yes"
+# Allow user to disable doc build
+AC_ARG_WITH([documentation], [AS_HELP_STRING([--without-documentation],
+    [disable documentation build even if asciidoc and xmlto are present [default=no]])])
 
-# Check for asciidoc and xmlto and don't build the docs if these are not installed.
-AC_CHECK_PROG(czmq_have_asciidoc, asciidoc, yes, no)
-AC_CHECK_PROG(czmq_have_xmlto, xmlto, yes, no)
-if test "x$czmq_have_asciidoc" = "xno" -o "x$czmq_have_xmlto" = "xno"; then
+if test "x$with_documentation" = "xno"; then
     czmq_build_doc="no"
-    # Tarballs built with 'make dist' ship with prebuilt documentation.
-    if ! test -f doc/czmq.7; then
-        czmq_install_man="no"
-        AC_MSG_WARN([You are building an unreleased version of CZMQ and asciidoc or xmlto are not installed.])
-        AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+    czmq_install_man="no"
+else
+    # Determine whether or not documentation should be built and installed.
+    czmq_build_doc="yes"
+    czmq_install_man="yes"
+
+    # Check for asciidoc and xmlto and don't build the docs if these are not installed.
+    AC_CHECK_PROG(czmq_have_asciidoc, asciidoc, yes, no)
+    AC_CHECK_PROG(czmq_have_xmlto, xmlto, yes, no)
+    if test "x$czmq_have_asciidoc" = "xno" -o "x$czmq_have_xmlto" = "xno"; then
+        czmq_build_doc="no"
+        # Tarballs built with 'make dist' ship with prebuilt documentation.
+        if ! test -f doc/czmq.7; then
+            czmq_install_man="no"
+            AC_MSG_WARN([You are building an unreleased version of CZMQ and asciidoc or xmlto are not installed.])
+            AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+        fi
     fi
 fi
 AC_MSG_CHECKING([whether to build documentation])


### PR DESCRIPTION
Solution: use parallel make (-j 4) and don't build man pages.

Via zproject.