### PR TITLE
Problem: zlist_sort does not work according to docs

### DIFF
--- a/api/zlist.api
+++ b/api/zlist.api
@@ -116,8 +116,11 @@
     </method>
 
     <method name = "sort">
-        Sort the list by ascending key value using a straight ASCII comparison.
-        The sort is not stable, so may reorder items with the same keys.
+        Sort the list. If the compare function is null, sorts the list by
+        ascending key value using a straight ASCII comparison. If you specify
+        a compare function, this decides how items are sorted. The sort is not
+        stable, so may reorder items with the same keys. The algorithm used is
+        combsort, a compromise between performance and simplicity.
         <argument name = "compare" type = "zlist_compare_fn" callback = "1" />
     </method>
 

--- a/include/zlist.h
+++ b/include/zlist.h
@@ -109,8 +109,11 @@ CZMQ_EXPORT void
 CZMQ_EXPORT size_t
     zlist_size (zlist_t *self);
 
-//  Sort the list by ascending key value using a straight ASCII comparison.
-//  The sort is not stable, so may reorder items with the same keys.       
+//  Sort the list. If the compare function is null, sorts the list by     
+//  ascending key value using a straight ASCII comparison. If you specify 
+//  a compare function, this decides how items are sorted. The sort is not
+//  stable, so may reorder items with the same keys. The algorithm used is
+//  combsort, a compromise between performance and simplicity.            
 CZMQ_EXPORT void
     zlist_sort (zlist_t *self, zlist_compare_fn compare);
 


### PR DESCRIPTION
The docs say this does an ASCII sort but in fact it does not,
and it won't work unless you pass a comparison function. This
is over-design for 90% of cases.

Solution: extend API slightly so that a NULL comparison function
gets treated as "strcmp", giving the desired effect for most
simple cases.