### PR TITLE
Problem: CZMQ doesn't build with MSVC without DRAFT_API definition

### DIFF
--- a/include/czmq_library.h
+++ b/include/czmq_library.h
@@ -37,6 +37,7 @@
     CZMQ_MAKE_VERSION(CZMQ_VERSION_MAJOR, CZMQ_VERSION_MINOR, CZMQ_VERSION_PATCH)
 
 #if defined (__WINDOWS__)
+	#define CZMQ_BUILD_DRAFT_API
 #   if defined LIBCZMQ_STATIC
 #       define CZMQ_EXPORT
 #   elif defined LIBCZMQ_EXPORTS
@@ -177,6 +178,7 @@ typedef struct _ztrie_t ztrie_t;
 #include "zsocket.h"
 #include "zsockopt.h"
 #include "zthread.h"
+
 #ifdef CZMQ_BUILD_DRAFT_API
 #include "zproc.h"
 #include "ztrie.h"


### PR DESCRIPTION
Solution: Add DRAFT_API defs