### PR TITLE
Give zcertstore loaders ability to store state

### DIFF
--- a/api/zcertstore.api
+++ b/api/zcertstore.api
@@ -30,9 +30,16 @@
         <argument name = "self" type = "zcertstore" />
     </callback_type>
 
+    <callback_type name = "destructor">
+        Destructor for loader state.
+        <argument name = "self_p" type = "buffer" c_type = "void **" />
+    </callback_type>
+
     <method name = "set_loader">
       Override the default disk loader with a custom loader fn.
       <argument name = "loader" type = "zcertstore_loader" callback = "1" />
+      <argument name = "destructor" type = "zcertstore_destructor" callback = "1" />
+      <argument name = "state" type = "buffer" c_type = "void *" />
     </method>
 
     <method name = "lookup">

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zsock.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zsock.c
@@ -165,6 +165,24 @@ Java_org_zeromq_czmq_Zsock__1_1newDish (JNIEnv *env, jclass c, jstring endpoint)
     return new_dish_;
 }
 
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zsock__1_1newGather (JNIEnv *env, jclass c, jstring endpoint)
+{
+    char *endpoint_ = (char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
+    jlong new_gather_ = (jlong) (intptr_t) zsock_new_gather (endpoint_);
+    (*env)->ReleaseStringUTFChars (env, endpoint, endpoint_);
+    return new_gather_;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zsock__1_1newScatter (JNIEnv *env, jclass c, jstring endpoint)
+{
+    char *endpoint_ = (char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
+    jlong new_scatter_ = (jlong) (intptr_t) zsock_new_scatter (endpoint_);
+    (*env)->ReleaseStringUTFChars (env, endpoint, endpoint_);
+    return new_scatter_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zsock__1_1destroy (JNIEnv *env, jclass c, jlong self)
 {

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -146,6 +146,20 @@ public class Zsock implements AutoCloseable{
         return new Zsock (__newDish (endpoint));
     }
     /*
+    Create a GATHER socket. Default action is bind.
+    */
+    native static long __newGather (String endpoint);
+    public Zsock newGather (String endpoint) {
+        return new Zsock (__newGather (endpoint));
+    }
+    /*
+    Create a SCATTER socket. Default action is connect.
+    */
+    native static long __newScatter (String endpoint);
+    public Zsock newScatter (String endpoint) {
+        return new Zsock (__newScatter (endpoint));
+    }
+    /*
     Destroy the socket. You must use this for any socket created via the
     zsock_new method.                                                   
     */

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -4253,6 +4253,12 @@ NAN_METHOD (Zsock::New) {
         if (streq (type_name, "dish"))
             type = 15;
         else
+        if (streq (type_name, "gather"))
+            type = 16;
+        else
+        if (streq (type_name, "scatter"))
+            type = 17;
+        else
             return Nan::ThrowTypeError ("`type` not a valid string");
     }
     else

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -724,12 +724,13 @@ and you should use the print method.
 
 # zcertstore
 zcertstore_loader = CFUNCTYPE(None, zcertstore_p)
+zcertstore_destructor = CFUNCTYPE(None, c_void_p)
 lib.zcertstore_new.restype = zcertstore_p
 lib.zcertstore_new.argtypes = [c_char_p]
 lib.zcertstore_destroy.restype = None
 lib.zcertstore_destroy.argtypes = [POINTER(zcertstore_p)]
 lib.zcertstore_set_loader.restype = None
-lib.zcertstore_set_loader.argtypes = [zcertstore_p, zcertstore_loader]
+lib.zcertstore_set_loader.argtypes = [zcertstore_p, zcertstore_loader, zcertstore_destructor, c_void_p]
 lib.zcertstore_lookup.restype = zcert_p
 lib.zcertstore_lookup.argtypes = [zcertstore_p, c_char_p]
 lib.zcertstore_insert.restype = None
@@ -797,11 +798,11 @@ stored on disk.
         "Determine whether the object is valid by converting to boolean" # Python 2
         return self._as_parameter_.__nonzero__()
 
-    def set_loader(self, loader):
+    def set_loader(self, loader, destructor, state):
         """
         Override the default disk loader with a custom loader fn.
         """
-        return lib.zcertstore_set_loader(self._as_parameter_, loader)
+        return lib.zcertstore_set_loader(self._as_parameter_, loader, destructor, state)
 
     def lookup(self, public_key):
         """
@@ -4810,6 +4811,10 @@ lib.zsock_new_radio.restype = zsock_p
 lib.zsock_new_radio.argtypes = [c_char_p]
 lib.zsock_new_dish.restype = zsock_p
 lib.zsock_new_dish.argtypes = [c_char_p]
+lib.zsock_new_gather.restype = zsock_p
+lib.zsock_new_gather.argtypes = [c_char_p]
+lib.zsock_new_scatter.restype = zsock_p
+lib.zsock_new_scatter.argtypes = [c_char_p]
 lib.zsock_bind.restype = c_int
 lib.zsock_bind.argtypes = [zsock_p, c_char_p]
 lib.zsock_endpoint.restype = c_char_p
@@ -5229,6 +5234,20 @@ action is connect.
         Create a DISH socket. Default action is connect.
         """
         return Zsock(lib.zsock_new_dish(endpoint), True)
+
+    @staticmethod
+    def new_gather(endpoint):
+        """
+        Create a GATHER socket. Default action is bind.
+        """
+        return Zsock(lib.zsock_new_gather(endpoint), True)
+
+    @staticmethod
+    def new_scatter(endpoint):
+        """
+        Create a SCATTER socket. Default action is connect.
+        """
+        return Zsock(lib.zsock_new_scatter(endpoint), True)
 
     def bind(self, format, *args):
         """

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -85,6 +85,10 @@ typedef void (zactor_fn) (
 typedef void (zcertstore_loader) (
     zcertstore_t *self);
 
+// Destructor for loader state.
+typedef void (zcertstore_destructor) (
+    void **self_p);
+
 // 
 typedef int (zconfig_fct) (
     zconfig_t *self, void *arg, int level);
@@ -379,7 +383,7 @@ void
 
 // Override the default disk loader with a custom loader fn.
 void
-    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader);
+    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
 
 // Look up certificate by public key, returns zcert_t object if found,
 // else returns NULL. The public key is provided in Z85 text format.  
@@ -2338,6 +2342,14 @@ zsock_t *
 // Create a DISH socket. Default action is connect.
 zsock_t *
     zsock_new_dish (const char *endpoint);
+
+// Create a GATHER socket. Default action is bind.
+zsock_t *
+    zsock_new_gather (const char *endpoint);
+
+// Create a SCATTER socket. Default action is connect.
+zsock_t *
+    zsock_new_scatter (const char *endpoint);
 
 // Bind a socket to a formatted endpoint. For tcp:// endpoints, supports   
 // ephemeral ports, if you specify the port number as "*". By default      

--- a/bindings/qml/src/QmlZcertstore.cpp
+++ b/bindings/qml/src/QmlZcertstore.cpp
@@ -10,8 +10,8 @@
 
 ///
 //  Override the default disk loader with a custom loader fn.
-void QmlZcertstore::setLoader (zcertstore_loader loader) {
-    zcertstore_set_loader (self, loader);
+void QmlZcertstore::setLoader (zcertstore_loader loader, zcertstore_destructor destructor, void *state) {
+    zcertstore_set_loader (self, loader, destructor, state);
 };
 
 ///

--- a/bindings/qml/src/QmlZcertstore.h
+++ b/bindings/qml/src/QmlZcertstore.h
@@ -29,7 +29,7 @@ public:
     
 public slots:
     //  Override the default disk loader with a custom loader fn.
-    void setLoader (zcertstore_loader loader);
+    void setLoader (zcertstore_loader loader, zcertstore_destructor destructor, void *state);
 
     //  Look up certificate by public key, returns zcert_t object if found,
     //  else returns NULL. The public key is provided in Z85 text format.  

--- a/bindings/qml/src/QmlZsock.cpp
+++ b/bindings/qml/src/QmlZsock.cpp
@@ -1078,6 +1078,22 @@ QmlZsock *QmlZsockAttached::constructDish (const QString &endpoint) {
 };
 
 ///
+//  Create a GATHER socket. Default action is bind.
+QmlZsock *QmlZsockAttached::constructGather (const QString &endpoint) {
+    QmlZsock *qmlSelf = new QmlZsock ();
+    qmlSelf->self = zsock_new_gather (endpoint.toUtf8().data());
+    return qmlSelf;
+};
+
+///
+//  Create a SCATTER socket. Default action is connect.
+QmlZsock *QmlZsockAttached::constructScatter (const QString &endpoint) {
+    QmlZsock *qmlSelf = new QmlZsock ();
+    qmlSelf->self = zsock_new_scatter (endpoint.toUtf8().data());
+    return qmlSelf;
+};
+
+///
 //  Destroy the socket. You must use this for any socket created via the
 //  zsock_new method.                                                   
 void QmlZsockAttached::destruct (QmlZsock *qmlSelf) {

--- a/bindings/qml/src/QmlZsock.h
+++ b/bindings/qml/src/QmlZsock.h
@@ -607,6 +607,12 @@ public slots:
     //  Create a DISH socket. Default action is connect.
     QmlZsock *constructDish (const QString &endpoint);
 
+    //  Create a GATHER socket. Default action is bind.
+    QmlZsock *constructGather (const QString &endpoint);
+
+    //  Create a SCATTER socket. Default action is connect.
+    QmlZsock *constructScatter (const QString &endpoint);
+
     //  Destroy the socket. You must use this for any socket created via the
     //  zsock_new method.                                                   
     void destruct (QmlZsock *qmlSelf);

--- a/bindings/qt/src/qzcertstore.cpp
+++ b/bindings/qt/src/qzcertstore.cpp
@@ -37,9 +37,9 @@ QZcertstore::~QZcertstore ()
 
 ///
 //  Override the default disk loader with a custom loader fn.
-void QZcertstore::setLoader (zcertstore_loader loader)
+void QZcertstore::setLoader (zcertstore_loader loader, zcertstore_destructor destructor, void *state)
 {
-    zcertstore_set_loader (self, loader);
+    zcertstore_set_loader (self, loader, destructor, state);
     
 }
 

--- a/bindings/qt/src/qzcertstore.h
+++ b/bindings/qt/src/qzcertstore.h
@@ -30,7 +30,7 @@ public:
     ~QZcertstore ();
 
     //  Override the default disk loader with a custom loader fn.
-    void setLoader (zcertstore_loader loader);
+    void setLoader (zcertstore_loader loader, zcertstore_destructor destructor, void *state);
 
     //  Look up certificate by public key, returns zcert_t object if found,
     //  else returns NULL. The public key is provided in Z85 text format.  

--- a/bindings/qt/src/qzsock.cpp
+++ b/bindings/qt/src/qzsock.cpp
@@ -141,6 +141,20 @@ QZsock* QZsock::newDish (const QString &endpoint, QObject *qObjParent)
 }
 
 ///
+//  Create a GATHER socket. Default action is bind.
+QZsock* QZsock::newGather (const QString &endpoint, QObject *qObjParent)
+{
+    return new QZsock (zsock_new_gather (endpoint.toUtf8().data()), qObjParent);
+}
+
+///
+//  Create a SCATTER socket. Default action is connect.
+QZsock* QZsock::newScatter (const QString &endpoint, QObject *qObjParent)
+{
+    return new QZsock (zsock_new_scatter (endpoint.toUtf8().data()), qObjParent);
+}
+
+///
 //  Destroy the socket. You must use this for any socket created via the
 //  zsock_new method.                                                   
 QZsock::~QZsock ()

--- a/bindings/qt/src/qzsock.h
+++ b/bindings/qt/src/qzsock.h
@@ -74,6 +74,12 @@ public:
     //  Create a DISH socket. Default action is connect.
     static QZsock* newDish (const QString &endpoint, QObject *qObjParent = 0);
 
+    //  Create a GATHER socket. Default action is bind.
+    static QZsock* newGather (const QString &endpoint, QObject *qObjParent = 0);
+
+    //  Create a SCATTER socket. Default action is connect.
+    static QZsock* newScatter (const QString &endpoint, QObject *qObjParent = 0);
+
     //  Destroy the socket. You must use this for any socket created via the
     //  zsock_new method.                                                   
     ~QZsock ();

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -102,7 +102,7 @@ module CZMQ
 
       attach_function :zcertstore_new, [:string], :pointer, **opts
       attach_function :zcertstore_destroy, [:pointer], :void, **opts
-      attach_function :zcertstore_set_loader, [:pointer, :pointer], :void, **opts
+      attach_function :zcertstore_set_loader, [:pointer, :pointer, :pointer, :pointer], :void, **opts
       attach_function :zcertstore_lookup, [:pointer, :string], :pointer, **opts
       attach_function :zcertstore_insert, [:pointer, :pointer], :void, **opts
       attach_function :zcertstore_empty, [:pointer], :void, **opts
@@ -735,6 +735,22 @@ module CZMQ
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
           warn "The function zsock_new_dish() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_new_gather, [:string], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zsock_new_gather() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsock_new_scatter, [:string], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zsock_new_scatter() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -217,6 +217,22 @@ module CZMQ
         __new ptr
       end
 
+      # Create a GATHER socket. Default action is bind.
+      # @param endpoint [String, #to_s, nil]
+      # @return [CZMQ::Zsock]
+      def self.new_gather(endpoint)
+        ptr = ::CZMQ::FFI.zsock_new_gather(endpoint)
+        __new ptr
+      end
+
+      # Create a SCATTER socket. Default action is connect.
+      # @param endpoint [String, #to_s, nil]
+      # @return [CZMQ::Zsock]
+      def self.new_scatter(endpoint)
+        ptr = ::CZMQ::FFI.zsock_new_scatter(endpoint)
+        __new ptr
+      end
+
       # Destroy the socket. You must use this for any socket created via the
       # zsock_new method.                                                   
       #

--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -29,6 +29,10 @@ extern "C" {
 typedef void (zcertstore_loader) (
     zcertstore_t *self);
 
+// Destructor for loader state.
+typedef void (zcertstore_destructor) (
+    void **self_p);
+
 //  Create a new certificate store from a disk directory, loading and        
 //  indexing all certificates in that location. The directory itself may be  
 //  absent, and created later, or modified at any time. The certificate store
@@ -45,7 +49,7 @@ CZMQ_EXPORT void
 
 //  Override the default disk loader with a custom loader fn.
 CZMQ_EXPORT void
-    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader);
+    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
 
 //  Look up certificate by public key, returns zcert_t object if found,
 //  else returns NULL. The public key is provided in Z85 text format.  

--- a/src/zauth.c
+++ b/src/zauth.c
@@ -711,7 +711,7 @@ zauth_test (bool verbose)
 
         // Test custom zcertstore
         zcertstore_t *certstore = zcertstore_new (NULL);
-        zcertstore_set_loader (certstore, s_test_loader);
+        zcertstore_set_loader (certstore, s_test_loader, NULL, NULL);
         zactor_destroy(&auth);
         auth = zactor_new (zauth, certstore);
         assert (auth);


### PR DESCRIPTION
This builds on my previous PR #1411 to allow any zcertstore loader to store state, rather than just providing a callback. This gives us two nice things:

1. It makes the interface consistent between the default disk loader and user-defined loaders
2. It allows user-defined loaders to store, for example, a connector to their certificate store, transaction IDs etc.