### PR TITLE
Problem: build with stable ZMQ broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ sudo: false
 env:
 - BUILD_TYPE=default ZMQ_REPO=zeromq2-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq3-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1
-- BUILD_TYPE=default ZMQ_REPO=zeromq4-1 WITH_LIBSODIUM=1
-- BUILD_TYPE=default ZMQ_REPO=libzmq    WITH_LIBSODIUM=1
+- BUILD_TYPE=default ZMQ_REPO=zeromq4-x
+- BUILD_TYPE=default ZMQ_REPO=zeromq4-1
+- BUILD_TYPE=default ZMQ_REPO=libzmq
 - BUILD_TYPE=android
 # As we have errors in bindings/python/test.py I'm suspending this...
 #- BUILD_TYPE=check-py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ os:
 sudo: false
 
 env:
-- BUILD_TYPE=default ZMQ_REPO=zeromq2-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq3-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq4-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq4-1
-- BUILD_TYPE=default ZMQ_REPO=libzmq
+- BUILD_TYPE=default
+- BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq2-x
+- BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq3-x
+- BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq4-x
+- BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq4-1
 - BUILD_TYPE=android
 # As we have errors in bindings/python/test.py I'm suspending this...
 #- BUILD_TYPE=check-py

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -18,9 +18,6 @@ CMAKE_OPTS+=("-DCMAKE_PREFIX_PATH:PATH=${BUILD_PREFIX}")
 CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
 CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
 
-git clone git://github.com/jedisct1/libsodium.git &&
-( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make check && make install ) || exit 1
-
 # Build, check, and install ZeroMQ
 git clone git://github.com/zeromq/libzmq.git &&
 ( cd libzmq; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --prefix=${BUILD_PREFIX} && make check && make install ) || exit 1

--- a/builds/stable_zmq/ci_build.sh
+++ b/builds/stable_zmq/ci_build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+CONFIG_OPTS=()
+CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+CONFIG_OPTS+=("--without-docs")
+CONFIG_OPTS+=("--quiet")
+
+git clone --quiet --depth 1 -b stable git://github.com/jedisct1/libsodium.git &&
+( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make -j4 install ) || exit 1
+
+# Clone and build dependencies
+git clone --quiet --depth 1 https://github.com/zeromq/${ZMQ_REPO} libzmq
+cd libzmq
+git --no-pager log --oneline -n1
+./autogen.sh 2> /dev/null
+./configure "${CONFIG_OPTS[@]}"
+make -j4
+make install
+cd ../../..
+
+# Build and check this project
+./autogen.sh 2> /dev/null
+./configure "${CONFIG_OPTS[@]}"
+make -j4
+make check
+make memcheck
+make install

--- a/builds/stable_zmq/ci_build.sh
+++ b/builds/stable_zmq/ci_build.sh
@@ -13,7 +13,7 @@ CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
 CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
 CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
 CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-CONFIG_OPTS+=("--without-docs")
+CONFIG_OPTS+=("--with-docs=no")
 CONFIG_OPTS+=("--quiet")
 
 git clone --quiet --depth 1 -b stable git://github.com/jedisct1/libsodium.git &&
@@ -34,5 +34,4 @@ cd ../../..
 ./configure "${CONFIG_OPTS[@]}"
 make -j4
 make check
-make memcheck
 make install

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -19,7 +19,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
     CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
-    CONFIG_OPTS+=("--without-docs")
+    CONFIG_OPTS+=("--with-docs=no")
     CONFIG_OPTS+=("--quiet")
 
     # Clone and build dependencies

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1283,8 +1283,10 @@ zsock_bsend (void *self, const char *picture, ...)
     byte *needle = (byte *) zmq_msg_data (&msg);
 
     //  Set routing id if self is zsock
+#if defined ZMQ_SERVER
     if (zsock_is (self) && zsock_routing_id ((zsock_t *)self) != 0)
         zmq_msg_set_routing_id (&msg, zsock_routing_id ((zsock_t *)self));
+#endif
 
     va_start (argptr, picture);
     picptr = picture;
@@ -1417,8 +1419,10 @@ zsock_brecv (void *selfish, const char *picture, ...)
     byte *ceiling = needle + zmq_msg_size (&msg);
 
     //  If selfish is zsock get routing id from msg
+#if defined ZMQ_SERVER
     if (zsock_is (selfish) && zsock_type (self) == ZMQ_SERVER)
         zsock_set_routing_id (self, zmq_msg_routing_id (&msg));
+#endif
 
     va_list argptr;
     va_start (argptr, picture);


### PR DESCRIPTION
When the main CI script became autogenerated by zproject a while ago, the CI builds with stable versions of libzmq were broken, and all builds were done with the dev repository. As a result we didn't notice when the build with a version of libzmq without ZMQ_SERVER (anything but the dev repo) broke due to missing ifdef.

I've added a new build type, zmq_stable, to avoid this problem in the future.

Few other small fixes, including not using libsodium in the CMake build and using the correct parameter to avoid building with docs in the CI.

I'm still looking at the Valgrind issue. The problem is timing: some tests fail when running in a slower environment, which is not nice at all. I'm trying to bandaid them by adding sleeps to let the sockets enough time to stabilize, which is arguably horrible, but given there's no mock mechanism in place I can't see another way around it. PR for this will come once I'm confident it's done for good.