### PR TITLE
add ZMTP 3.1 heartbeat options

### DIFF
--- a/api/zsock_option.xml
+++ b/api/zsock_option.xml
@@ -8,6 +8,36 @@
 ******************************************************************
 -->
 
+<method name = "heartbeat ivl" polymorphic = "1">
+    Get socket option `heartbeat_ivl`.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set heartbeat ivl" polymorphic = "1">
+    Set socket option `heartbeat_ivl`.
+    <argument name = "heartbeat ivl" type = "integer" />
+</method>
+
+<method name = "heartbeat ttl" polymorphic = "1">
+    Get socket option `heartbeat_ttl`.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set heartbeat ttl" polymorphic = "1">
+    Set socket option `heartbeat_ttl`.
+    <argument name = "heartbeat ttl" type = "integer" />
+</method>
+
+<method name = "heartbeat timeout" polymorphic = "1">
+    Get socket option `heartbeat_timeout`.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set heartbeat timeout" polymorphic = "1">
+    Set socket option `heartbeat_timeout`.
+    <argument name = "heartbeat timeout" type = "integer" />
+</method>
+
 <method name = "tos" polymorphic = "1">
     Get socket option `tos`.
     <return type = "integer" fresh = "1" />

--- a/api/zsock_option.xml
+++ b/api/zsock_option.xml
@@ -3,7 +3,7 @@
 *   GENERATED SOURCE CODE, DO NOT EDIT!!                         *
 *   TO CHANGE THIS FILE:                                         *
 *    - EDIT src/zsock_option.gsl and/or                          *
-*    - EDIT src/zsock_option.xml and then                        *
+*    - EDIT src/sockopts.xml     and then                        *
 *    - RUN 'make code'                                           *
 ******************************************************************
 -->

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -492,6 +492,12 @@ module CZMQ
       attach_function :zsock_flush, [:pointer], :void, **opts
       attach_function :zsock_is, [:pointer], :bool, **opts
       attach_function :zsock_resolve, [:pointer], :pointer, **opts
+      attach_function :zsock_heartbeat_ivl, [:pointer], :int, **opts
+      attach_function :zsock_set_heartbeat_ivl, [:pointer, :int], :void, **opts
+      attach_function :zsock_heartbeat_ttl, [:pointer], :int, **opts
+      attach_function :zsock_set_heartbeat_ttl, [:pointer, :int], :void, **opts
+      attach_function :zsock_heartbeat_timeout, [:pointer], :int, **opts
+      attach_function :zsock_set_heartbeat_timeout, [:pointer, :int], :void, **opts
       attach_function :zsock_tos, [:pointer], :int, **opts
       attach_function :zsock_set_tos, [:pointer, :int], :void, **opts
       attach_function :zsock_set_router_handover, [:pointer, :int], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -816,6 +816,156 @@ module CZMQ
         result
       end
 
