### PR TITLE
Problem: 'clock' type no longer supported in zproject

### DIFF
--- a/api/zchunk.xml
+++ b/api/zchunk.xml
@@ -1,187 +1,169 @@
 <class name = "zchunk" >
+    <!--
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
 
-    <include filename = "../license.xml" />
-
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    -->
     <constructor>
-  Create a new chunk of the specified size. If you specify the data, it
-  is copied into the chunk. If you do not specify the data, the chunk is
-  allocated and left empty, and you can then add data using zchunk_append.
-
+        Create a new chunk of the specified size. If you specify the data, it
+        is copied into the chunk. If you do not specify the data, the chunk is
+        allocated and left empty, and you can then add data using zchunk_append.
         <argument name = "data" type = "anything" mutable = "0" />
         <argument name = "size" type = "size" />
     </constructor>
 
     <destructor>
-  Destroy a chunk
-
+        Destroy a chunk
     </destructor>
 
     <method name = "resize">
-  Resizes chunk max_size as requested; chunk_cur size is set to zero
-
+        Resizes chunk max_size as requested; chunk_cur size is set to zero
         <argument name = "size" type = "size" />
     </method>
 
     <method name = "size">
-  Return chunk cur size
-
+        Return chunk cur size
         <return type = "size" />
     </method>
 
     <method name = "max_size">
-  Return chunk max size
-
+        Return chunk max size
         <return type = "size" />
     </method>
 
     <method name = "data">
-  Return chunk data
+        Return chunk data
         <return type = "buffer" mutable = "1" />
     </method>
 
     <method name = "set">
-  Set chunk data from user-supplied data; truncate if too large. Data may
-  be null. Returns actual size of chunk
-
+        Set chunk data from user-supplied data; truncate if too large. Data may
+        be null. Returns actual size of chunk
         <argument name = "data" type = "anything" mutable = "0" />
         <argument name = "size" type = "size" />
         <return type = "size" />
     </method>
 
     <method name = "fill">
-  Fill chunk data from user-supplied octet
-
+        Fill chunk data from user-supplied octet
         <argument name = "filler" type = "byte" />
         <argument name = "size" type = "size" />
         <return type = "size" />
     </method>
 
     <method name = "append">
-  Append user-supplied data to chunk, return resulting chunk size. If the
-  data would exceeded the available space, it is truncated. If you want to
-  grow the chunk to accommodate new data, use the zchunk_extend method.
-
+        Append user-supplied data to chunk, return resulting chunk size. If the
+        data would exceeded the available space, it is truncated. If you want to
+        grow the chunk to accommodate new data, use the zchunk_extend method.
         <argument name = "data" type = "anything" mutable = "0" />
         <argument name = "size" type = "size" />
         <return type = "size" />
     </method>
 
     <method name = "extend">
-  Append user-supplied data to chunk, return resulting chunk size. If the
-  data would exceeded the available space, the chunk grows in size.
-
+        Append user-supplied data to chunk, return resulting chunk size. If the
+        data would exceeded the available space, the chunk grows in size.
         <argument name = "data" type = "anything" mutable = "0" />
         <argument name = "size" type = "size" />
         <return type = "size" />
     </method>
 
     <method name = "consume">
-  Copy as much data from 'source' into the chunk as possible; returns the
-  new size of chunk. If all data from 'source' is used, returns exhausted
-  on the source chunk. Source can be consumed as many times as needed until
-  it is exhausted. If source was already exhausted, does not change chunk.
-
+        Copy as much data from 'source' into the chunk as possible; returns the
+        new size of chunk. If all data from 'source' is used, returns exhausted
+        on the source chunk. Source can be consumed as many times as needed until
+        it is exhausted. If source was already exhausted, does not change chunk.
         <argument name = "source" type = "zchunk" mutable = "1" />
         <return type = "size" />
     </method>
 
     <method name = "exhausted">
-  Returns true if the chunk was exhausted by consume methods, or if the
-  chunk has a size of zero.
-
+        Returns true if the chunk was exhausted by consume methods, or if the
+        chunk has a size of zero.
         <return type = "boolean" />
     </method>
 
     <method name = "read" singleton = "1">
-  Read chunk from an open file descriptor
-
+        Read chunk from an open file descriptor
         <argument name = "handle" type = "FILE" mutable = "1" />
         <argument name = "bytes" type = "size" />
         <return type = "zchunk" fresh = "1" />
     </method>
 
     <method name = "write">
-  Write chunk to an open file descriptor
-
+        Write chunk to an open file descriptor
         <argument name = "handle" type = "FILE" mutable = "1" />
         <return type = "integer" />
     </method>
 
     <method name = "slurp" singleton = "1">
