### PR TITLE
Problem: zsys.c did not know about SCATTER / GATHER

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -367,11 +367,14 @@ zsys_sockname (int socktype)
         "DEALER", "ROUTER", "PULL", "PUSH",
         "XPUB", "XSUB", "STREAM",
         "SERVER", "CLIENT",
-        "RADIO", "DISH"
+        "RADIO", "DISH",
+        "SCATTER", "GATHER"
     };
     //  This array matches ZMQ_XXX type definitions
     assert (ZMQ_PAIR == 0);
-#if defined (ZMQ_DISH)
+#if defined (ZMQ_SCATTER)
+    assert (socktype >= 0 && socktype <= ZMQ_SCATTER);
+#elif defined (ZMQ_DISH)
     assert (socktype >= 0 && socktype <= ZMQ_DISH);
 #elif defined (ZMQ_CLIENT)
     assert (socktype >= 0 && socktype <= ZMQ_CLIENT);


### PR DESCRIPTION
Solution: add them to zsys_sockname in zsys.c.