+      # Get socket option `heartbeat_ivl`.
+      #
+      # @return [Integer]
+      def heartbeat_ivl()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zsock_heartbeat_ivl(self_p)
+        result
+      end
+
+      # Get socket option `heartbeat_ivl`.
+      #
+      # This is the polymorphic version of #heartbeat_ivl.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @return [Integer]
+      def self.heartbeat_ivl(self_p)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        result = ::CZMQ::FFI.zsock_heartbeat_ivl(self_p)
+        result
+      end
+
+      # Set socket option `heartbeat_ivl`.
+      #
+      # @param heartbeat_ivl [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_heartbeat_ivl(heartbeat_ivl)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        heartbeat_ivl = Integer(heartbeat_ivl)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_ivl(self_p, heartbeat_ivl)
+        result
+      end
+
+      # Set socket option `heartbeat_ivl`.
+      #
+      # This is the polymorphic version of #set_heartbeat_ivl.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param heartbeat_ivl [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_heartbeat_ivl(self_p, heartbeat_ivl)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        heartbeat_ivl = Integer(heartbeat_ivl)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_ivl(self_p, heartbeat_ivl)
+        result
+      end
+
+      # Get socket option `heartbeat_ttl`.
+      #
+      # @return [Integer]
+      def heartbeat_ttl()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zsock_heartbeat_ttl(self_p)
+        result
+      end
+
+      # Get socket option `heartbeat_ttl`.
+      #
+      # This is the polymorphic version of #heartbeat_ttl.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @return [Integer]
+      def self.heartbeat_ttl(self_p)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        result = ::CZMQ::FFI.zsock_heartbeat_ttl(self_p)
+        result
+      end
+
+      # Set socket option `heartbeat_ttl`.
+      #
+      # @param heartbeat_ttl [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_heartbeat_ttl(heartbeat_ttl)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        heartbeat_ttl = Integer(heartbeat_ttl)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_ttl(self_p, heartbeat_ttl)
+        result
+      end
+
+      # Set socket option `heartbeat_ttl`.
+      #
+      # This is the polymorphic version of #set_heartbeat_ttl.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param heartbeat_ttl [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_heartbeat_ttl(self_p, heartbeat_ttl)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        heartbeat_ttl = Integer(heartbeat_ttl)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_ttl(self_p, heartbeat_ttl)
+        result
+      end
+
+      # Get socket option `heartbeat_timeout`.
+      #
+      # @return [Integer]
+      def heartbeat_timeout()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zsock_heartbeat_timeout(self_p)
+        result
+      end
+
+      # Get socket option `heartbeat_timeout`.
+      #
+      # This is the polymorphic version of #heartbeat_timeout.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @return [Integer]
+      def self.heartbeat_timeout(self_p)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        result = ::CZMQ::FFI.zsock_heartbeat_timeout(self_p)
+        result
+      end
+
+      # Set socket option `heartbeat_timeout`.
+      #
+      # @param heartbeat_timeout [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_heartbeat_timeout(heartbeat_timeout)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        heartbeat_timeout = Integer(heartbeat_timeout)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_timeout(self_p, heartbeat_timeout)
+        result
+      end
+
+      # Set socket option `heartbeat_timeout`.
+      #
+      # This is the polymorphic version of #set_heartbeat_timeout.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param heartbeat_timeout [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_heartbeat_timeout(self_p, heartbeat_timeout)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        heartbeat_timeout = Integer(heartbeat_timeout)
+        result = ::CZMQ::FFI.zsock_set_heartbeat_timeout(self_p, heartbeat_timeout)
+        result
+      end
+
       # Get socket option `tos`.
       #
       # @return [Integer]

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -312,6 +312,33 @@ CZMQ_EXPORT bool
 CZMQ_EXPORT void *
     zsock_resolve (void *self);
 
+//  Get socket option `heartbeat_ivl`.
+//  The caller is responsible for destroying the return value when finished with it.
+CZMQ_EXPORT int
+    zsock_heartbeat_ivl (void *self);
+
+//  Set socket option `heartbeat_ivl`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
+
+//  Get socket option `heartbeat_ttl`.
+//  The caller is responsible for destroying the return value when finished with it.
+CZMQ_EXPORT int
+    zsock_heartbeat_ttl (void *self);
+
+//  Set socket option `heartbeat_ttl`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
+
+//  Get socket option `heartbeat_timeout`.
+//  The caller is responsible for destroying the return value when finished with it.
+CZMQ_EXPORT int
+    zsock_heartbeat_timeout (void *self);
+
+//  Set socket option `heartbeat_timeout`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
+
 //  Get socket option `tos`.
 //  The caller is responsible for destroying the return value when finished with it.
 CZMQ_EXPORT int

