### PR TITLE
Problem: userland needs bindings install

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -17,8 +17,9 @@
     "url": ""
   },
   "dependencies": {
-    "prebuild": "^3.0.3",
+    "bindings": "^1.2.1",
+    "nan": "^2.2.0",
     "node-ninja": "^1.0.1",
-    "nan": "^2.2.0"
+    "prebuild": "^3.0.3"
   }
 }


### PR DESCRIPTION
Solution: run `npm install --save bindings`

Solely for the node bindings