### PR TITLE
Problem: New zcertstore APIs were not marked as "draft".

### DIFF
--- a/api/zcertstore.api
+++ b/api/zcertstore.api
@@ -25,17 +25,17 @@
         stored on disk.
     </destructor>
 
-    <callback_type name = "loader">
+    <callback_type name = "loader" state = "draft">
         Loaders retrieve certificates from an arbitrary source.
         <argument name = "self" type = "zcertstore" />
     </callback_type>
 
-    <callback_type name = "destructor">
+    <callback_type name = "destructor" state = "draft">
         Destructor for loader state.
         <argument name = "self_p" type = "buffer" c_type = "void **" />
     </callback_type>
 
-    <method name = "set_loader">
+    <method name = "set_loader" state = "draft">
       Override the default disk loader with a custom loader fn.
       <argument name = "loader" type = "zcertstore_loader" callback = "1" />
       <argument name = "destructor" type = "zcertstore_destructor" callback = "1" />
@@ -56,7 +56,7 @@
         <argument name = "cert p" type = "zcert" by_reference = "1" />
     </method>
 
-    <method name = "empty">
+    <method name = "empty" state = "draft">
         Empty certificate hashtable. This wrapper exists to be friendly to bindings,
         which don't usually have access to struct internals.
     </method>

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -102,10 +102,24 @@ module CZMQ
 
       attach_function :zcertstore_new, [:string], :pointer, **opts
       attach_function :zcertstore_destroy, [:pointer], :void, **opts
-      attach_function :zcertstore_set_loader, [:pointer, :pointer, :pointer, :pointer], :void, **opts
+      begin # DRAFT method
+        attach_function :zcertstore_set_loader, [:pointer, :pointer, :pointer, :pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zcertstore_set_loader() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zcertstore_lookup, [:pointer, :string], :pointer, **opts
       attach_function :zcertstore_insert, [:pointer, :pointer], :void, **opts
-      attach_function :zcertstore_empty, [:pointer], :void, **opts
+      begin # DRAFT method
+        attach_function :zcertstore_empty, [:pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zcertstore_empty() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zcertstore_print, [:pointer], :void, **opts
       attach_function :zcertstore_fprint, [:pointer, :pointer], :void, **opts
       attach_function :zcertstore_test, [:bool], :void, **opts

--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -23,16 +23,10 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-drafts to enable.
 //  This class has legacy methods, which will be removed over time. You
 //  should not use them, and migrate any code that is still using them.
-// Loaders retrieve certificates from an arbitrary source.
-typedef void (zcertstore_loader) (
-    zcertstore_t *self);
-
-// Destructor for loader state.
-typedef void (zcertstore_destructor) (
-    void **self_p);
-
 //  Create a new certificate store from a disk directory, loading and        
 //  indexing all certificates in that location. The directory itself may be  
 //  absent, and created later, or modified at any time. The certificate store
@@ -47,10 +41,6 @@ CZMQ_EXPORT zcertstore_t *
 CZMQ_EXPORT void
     zcertstore_destroy (zcertstore_t **self_p);
 
-//  Override the default disk loader with a custom loader fn.
-CZMQ_EXPORT void
-    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
-
 //  Look up certificate by public key, returns zcert_t object if found,
 //  else returns NULL. The public key is provided in Z85 text format.  
 CZMQ_EXPORT zcert_t *
@@ -61,11 +51,6 @@ CZMQ_EXPORT zcert_t *
 //  directly on the certificate. Takes ownership of zcert_t object.    
 CZMQ_EXPORT void
     zcertstore_insert (zcertstore_t *self, zcert_t **cert_p);
-
-//  Empty certificate hashtable. This wrapper exists to be friendly to bindings,
-//  which don't usually have access to struct internals.                        
-CZMQ_EXPORT void
-    zcertstore_empty (zcertstore_t *self);
 
 //  Print list of certificates in store to logging facility
 CZMQ_EXPORT void
@@ -81,6 +66,27 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zcertstore_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+// Loaders retrieve certificates from an arbitrary source.
+typedef void (zcertstore_loader) (
+    zcertstore_t *self);
+
+// Destructor for loader state.
+typedef void (zcertstore_destructor) (
+    void **self_p);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Override the default disk loader with a custom loader fn.
+CZMQ_EXPORT void
+    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Empty certificate hashtable. This wrapper exists to be friendly to bindings,
+//  which don't usually have access to struct internals.                        
+CZMQ_EXPORT void
+    zcertstore_empty (zcertstore_t *self);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @end
 
 

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -33,6 +33,25 @@ CZMQ_EXPORT void
     zcert_unset_meta (zcert_t *self, const char *name);
 
 //  *** Draft method, defined for internal use only ***
+//  Override the default disk loader with a custom loader fn.
+CZMQ_EXPORT void
+    zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
+
+//  *** Draft method, defined for internal use only ***
+//  Empty certificate hashtable. This wrapper exists to be friendly to bindings,
+//  which don't usually have access to struct internals.                        
+CZMQ_EXPORT void
+    zcertstore_empty (zcertstore_t *self);
+
+//  *** Draft callbacks, defined for internal use only ***
+// Loaders retrieve certificates from an arbitrary source.
+typedef void (zcertstore_loader) (
+    zcertstore_t *self);
+// Destructor for loader state.
+typedef void (zcertstore_destructor) (
+    void **self_p);
+
+//  *** Draft method, defined for internal use only ***
 //  Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                  
 CZMQ_EXPORT uint32_t


### PR DESCRIPTION
Solution: Mark as "draft".

As discussed in #1413.