### PR TITLE
Problem: brew install errors out with new version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
     - valgrind
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install ossp-uuid binutils valgrind ; fi
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew reinstall ossp-uuid binutils valgrind ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so


### PR DESCRIPTION
Solution: run brew reinstall instead.
If the previous revision is already installed, instead of upgrading
(or doing nothing) brew errors out, which stops the test run.