-  Try to slurp an entire file into a chunk. Will read up to maxsize of
-  the file. If maxsize is 0, will attempt to read the entire file and
-  fail with an assertion if that cannot fit into memory. Returns a new
-  chunk containing the file data, or NULL if the file could not be read.
-
+        Try to slurp an entire file into a chunk. Will read up to maxsize of
+        the file. If maxsize is 0, will attempt to read the entire file and
+        fail with an assertion if that cannot fit into memory. Returns a new
+        chunk containing the file data, or NULL if the file could not be read.
         <argument name = "filename" type = "string" />
         <argument name = "maxsize" type = "size" />
         <return type = "zchunk" fresh = "1" />
     </method>
 
     <method name = "dup">
-  Create copy of chunk, as new chunk object. Returns a fresh zchunk_t
-  object, or null if there was not enough heap memory. If chunk is null,
-  returns null.
-
+        Create copy of chunk, as new chunk object. Returns a fresh zchunk_t
+        object, or null if there was not enough heap memory. If chunk is null,
+        returns null.
         <return type = "zchunk" fresh = "1" />
     </method>
 
     <method name = "strhex">
-  Return chunk data encoded as printable hex string. Caller must free
-  string when finished with it.
+        Return chunk data encoded as printable hex string. Caller must free
+        string when finished with it.
         <return type = "string" fresh = "1" />
     </method>
 
     <method name = "strdup">
-  Return chunk data copied into freshly allocated string
-  Caller must free string when finished with it.
-
+        Return chunk data copied into freshly allocated string
+        Caller must free string when finished with it.
         <return type = "string" fresh = "1" />
     </method>
 
     <method name = "streq">
-  Return TRUE if chunk body is equal to string, excluding terminator
-
+        Return TRUE if chunk body is equal to string, excluding terminator
         <argument name = "string" type = "string" />
         <return type = "boolean" />
     </method>
 
     <method name = "pack">
-  Transform zchunk into a zframe that can be sent in a message.
-
+        Transform zchunk into a zframe that can be sent in a message.
         <return type = "zframe" fresh = "1" />
     </method>
 
     <method name = "unpack" singleton = "1">
-  Transform a zframe into a zchunk.
-
+        Transform a zframe into a zchunk.
         <argument name = "frame" type = "zframe" mutable = "1" />
         <return type = "zchunk" fresh = "1" />
     </method>
 
     <method name = "digest">
-  Calculate SHA1 digest for chunk, using zdigest class.
-
+        Calculate SHA1 digest for chunk, using zdigest class.
         <return type = "string" />
     </method>
 
     <method name = "fprint">
-  Dump chunk to FILE stream, for debugging and tracing.
-
+        Dump chunk to FILE stream, for debugging and tracing.
         <argument name = "file" type = "FILE" mutable = "1" />
     </method>
 
     <method name = "print">
-  Dump message to stderr, for debugging and tracing.
-  See zchunk_fprint for details
-
+        Dump message to stderr, for debugging and tracing.
+        See zchunk_fprint for details
     </method>
 
     <method name = "is" singleton = "1">
-  Probe the supplied object, and report if it looks like a zchunk_t.
-
+        Probe the supplied object, and report if it looks like a zchunk_t.
         <argument name = "self" type = "anything" mutable = "1" />
         <return type = "boolean" />
     </method>
-
 </class>

--- a/api/zclock.xml
+++ b/api/zclock.xml
@@ -1,6 +1,13 @@
 <class name = "zclock" >
+    <!--
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
 
-    <include filename = "../license.xml" />
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    -->
 
     <method name = "sleep" singleton = "1">
         Sleep for a number of milliseconds
@@ -11,21 +18,21 @@
         Return current system clock as milliseconds. Note that this clock can
         jump backwards (if the system clock is changed) so is unsafe to use for
         timers and time offsets. Use zclock_mono for that instead.
-        <return type = "clock" />
+        <return type = "msecs" />
     </method>
 
     <method name = "mono" singleton = "1">
         Return current monotonic clock in milliseconds. Use this when you compute
         time offsets. The monotonic clock is not affected by system changes and
         so will never be reset backwards, unlike a system clock.
-        <return type = "clock" />
+        <return type = "msecs" />
     </method>
 
     <method name = "usecs" singleton = "1">
         Return current monotonic clock in microseconds. Use this when you compute
         time offsets. The monotonic clock is not affected by system changes and
         so will never be reset backwards, unlike a system clock.
-        <return type = "clock" />
+        <return type = "msecs" />
     </method>
 
     <method name = "timestr" singleton = "1">


### PR DESCRIPTION
Solution: use new 'msecs' type instead

(Also fixed bogus license header).