### PR TITLE
Problem: Travis CI fails due to missing Valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ addons:
   apt:
     packages:
     - uuid-dev
+    - valgrind
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils ; fi
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils valgrind ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so


### PR DESCRIPTION
Solution: add Valgrind to the Travis dependencies


make memcheck was added a while ago, but build-deps were missing from travis.yml.
Please note that make memcheck still fails due to many reported leaks by valgrind.