--- a/include/zsockopt.h
+++ b/include/zsockopt.h
@@ -27,6 +27,9 @@ extern "C" {
 //  @interface
 #if (ZMQ_VERSION_MAJOR == 4)
 //  Get socket options
+CZMQ_EXPORT int zsocket_heartbeat_ivl (void *zocket);
+CZMQ_EXPORT int zsocket_heartbeat_ttl (void *zocket);
+CZMQ_EXPORT int zsocket_heartbeat_timeout (void *zocket);
 CZMQ_EXPORT int zsocket_tos (void *zocket);
 CZMQ_EXPORT char * zsocket_zap_domain (void *zocket);
 CZMQ_EXPORT int zsocket_mechanism (void *zocket);
@@ -72,6 +75,9 @@ CZMQ_EXPORT int zsocket_events (void *zocket);
 CZMQ_EXPORT char * zsocket_last_endpoint (void *zocket);
 
 //  Set socket options
+CZMQ_EXPORT void zsocket_set_heartbeat_ivl (void *zocket, int heartbeat_ivl);
+CZMQ_EXPORT void zsocket_set_heartbeat_ttl (void *zocket, int heartbeat_ttl);
+CZMQ_EXPORT void zsocket_set_heartbeat_timeout (void *zocket, int heartbeat_timeout);
 CZMQ_EXPORT void zsocket_set_tos (void *zocket, int tos);
 CZMQ_EXPORT void zsocket_set_router_handover (void *zocket, int router_handover);
 CZMQ_EXPORT void zsocket_set_router_mandatory (void *zocket, int router_mandatory);

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -9,6 +9,14 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
     -->
     <version major = "4" style = "macro">
+        <!-- Options that are new in 4.2 -->
+        <option name = "heartbeat_ivl"     type = "int"    mode = "rw" test = "DEALER"
+            test_value = "2000" />
+        <option name = "heartbeat_ttl"     type = "int"    mode = "rw"  test = "DEALER"
+            test_value = "4000" />
+        <option name = "heartbeat_timeout" type = "int"    mode = "rw"  test = "DEALER"
+            test_value = "6000" />
+
         <!-- Options that are new in 4.1 -->
         <option name = "tos"               type = "int"    mode = "rw" test = "DEALER" />
         <option name = "router_handover"   type = "int"    mode = "w"  test = "ROUTER">

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -8,7 +8,7 @@
 *   GENERATED SOURCE CODE, DO NOT EDIT!!                         *
 *   TO CHANGE THIS FILE:                                         *
 *    - EDIT src/zsock_option.gsl and/or                          *
-*    - EDIT src/zsock_option.xml and then                        *
+*    - EDIT src/sockopts.xml     and then                        *
 *    - RUN 'make code'                                           *
 ******************************************************************
 -->

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -231,9 +231,9 @@ zsock_option_test (bool verbose)
     assert (self);
 .       if mode = "rw" | mode = "w"
 .           if ctype = "int"
-    zsock_set_$(name) (self, 1);
+    zsock_set_$(name) (self, $(test_value? 1 :));
 .               if mode = "rw"
-    assert (zsock_$(name) (self) == 1);
+    assert (zsock_$(name) (self) == $(test_value? 1 :));
 .               endif
 .           else
     zsock_set_$(name) (self, "$(test_value?'test':)");

--- a/src/zsock_option.inc
+++ b/src/zsock_option.inc
@@ -21,6 +21,105 @@
 
 #if (ZMQ_VERSION_MAJOR == 4)
 //  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_IVL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_IVL)
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_IVL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsock_heartbeat_ivl (void *self)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_IVL)
+    int heartbeat_ivl;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, &option_len);
+    return heartbeat_ivl;
+#   else
+    return 0;
+#   endif
+}
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_TTL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_TTL)
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_TTL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsock_heartbeat_ttl (void *self)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_TTL)
+    int heartbeat_ttl;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, &option_len);
+    return heartbeat_ttl;
+#   else
+    return 0;
+#   endif
+}
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_TIMEOUT value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_TIMEOUT value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsock_heartbeat_timeout (void *self)
+{
+    assert (self);
+#   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int heartbeat_timeout;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, &option_len);
+    return heartbeat_timeout;
+#   else
+    return 0;
+#   endif
+}
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_TOS value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -3198,6 +3297,30 @@ zsock_option_test (bool verbose)
     //  @selftest
     zsock_t *self;
 #if (ZMQ_VERSION_MAJOR == 4)
+#     if defined (ZMQ_HEARTBEAT_IVL)
+    self = zsock_new (ZMQ_DEALER);
+    assert (self);
+    zsock_set_heartbeat_ivl (self, 2000);
+    assert (zsock_heartbeat_ivl (self) == 2000);
+    zsock_heartbeat_ivl (self);
+    zsock_destroy (&self);
+#     endif
+#     if defined (ZMQ_HEARTBEAT_TTL)
+    self = zsock_new (ZMQ_DEALER);
+    assert (self);
+    zsock_set_heartbeat_ttl (self, 4000);
+    assert (zsock_heartbeat_ttl (self) == 4000);
+    zsock_heartbeat_ttl (self);
+    zsock_destroy (&self);
+#     endif
+#     if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    self = zsock_new (ZMQ_DEALER);
+    assert (self);
+    zsock_set_heartbeat_timeout (self, 6000);
+    assert (zsock_heartbeat_timeout (self) == 6000);
+    zsock_heartbeat_timeout (self);
+    zsock_destroy (&self);
+#     endif
 #     if defined (ZMQ_TOS)
     self = zsock_new (ZMQ_DEALER);
     assert (self);

--- a/src/zsockopt.c
+++ b/src/zsockopt.c
@@ -31,6 +31,114 @@
 
 #if (ZMQ_VERSION_MAJOR == 4)
 //  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_IVL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsocket_set_heartbeat_ivl (void *zocket, int heartbeat_ivl)
