### PR TITLE
Problem: qt bindings won't compile against draft APIs

### DIFF
--- a/bindings/qt/common.pri
+++ b/bindings/qt/common.pri
@@ -10,6 +10,8 @@ CONFIG(debug, debug|release) {
     else:win32:QCZMQ_LIBNAME = $$member(QCZMQ_LIBNAME, 0)d
 }
 TEMPLATE -= fakelib
+CONFIG += link_pkgconfig
+PKGCONFIG += libczmq
 QCZMQ_LIBDIR = $$PWD/lib
 unix:qczmq-uselib:!qczmq-buildlib:QMAKE_RPATHDIR += $$QCZMQ_LIBDIR
 ################################################################################


### PR DESCRIPTION
Solution: make qmake read pkgconfig

Note: This change has been done in zproject