### PR TITLE
Problem: czmq_selftest failing on zsys

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,9 +427,14 @@ AM_COND_IF([WITH_SYSTEMD],
         [AC_MSG_ERROR([Cannot find required package for systemd. Note, pkg-config is required due to specified version >= 200])])],
     [])
 
-# enable draft API by default if we're in a git repository
-# else disable it by default; then allow --with-draft=yes/no override
-AC_CHECK_FILE(.git, [gitmaster=yes], [gitmaster=no])
+if test "x$cross_compiling" = "xyes"; then
+    #   Enable draft by default when cross-compiling
+    gitmaster=yes
+else
+    # enable draft API by default if we're in a git repository
+    # else disable it by default; then allow --with-draft=yes/no override
+    AC_CHECK_FILE(.git, [gitmaster=yes], [gitmaster=no])
+fi
 
 AC_ARG_WITH([drafts],
     AS_HELP_STRING([--with-drafts],

--- a/include/czmq_library.h
+++ b/include/czmq_library.h
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    czmq - CZMQ wrapper
+    czmq - generated layer of public API
 
     Copyright (c) the Contributors as noted in the AUTHORS file.       
     This file is part of CZMQ, the high-level C binding for 0MQ:       

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1683,7 +1683,6 @@ zsys_test (bool verbose)
         free (hostname);
         zsys_info ("system limit is %zu ZeroMQ sockets", zsys_socket_limit ());
     }
-    zsys_set_io_threads (1);
     zsys_set_max_sockets (0);
     zsys_set_linger (0);
     zsys_set_sndhwm (1000);


### PR DESCRIPTION
We used to run zsys_test first, so it could test set_io_threads ()
which has to be the first thing a process does before creating any
sockets.

With zproject's test framework, we don't control the order of test
cases (and this is good, they should not be dependent). Now zsys is
called late, and so the call to set_io_threads () asserts.

Solution: remove this specific test.