### PR TITLE
draft related improvements

### DIFF
--- a/api/zcert.xml
+++ b/api/zcert.xml
@@ -55,7 +55,7 @@
         <argument name = "format" type = "format" />
     </method>
 
-    <method name = "unset meta">
+    <method name = "unset meta" state = "draft" >
         Unset certificate metadata.
         <argument name = "name" type = "string" />
     </method>

--- a/api/zframe.xml
+++ b/api/zframe.xml
@@ -97,13 +97,13 @@
         <argument name = "more" type = "integer" />
     </method>
 
-    <method name = "routing id">
+    <method name = "routing id" state = "draft" >
         Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
         Else returns zero.
         <return type = "number" size = "4" />
     </method>
 
-    <method name = "set routing id">
+    <method name = "set routing id" state = "draft" >
         Set routing ID on frame. This is used if/when the frame is sent to a
         ZMQ_SERVER socket.
         <argument name = "routing id" type = "number" size = "4" />

--- a/api/zlistx.xml
+++ b/api/zlistx.xml
@@ -40,12 +40,12 @@
         <return type = "size" />
     </method>
 
-    <method name = "head">
+    <method name = "head" state = "draft" >
         Return first item in the list, or null, leaves the cursor
         <return type = "anything" mutable = "1" />
     </method>
 
-    <method name = "tail">
+    <method name = "tail" state = "draft" >
         Return last item in the list, or null, leaves the cursor
         <return type = "anything" mutable = "1" />
     </method>

--- a/api/zloop.xml
+++ b/api/zloop.xml
@@ -158,7 +158,7 @@
         <argument name = "verbose" type = "boolean" />
     </method>
 
-    <method name = "set nonstop">
+    <method name = "set nonstop" state = "draft" >
         By default the reactor stops if the process receives a SIGINT or SIGTERM
         signal. This makes it impossible to shut-down message based architectures
         like zactors. This method lets you switch off break handling. The default

--- a/api/zmsg.xml
+++ b/api/zmsg.xml
@@ -58,13 +58,13 @@
         <return type = "size" />
     </method>
 
-    <method name = "routing id">
+    <method name = "routing id" state = "draft" >
         Return message routing ID, if the message came from a ZMQ_SERVER socket.
         Else returns zero.
         <return type = "number" size = "4" />
     </method>
 
-    <method name = "set routing id">
+    <method name = "set routing id" state = "draft" >
         Set routing ID on message. This is used if/when the message is sent to a
         ZMQ_SERVER socket.
         <argument name = "routing id" type = "number" size = "4" />

--- a/api/zpoller.xml
+++ b/api/zpoller.xml
@@ -35,7 +35,7 @@
         <return type = "integer" />
     </method>
 
-    <method name = "set nonstop">
+    <method name = "set nonstop" state = "draft" >
         By default the poller stops if the process receives a SIGINT or SIGTERM
         signal. This makes it impossible to shut-down message based architectures
         like zactors. This method lets you switch off break handling. The default

--- a/api/zsock.xml
+++ b/api/zsock.xml
@@ -87,12 +87,12 @@
         <argument name = "endpoint" type = "string" />
     </constructor>
 
-    <constructor name = "new server">
+    <constructor name = "new server" state = "draft" >
         Create a SERVER socket. Default action is bind.
         <argument name = "endpoint" type = "string" />
     </constructor>
 
-    <constructor name = "new client">
+    <constructor name = "new client" state = "draft" >
         Create a CLIENT socket. Default action is connect.
         <argument name = "endpoint" type = "string" />
     </constructor>
@@ -289,13 +289,13 @@
         <return type = "integer" />
     </method>
 
-    <method name = "routing id">
+    <method name = "routing id" state = "draft" >
         Return socket routing ID if any. This returns 0 if the socket is not
         of type ZMQ_SERVER or if no request was already received on it.
         <return type = "number" size = "4" />
     </method>
 
