### PR TITLE
Problem: unconfigured zbeacon closes STDIN on destruction

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -56,7 +56,8 @@ s_self_destroy (self_t **self_p)
         self_t *self = *self_p;
         zframe_destroy (&self->transmit);
         zframe_destroy (&self->filter);
-        zsys_udp_close (self->udpsock);
+        if (self->udpsock) // don't close STDIN
+            zsys_udp_close (self->udpsock);
         free (self);
         *self_p = NULL;
     }


### PR DESCRIPTION
Solution: only close UDP socket if fd isn't 0

This closes #1281.