### PR TITLE
Problem: printf "%d" format is pedantically wrong for pid_t getpid() return type

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1102,7 +1102,7 @@ zsys_run_as (const char *lockfile, const char *group, const char *user)
         }
         //   We record the current process id in the lock file
         char pid_buffer [10];
-        snprintf (pid_buffer, sizeof (pid_buffer), "%6d\n", getpid ());
+        snprintf (pid_buffer, sizeof (pid_buffer), "%6" PRIi64 "\n", (int64_t)getpid ());
         if ((size_t) write (handle, pid_buffer, strlen (pid_buffer)) != strlen (pid_buffer)) {
             zsys_error ("cannot write to lockfile: %s", strerror (errno));
             close (handle);


### PR DESCRIPTION
Solution: fix the call to use explicit printing via PRIi64 and casting to int64_t