-    <method name = "set routing id">
+    <method name = "set routing id" state = "draft" >
         Set routing ID on socket. The socket MUST be of type ZMQ_SERVER.
         This will be used when sending messages on the socket via the zsock API.
         <argument name = "routing id" type = "number" size = "4" />

--- a/api/zsock_option.xml
+++ b/api/zsock_option.xml
@@ -8,32 +8,32 @@
 ******************************************************************
 -->
 
-<method name = "heartbeat ivl" polymorphic = "1">
+<method name = "heartbeat ivl" polymorphic = "1" state = "draft">
     Get socket option `heartbeat_ivl`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat ivl" polymorphic = "1">
+<method name = "set heartbeat ivl" polymorphic = "1" state = "draft">
     Set socket option `heartbeat_ivl`.
     <argument name = "heartbeat ivl" type = "integer" />
 </method>
 
-<method name = "heartbeat ttl" polymorphic = "1">
+<method name = "heartbeat ttl" polymorphic = "1" state = "draft">
     Get socket option `heartbeat_ttl`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat ttl" polymorphic = "1">
+<method name = "set heartbeat ttl" polymorphic = "1" state = "draft">
     Set socket option `heartbeat_ttl`.
     <argument name = "heartbeat ttl" type = "integer" />
 </method>
 
-<method name = "heartbeat timeout" polymorphic = "1">
+<method name = "heartbeat timeout" polymorphic = "1" state = "draft">
     Get socket option `heartbeat_timeout`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat timeout" polymorphic = "1">
+<method name = "set heartbeat timeout" polymorphic = "1" state = "draft">
     Set socket option `heartbeat_timeout`.
     <argument name = "heartbeat timeout" type = "integer" />
 </method>

--- a/api/zstr.xml
+++ b/api/zstr.xml
@@ -75,7 +75,7 @@
         <return type = "integer" />
     </method>
 
-    <method name = "str" singleton = "1">
+    <method name = "str" singleton = "1" state = "draft" >
         Accepts a void pointer and returns a fresh character string. If source
         is null, returns an empty string.
         <argument name = "source" type = "anything" />

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -87,7 +87,14 @@ module CZMQ
       attach_function :zcert_public_txt, [:pointer], :pointer, **opts
       attach_function :zcert_secret_txt, [:pointer], :pointer, **opts
       attach_function :zcert_set_meta, [:pointer, :string, :string, :varargs], :void, **opts
