### PR TITLE
Problem: libuuid dependency is fragile and unnecessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,17 +90,6 @@ ELSE (LIBZMQ_FOUND)
 ENDIF (LIBZMQ_FOUND)
 
 ########################################################################
-# UUID dependency
-########################################################################
-find_package(uuid)
-IF (UUID_FOUND)
-    include_directories(${UUID_INCLUDE_DIRS})
-    list(APPEND MORE_LIBRARIES ${UUID_LIBRARIES})
-    add_definitions(-DHAVE_UUID)
-    list(APPEND OPTIONAL_LIBRARIES ${UUID_LIBRARIES})
-ENDIF (UUID_FOUND)
-
-########################################################################
 # SYSTEMD dependency
 ########################################################################
 find_package(systemd)

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,11 +11,10 @@ AM_CFLAGS = \
 
 AM_CPPFLAGS = \
     ${libzmq_CFLAGS} \
-    ${uuid_CFLAGS} \
     ${systemd_CFLAGS} \
     -I$(srcdir)/include
 
-project_libs = ${libzmq_LIBS} ${uuid_LIBS} ${systemd_LIBS}
+project_libs = ${libzmq_LIBS} ${systemd_LIBS}
 
 SUBDIRS = doc
 DIST_SUBDIRS = doc

--- a/configure.ac
+++ b/configure.ac
@@ -118,52 +118,6 @@ if test "x$was_libzmq_check_lib_detected" = "xno"; then
     LIBS="${libzmq_LIBS} ${LIBS}"
 fi
 
-was_uuid_check_lib_detected=no
-
-PKG_CHECK_MODULES([uuid], [uuid >= 0.0.0],
-    [
-        AC_DEFINE(HAVE_UUID, 1, [The uuid library is to be used])
-    ],
-    [
-        AC_ARG_WITH([uuid],
-            [
-                AS_HELP_STRING([--with-uuid],
-                [Specify uuid prefix])
-            ],
-            [search_uuid="yes"],
-            [])
-
-        uuid_synthetic_cflags=""
-        uuid_synthetic_libs="-luuid"
-
-        if test "x$search_uuid" = "xyes"; then
-            if test -r "${with_uuid}/include/uuid/uuid.h"; then
-                uuid_synthetic_cflags="-I${with_uuid}/include"
-                uuid_synthetic_libs="-L${with_uuid}/lib -luuid"
-            else
-                AC_MSG_ERROR([${with_uuid}/include/uuid/uuid.h not found. Please check uuid prefix])
-            fi
-        fi
-
-        AC_CHECK_LIB([uuid], [uuid_generate],
-            [
-                CFLAGS="${uuid_synthetic_cflags} ${CFLAGS}"
-                LDFLAGS="${uuid_synthetic_libs} ${LDFLAGS}"
-                LIBS="${uuid_synthetic_libs} ${LIBS}"
-
-                AC_SUBST([uuid_CFLAGS],[${uuid_synthetic_cflags}])
-                AC_SUBST([uuid_LIBS],[${uuid_synthetic_libs}])
-                was_uuid_check_lib_detected=yes
-                AC_DEFINE(HAVE_UUID, 1, [The uuid library is to be used])
-            ],
-            [])
-    ])
-
-if test "x$was_uuid_check_lib_detected" = "xno"; then
-    CFLAGS="${uuid_CFLAGS} ${CFLAGS}"
-    LIBS="${uuid_LIBS} ${LIBS}"
-fi
-
 was_systemd_check_lib_detected=no
 
 PKG_CHECK_MODULES([systemd], [libsystemd >= 200.0.0],


### PR DESCRIPTION
CZMQ doesn't even need this, it can generate its own UUIDs.
We may need a way to add optional packages that aren't
dependencies and aren't detected (like libsodium in libzmq).

Solution: remove libuuid dependency