### PR TITLE
Problem: zframe_set_group and zframe_group not exported

### DIFF
--- a/api/zframe.api
+++ b/api/zframe.api
@@ -104,6 +104,17 @@
         <argument name = "more" type = "integer" />
     </method>
 
+    <method name = "group">
+        Return frame group of radio-dish pattern.
+        <return type = "string" fresh = "0" />
+    </method>
+
+    <method name = "set group">
+        Set group on frame. This is used if/when the frame is sent to a
+        ZMQ_RADIO socket. Return -1 on error, 0 on success.
+        <return type = "integer" />
+    </method>
+
     <method name = "routing id" state = "draft" >
         Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
         Else returns zero.

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -103,6 +103,15 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zframe_set_more (zframe_t *self, int more);
 
+//  Return frame group of radio-dish pattern.
+CZMQ_EXPORT const char *
+    zframe_group (zframe_t *self);
+
+//  Set group on frame. This is used if/when the frame is sent to a
+//  ZMQ_RADIO socket. Return -1 on error, 0 on success.            
+CZMQ_EXPORT int
+    zframe_set_group (zframe_t *self);
+
 //  Return TRUE if two frames have identical size and data
 //  If either frame is NULL, equality is always false.    
 CZMQ_EXPORT bool


### PR DESCRIPTION
This pr adds the zframe_group and zframe_set_group calls to the api model for zframe, and updates the zframe header to export these functions.

Please note I did not regenerate all of the bindings via zproject - if that's desired I can do so and send a followup PR (or someone else is welcome to).