### PR TITLE
Problem: czmq_prelude.h refers to zmq_utils.h

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -211,7 +211,9 @@
 //- Always include ZeroMQ headers -------------------------------------------
 
 #include "zmq.h"
-#include "zmq_utils.h"
+#if (ZMQ_VERSION < ZMQ_MAKE_VERSION (4, 2, 0))
+#   include "zmq_utils.h"
+#endif
 
 //- Standard ANSI include files ---------------------------------------------
 


### PR DESCRIPTION
This header file is empty in 4.2.0 and was removed on 2016/02/01.

Solution: include in ZMQ versions prior to 4.2.0.