### PR TITLE
Problem: zsys_test is failing

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1681,7 +1681,6 @@ zsys_test (bool verbose)
         free (hostname);
         zsys_info ("system limit is %zu ZeroMQ sockets", zsys_socket_limit ());
     }
-    zsys_set_max_sockets (0);
     zsys_set_linger (0);
     zsys_set_sndhwm (1000);
     zsys_set_rcvhwm (1000);


### PR DESCRIPTION
Caused by selftest that runs zsys_test after other tests,
when code was desiged to be run as first test case.

Solution: do not test zsys_set_max_sockets () which cannot be
used after any sockets are created.