### PR TITLE
Problem: Cannot compile czmq without libsodium

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,7 @@ was_libsodium_check_lib_detected=no
 
 PKG_CHECK_MODULES([libsodium], [libsodium >= 0.0.0],
     [
+        AC_DEFINE(HAVE_LIBSODIUM, 1, [The libsodium library is to be used.])
     ],
     [
         AC_ARG_WITH([libsodium],
@@ -110,8 +111,9 @@ PKG_CHECK_MODULES([libsodium], [libsodium >= 0.0.0],
                 AC_SUBST([libsodium_CFLAGS],[${libsodium_synthetic_cflags}])
                 AC_SUBST([libsodium_LIBS],[${libsodium_synthetic_libs}])
                 was_libsodium_check_lib_detected=yes
+                AC_DEFINE(HAVE_LIBSODIUM, 1, [The libsodium library is to be used.])
             ],
-            [AC_MSG_ERROR([cannot link with -lsodium, install libsodium.])])
+            [])
     ])
 
 if test "x$was_libsodium_check_lib_detected" = "xno"; then

--- a/src/libczmq.pc.in
+++ b/src/libczmq.pc.in
@@ -12,7 +12,7 @@ Name: libczmq
 Description: The high-level C binding for 0MQ
 Version: @VERSION@
 
-Requires:libsodium libzmq
+Requires:libzmq
 
 Libs: -L${libdir} -lczmq
 Cflags: -I${includedir}


### PR DESCRIPTION
Solution: Make libsodium an optional dependency

Note: This change has been done in zproject which generates czmq's
configuration files.

Fixes #1294 