### PR TITLE
Problem: czmq python bindings are a bit painful to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup
+
+setup(name='czmq',
+	  description="""The high-level C binding for 0MQ""",
+	  version='0.1',
+	  packages=['czmq'],
+	  package_dir={'': 'bindings/python'},
+)


### PR DESCRIPTION
Solution: generate setup.py using zproject.

Now "python setup.py install" works.