-      attach_function :zcert_unset_meta, [:pointer, :string], :void, **opts
+      begin # DRAFT method
+        attach_function :zcert_unset_meta, [:pointer, :string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function unset_meta() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zcert_meta, [:pointer, :string], :pointer, **opts
       attach_function :zcert_meta_keys, [:pointer], :pointer, **opts
       attach_function :zcert_save, [:pointer, :string], :int, **opts
@@ -270,8 +277,22 @@ module CZMQ
       attach_function :zframe_streq, [:pointer, :string], :bool, **opts
       attach_function :zframe_more, [:pointer], :int, **opts
       attach_function :zframe_set_more, [:pointer, :int], :void, **opts
-      attach_function :zframe_routing_id, [:pointer], :uint32, **opts
-      attach_function :zframe_set_routing_id, [:pointer, :uint32], :void, **opts
+      begin # DRAFT method
+        attach_function :zframe_routing_id, [:pointer], :uint32, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zframe_set_routing_id, [:pointer, :uint32], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zframe_eq, [:pointer, :pointer], :bool, **opts
       attach_function :zframe_reset, [:pointer, :pointer, :size_t], :void, **opts
       attach_function :zframe_print, [:pointer, :string], :void, **opts
@@ -384,8 +405,22 @@ module CZMQ
       attach_function :zlistx_add_start, [:pointer, :pointer], :pointer, **opts
       attach_function :zlistx_add_end, [:pointer, :pointer], :pointer, **opts
       attach_function :zlistx_size, [:pointer], :size_t, **opts
-      attach_function :zlistx_head, [:pointer], :pointer, **opts
-      attach_function :zlistx_tail, [:pointer], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zlistx_head, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function head() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zlistx_tail, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function tail() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zlistx_first, [:pointer], :pointer, **opts
       attach_function :zlistx_next, [:pointer], :pointer, **opts
       attach_function :zlistx_prev, [:pointer], :pointer, **opts
@@ -427,7 +462,14 @@ module CZMQ
       attach_function :zloop_set_ticket_delay, [:pointer, :size_t], :void, **opts
       attach_function :zloop_set_max_timers, [:pointer, :size_t], :void, **opts
       attach_function :zloop_set_verbose, [:pointer, :bool], :void, **opts
-      attach_function :zloop_set_nonstop, [:pointer, :bool], :void, **opts
+      begin # DRAFT method
+        attach_function :zloop_set_nonstop, [:pointer, :bool], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_nonstop() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zloop_start, [:pointer], :int, **opts
       attach_function :zloop_test, [:bool], :void, **opts
 
@@ -443,8 +485,22 @@ module CZMQ
       attach_function :zmsg_sendm, [:pointer, :pointer], :int, **opts
       attach_function :zmsg_size, [:pointer], :size_t, **opts
       attach_function :zmsg_content_size, [:pointer], :size_t, **opts
-      attach_function :zmsg_routing_id, [:pointer], :uint32, **opts
-      attach_function :zmsg_set_routing_id, [:pointer, :uint32], :void, **opts
+      begin # DRAFT method
+        attach_function :zmsg_routing_id, [:pointer], :uint32, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zmsg_set_routing_id, [:pointer, :uint32], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zmsg_prepend, [:pointer, :pointer], :int, **opts
       attach_function :zmsg_append, [:pointer, :pointer], :int, **opts
       attach_function :zmsg_pop, [:pointer], :pointer, **opts
@@ -476,7 +532,14 @@ module CZMQ
       attach_function :zpoller_destroy, [:pointer], :void, **opts
       attach_function :zpoller_add, [:pointer, :pointer], :int, **opts
       attach_function :zpoller_remove, [:pointer, :pointer], :int, **opts
-      attach_function :zpoller_set_nonstop, [:pointer, :bool], :void, **opts
+      begin # DRAFT method
+        attach_function :zpoller_set_nonstop, [:pointer, :bool], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_nonstop() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zpoller_wait, [:pointer, :int], :pointer, **opts
       attach_function :zpoller_expired, [:pointer], :bool, **opts
       attach_function :zpoller_terminated, [:pointer], :bool, **opts
@@ -484,25 +547,158 @@ module CZMQ
 
       require_relative 'ffi/zpoller'
 
-      attach_function :zproc_czmq_version, [], :int, **opts
-      attach_function :zproc_interrupted, [], :bool, **opts
-      attach_function :zproc_has_curve, [], :bool, **opts
-      attach_function :zproc_hostname, [], :pointer, **opts
-      attach_function :zproc_daemonize, [:string], :void, **opts
-      attach_function :zproc_run_as, [:string, :string, :string], :void, **opts
-      attach_function :zproc_set_io_threads, [:size_t], :void, **opts
-      attach_function :zproc_set_max_sockets, [:size_t], :void, **opts
-      attach_function :zproc_set_biface, [:string], :void, **opts
-      attach_function :zproc_biface, [], :string, **opts
-      attach_function :zproc_set_log_ident, [:string], :void, **opts
-      attach_function :zproc_set_log_sender, [:string], :void, **opts
-      attach_function :zproc_set_log_system, [:bool], :void, **opts
-      attach_function :zproc_log_error, [:string, :varargs], :void, **opts
-      attach_function :zproc_log_warning, [:string, :varargs], :void, **opts
-      attach_function :zproc_log_notice, [:string, :varargs], :void, **opts
-      attach_function :zproc_log_info, [:string, :varargs], :void, **opts
-      attach_function :zproc_log_debug, [:string, :varargs], :void, **opts
-      attach_function :zproc_test, [:bool], :void, **opts
+      begin # DRAFT method
+        attach_function :zproc_czmq_version, [], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function czmq_version() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_interrupted, [], :bool, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function interrupted() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_has_curve, [], :bool, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function has_curve() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_hostname, [], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function hostname() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_daemonize, [:string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function daemonize() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_run_as, [:string, :string, :string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function run_as() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_io_threads, [:size_t], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_io_threads() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_max_sockets, [:size_t], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_max_sockets() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_biface, [:string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_biface() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_biface, [], :string, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function biface() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_log_ident, [:string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_log_ident() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_log_sender, [:string], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_log_sender() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_set_log_system, [:bool], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_log_system() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_log_error, [:string, :varargs], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function log_error() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_log_warning, [:string, :varargs], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function log_warning() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_log_notice, [:string, :varargs], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function log_notice() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_log_info, [:string, :varargs], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function log_info() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_log_debug, [:string, :varargs], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function log_debug() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zproc_test, [:bool], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function test() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
 
       require_relative 'ffi/zproc'
 
@@ -519,8 +715,22 @@ module CZMQ
       attach_function :zsock_new_xsub, [:string], :pointer, **opts
       attach_function :zsock_new_pair, [:string], :pointer, **opts
       attach_function :zsock_new_stream, [:string], :pointer, **opts
-      attach_function :zsock_new_server, [:string], :pointer, **opts
-      attach_function :zsock_new_client, [:string], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zsock_new_server, [:string], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function new_server() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_new_client, [:string], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function new_client() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zsock_destroy, [:pointer], :void, **opts
       attach_function :zsock_bind, [:pointer, :string, :varargs], :int, **opts
       attach_function :zsock_endpoint, [:pointer], :string, **opts
@@ -535,20 +745,76 @@ module CZMQ
       attach_function :zsock_vrecv, [:pointer, :string, :pointer], :int, **opts
       attach_function :zsock_bsend, [:pointer, :string, :varargs], :int, **opts
       attach_function :zsock_brecv, [:pointer, :string, :varargs], :int, **opts
-      attach_function :zsock_routing_id, [:pointer], :uint32, **opts
-      attach_function :zsock_set_routing_id, [:pointer, :uint32], :void, **opts
+      begin # DRAFT method
+        attach_function :zsock_routing_id, [:pointer], :uint32, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_set_routing_id, [:pointer, :uint32], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_routing_id() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zsock_set_unbounded, [:pointer], :void, **opts
       attach_function :zsock_signal, [:pointer, :char], :int, **opts
       attach_function :zsock_wait, [:pointer], :int, **opts
       attach_function :zsock_flush, [:pointer], :void, **opts
       attach_function :zsock_is, [:pointer], :bool, **opts
       attach_function :zsock_resolve, [:pointer], :pointer, **opts
-      attach_function :zsock_heartbeat_ivl, [:pointer], :int, **opts
-      attach_function :zsock_set_heartbeat_ivl, [:pointer, :int], :void, **opts
-      attach_function :zsock_heartbeat_ttl, [:pointer], :int, **opts
-      attach_function :zsock_set_heartbeat_ttl, [:pointer, :int], :void, **opts
-      attach_function :zsock_heartbeat_timeout, [:pointer], :int, **opts
-      attach_function :zsock_set_heartbeat_timeout, [:pointer, :int], :void, **opts
+      begin # DRAFT method
+        attach_function :zsock_heartbeat_ivl, [:pointer], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function heartbeat_ivl() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_set_heartbeat_ivl, [:pointer, :int], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_heartbeat_ivl() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_heartbeat_ttl, [:pointer], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function heartbeat_ttl() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_set_heartbeat_ttl, [:pointer, :int], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_heartbeat_ttl() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_heartbeat_timeout, [:pointer], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function heartbeat_timeout() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_set_heartbeat_timeout, [:pointer, :int], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function set_heartbeat_timeout() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zsock_tos, [:pointer], :int, **opts
       attach_function :zsock_set_tos, [:pointer, :int], :void, **opts
       attach_function :zsock_set_router_handover, [:pointer, :int], :void, **opts
@@ -654,23 +920,107 @@ module CZMQ
       attach_function :zstr_sendf, [:pointer, :string, :varargs], :int, **opts
       attach_function :zstr_sendfm, [:pointer, :string, :varargs], :int, **opts
       attach_function :zstr_sendx, [:pointer, :string, :varargs], :int, **opts
-      attach_function :zstr_str, [:pointer], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zstr_str, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function str() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zstr_free, [:pointer], :void, **opts
       attach_function :zstr_test, [:bool], :void, **opts
 
       require_relative 'ffi/zstr'
 
-      attach_function :ztrie_new, [:pointer], :pointer, **opts
-      attach_function :ztrie_destroy, [:pointer], :void, **opts
-      attach_function :ztrie_insert_route, [:pointer, :string, :pointer, :pointer], :int, **opts
-      attach_function :ztrie_remove_route, [:pointer, :string], :int, **opts
-      attach_function :ztrie_matches, [:pointer, :string], :bool, **opts
-      attach_function :ztrie_hit_data, [:pointer], :pointer, **opts
-      attach_function :ztrie_hit_parameter_count, [:pointer], :size_t, **opts
-      attach_function :ztrie_hit_parameters, [:pointer], :pointer, **opts
-      attach_function :ztrie_hit_asterisk_match, [:pointer], :string, **opts
-      attach_function :ztrie_print, [:pointer], :void, **opts
-      attach_function :ztrie_test, [:bool], :void, **opts
+      begin # DRAFT method
+        attach_function :ztrie_new, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function new() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_destroy, [:pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function destroy() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_insert_route, [:pointer, :string, :pointer, :pointer], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function insert_route() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_remove_route, [:pointer, :string], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function remove_route() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_matches, [:pointer, :string], :bool, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function matches() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_hit_data, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function hit_data() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_hit_parameter_count, [:pointer], :size_t, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function hit_parameter_count() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_hit_parameters, [:pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function hit_parameters() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_hit_asterisk_match, [:pointer], :string, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function hit_asterisk_match() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_print, [:pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function print() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :ztrie_test, [:bool], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function test() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
 
       require_relative 'ffi/ztrie'
 

--- a/include/zcert.h
+++ b/include/zcert.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Create and initialize a new certificate in memory
 CZMQ_EXPORT zcert_t *
@@ -60,9 +62,11 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT void
     zcert_set_meta (zcert_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
 
+#ifdef WITH_DRAFTS
 //  Unset certificate metadata.
 CZMQ_EXPORT void
     zcert_unset_meta (zcert_t *self, const char *name);
+#endif // WITH_DRAFTS
 
 //  Get metadata value from certificate; if the metadata value doesn't
 //  exist, returns NULL.                                              

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 #define ZFRAME_MORE 1                       // 
 #define ZFRAME_REUSE 2                      // 
@@ -97,15 +99,19 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zframe_set_more (zframe_t *self, int more);
 
+#ifdef WITH_DRAFTS
 //  Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                  
 CZMQ_EXPORT uint32_t
     zframe_routing_id (zframe_t *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set routing ID on frame. This is used if/when the frame is sent to a
 //  ZMQ_SERVER socket.                                                  
 CZMQ_EXPORT void
     zframe_set_routing_id (zframe_t *self, uint32_t routing_id);
+#endif // WITH_DRAFTS
 
 //  Return TRUE if two frames have identical size and data
 //  If either frame is NULL, equality is always false.    

--- a/include/zlistx.h
+++ b/include/zlistx.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Create a new, empty list.
 CZMQ_EXPORT zlistx_t *
@@ -49,13 +51,17 @@ CZMQ_EXPORT void *
 CZMQ_EXPORT size_t
     zlistx_size (zlistx_t *self);
 
+#ifdef WITH_DRAFTS
 //  Return first item in the list, or null, leaves the cursor
 CZMQ_EXPORT void *
     zlistx_head (zlistx_t *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Return last item in the list, or null, leaves the cursor
 CZMQ_EXPORT void *
     zlistx_tail (zlistx_t *self);
+#endif // WITH_DRAFTS
 
 //  Return the item at the head of list. If the list is empty, returns NULL.
 //  Leaves cursor pointing at the head item, or NULL if the list is empty.  

--- a/include/zloop.h
+++ b/include/zloop.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 // Callback function for reactor socket activity
 typedef int (zloop_reader_fn) (
@@ -133,12 +135,14 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zloop_set_verbose (zloop_t *self, bool verbose);
 
+#ifdef WITH_DRAFTS
 //  By default the reactor stops if the process receives a SIGINT or SIGTERM 
 //  signal. This makes it impossible to shut-down message based architectures
 //  like zactors. This method lets you switch off break handling. The default
 //  nonstop setting is off (false).                                          
 CZMQ_EXPORT void
     zloop_set_nonstop (zloop_t *self, bool nonstop);
+#endif // WITH_DRAFTS
 
 //  Start the reactor. Takes control of the thread and returns when the 0MQ  
 //  context is terminated or the process is interrupted, or any event handler

--- a/include/zmsg.h
+++ b/include/zmsg.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Create a new empty message object
 CZMQ_EXPORT zmsg_t *
@@ -80,15 +82,19 @@ CZMQ_EXPORT size_t
 CZMQ_EXPORT size_t
     zmsg_content_size (zmsg_t *self);
 
+#ifdef WITH_DRAFTS
 //  Return message routing ID, if the message came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                      
 CZMQ_EXPORT uint32_t
     zmsg_routing_id (zmsg_t *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set routing ID on message. This is used if/when the message is sent to a
 //  ZMQ_SERVER socket.                                                      
 CZMQ_EXPORT void
     zmsg_set_routing_id (zmsg_t *self, uint32_t routing_id);
+#endif // WITH_DRAFTS
 
 //  Push frame to the front of the message, i.e. before all other frames.  
 //  Message takes ownership of frame, will destroy it when message is sent.

--- a/include/zpoller.h
+++ b/include/zpoller.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Create new poller, specifying zero or more readers. The list of 
 //  readers ends in a NULL. Each reader can be a zsock_t instance, a
@@ -44,12 +46,14 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zpoller_remove (zpoller_t *self, void *reader);
 
+#ifdef WITH_DRAFTS
 //  By default the poller stops if the process receives a SIGINT or SIGTERM  
 //  signal. This makes it impossible to shut-down message based architectures
 //  like zactors. This method lets you switch off break handling. The default
 //  nonstop setting is off (false).                                          
 CZMQ_EXPORT void
     zpoller_set_nonstop (zpoller_t *self, bool nonstop);
+#endif // WITH_DRAFTS
 
 //  Poll the registered readers for I/O, return first reader that has input.  
 //  The reader will be a libzmq void * socket, or a zsock_t or zactor_t       

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -29,6 +29,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Create a new socket. Returns the new socket, or NULL if the new socket
 //  could not be created. Note that the symbol zsock_new (and other       
@@ -266,15 +268,19 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zsock_brecv (void *self, const char *picture, ...);
 
+#ifdef WITH_DRAFTS
 //  Return socket routing ID if any. This returns 0 if the socket is not
 //  of type ZMQ_SERVER or if no request was already received on it.     
 CZMQ_EXPORT uint32_t
     zsock_routing_id (zsock_t *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set routing ID on socket. The socket MUST be of type ZMQ_SERVER.        
 //  This will be used when sending messages on the socket via the zsock API.
 CZMQ_EXPORT void
     zsock_set_routing_id (zsock_t *self, uint32_t routing_id);
+#endif // WITH_DRAFTS
 
 //  Set socket to use unbounded pipes (HWM=0); use this in cases when you are
 //  totally certain the message volume can fit in memory. This method works  
@@ -315,32 +321,44 @@ CZMQ_EXPORT bool
 CZMQ_EXPORT void *
     zsock_resolve (void *self);
 
+#ifdef WITH_DRAFTS
 //  Get socket option `heartbeat_ivl`.
 //  The caller owns the return value and must destroy it when done with it.
 CZMQ_EXPORT int
     zsock_heartbeat_ivl (void *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set socket option `heartbeat_ivl`.
 CZMQ_EXPORT void
     zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Get socket option `heartbeat_ttl`.
 //  The caller owns the return value and must destroy it when done with it.
 CZMQ_EXPORT int
     zsock_heartbeat_ttl (void *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set socket option `heartbeat_ttl`.
 CZMQ_EXPORT void
     zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Get socket option `heartbeat_timeout`.
 //  The caller owns the return value and must destroy it when done with it.
 CZMQ_EXPORT int
     zsock_heartbeat_timeout (void *self);
+#endif // WITH_DRAFTS
 
+#ifdef WITH_DRAFTS
 //  Set socket option `heartbeat_timeout`.
 CZMQ_EXPORT void
     zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
+#endif // WITH_DRAFTS
 
 //  Get socket option `tos`.
 //  The caller owns the return value and must destroy it when done with it.

--- a/include/zstr.h
+++ b/include/zstr.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-draft-api to enable.
 
 //  Receive C string from socket. Caller must free returned string using
 //  zstr_free(). Returns NULL if the context is being terminated or the 
@@ -70,11 +72,13 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zstr_sendx (void *dest, const char *string, ...);
 
+#ifdef WITH_DRAFTS
 //  Accepts a void pointer and returns a fresh character string. If source
 //  is null, returns an empty string.                                     
 //  The caller owns the return value and must destroy it when done with it.
 CZMQ_EXPORT char *
     zstr_str (void *source);
+#endif // WITH_DRAFTS
 
 //  Free a provided string, and nullify the parent pointer. Safe to call on
 //  a null pointer.                                                        

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -11,11 +11,11 @@
     <version major = "4" style = "macro">
         <!-- Options that are new in 4.2 -->
         <option name = "heartbeat_ivl"     type = "int"    mode = "rw" test = "DEALER"
-            test_value = "2000" />
+            test_value = "2000" state = "draft" />
         <option name = "heartbeat_ttl"     type = "int"    mode = "rw"  test = "DEALER"
-            test_value = "4000" />
+            test_value = "4000" state = "draft" />
         <option name = "heartbeat_timeout" type = "int"    mode = "rw"  test = "DEALER"
-            test_value = "6000" />
+            test_value = "6000" state = "draft" />
 
         <!-- Options that are new in 4.1 -->
         <option name = "tos"               type = "int"    mode = "rw" test = "DEALER" />

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -12,18 +12,24 @@
 *    - RUN 'make code'                                           *
 ******************************************************************
 -->
+.function state(option)
+.  if defined(my.option.state) & my.option.state = 'draft'
+.    return ' state = "draft"'
+.  endif
+.  return ''
+.endfunction
 .for version where major = "4"
 .   for option
 .       if mode = "rw" | mode = "r"
 
-<method name = "$(option.api_name:)" polymorphic = "1">
+<method name = "$(option.api_name:)" polymorphic = "1"$(state(option))>
     Get socket option `$(option.name:)`.
     <return type = "$(option.api_type:)" fresh = "1" />
 </method>
 .       endif
 .       if mode = "rw" | mode = "w"
 
-<method name = "set $(option.api_name:)" polymorphic = "1">
+<method name = "set $(option.api_name:)" polymorphic = "1"$(state(option))>
     Set socket option `$(option.name:)`.
     <argument name = "$(option.api_name:)" type = "$(option.api_type:)" />
 </method>


### PR DESCRIPTION
* socket options can be draft now (like heartbeat options)
* mark a few unreleased, recent API functions as draft
* regenerate Ruby binding

This allows CZTop to be used with the current stable release of CZMQ.