+{
+    if (zsock_is (zocket)) {
+        printf ("Please use zsock_set_heartbeat_ivl () on zsock_t instances\n");
+        assert (false);
+    }
+#   if defined (ZMQ_HEARTBEAT_IVL)
+    int rc = zmq_setsockopt (zocket, ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_IVL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsocket_heartbeat_ivl (void *zocket)
+{
+#   if defined (ZMQ_HEARTBEAT_IVL)
+    int heartbeat_ivl;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zocket, ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, &option_len);
+    return heartbeat_ivl;
+#   else
+    return 0;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_TTL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsocket_set_heartbeat_ttl (void *zocket, int heartbeat_ttl)
+{
+    if (zsock_is (zocket)) {
+        printf ("Please use zsock_set_heartbeat_ttl () on zsock_t instances\n");
+        assert (false);
+    }
+#   if defined (ZMQ_HEARTBEAT_TTL)
+    int rc = zmq_setsockopt (zocket, ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_TTL value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsocket_heartbeat_ttl (void *zocket)
+{
+#   if defined (ZMQ_HEARTBEAT_TTL)
+    int heartbeat_ttl;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zocket, ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, &option_len);
+    return heartbeat_ttl;
+#   else
+    return 0;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set socket ZMQ_HEARTBEAT_TIMEOUT value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+void
+zsocket_set_heartbeat_timeout (void *zocket, int heartbeat_timeout)
+{
+    if (zsock_is (zocket)) {
+        printf ("Please use zsock_set_heartbeat_timeout () on zsock_t instances\n");
+        assert (false);
+    }
+#   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int rc = zmq_setsockopt (zocket, ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, sizeof (int));
+    assert (rc == 0 || zmq_errno () == ETERM);
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return socket ZMQ_HEARTBEAT_TIMEOUT value
+//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+
+int
+zsocket_heartbeat_timeout (void *zocket)
+{
+#   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int heartbeat_timeout;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zocket, ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, &option_len);
+    return heartbeat_timeout;
+#   else
+    return 0;
+#   endif
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set socket ZMQ_TOS value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -3489,6 +3597,30 @@ zsockopt_test (bool verbose)
     assert (ctx);
     void *zocket;
 #if (ZMQ_VERSION_MAJOR == 4)
+#     if defined (ZMQ_HEARTBEAT_IVL)
+    zocket = zsocket_new (ctx, ZMQ_DEALER);
+    assert (zocket);
+    zsocket_set_heartbeat_ivl (zocket, 2000);
+    assert (zsocket_heartbeat_ivl (zocket) == 2000);
+    zsocket_heartbeat_ivl (zocket);
+    zsocket_destroy (ctx, zocket);
+#     endif
+#     if defined (ZMQ_HEARTBEAT_TTL)
+    zocket = zsocket_new (ctx, ZMQ_DEALER);
+    assert (zocket);
+    zsocket_set_heartbeat_ttl (zocket, 4000);
+    assert (zsocket_heartbeat_ttl (zocket) == 4000);
+    zsocket_heartbeat_ttl (zocket);
+    zsocket_destroy (ctx, zocket);
+#     endif
+#     if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    zocket = zsocket_new (ctx, ZMQ_DEALER);
+    assert (zocket);
+    zsocket_set_heartbeat_timeout (zocket, 6000);
+    assert (zsocket_heartbeat_timeout (zocket) == 6000);
+    zsocket_heartbeat_timeout (zocket);
+    zsocket_destroy (ctx, zocket);
+#     endif
 #     if defined (ZMQ_TOS)
     zocket = zsocket_new (ctx, ZMQ_DEALER);
     assert (zocket);

--- a/src/zsockopt.gsl
+++ b/src/zsockopt.gsl
@@ -285,9 +285,9 @@ zsockopt_test (bool verbose)
     assert (zocket);
 .       if mode = "rw" | mode = "w"
 .           if ctype = "int"
-    zsocket_set_$(name) (zocket, 1);
+    zsocket_set_$(name) (zocket, $(test_value? 1 :));
 .               if mode = "rw"
-    assert (zsocket_$(name) (zocket) == 1);
+    assert (zsocket_$(name) (zocket) == $(test_value? 1 :));
 .               endif
 .           else
     zsocket_set_$(name) (zocket, "$(test_value?'test':)");


### PR DESCRIPTION
This PR:

* fixes a wrong filename in a generated header comment
* adds the ability to use the `test_value` attribute for integers as well
* adds the three options (r/w) `heartbeat_ivl`, `heartbeat_ttl`, and `heartbeat_timeout`
* regenerates the affected API XML, C sources, and Ruby binding

`make check` is happy.