### PR TITLE
Problem: zsys_set_logstream(NULL) not functional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ src/app/jni/output
 # Python build directory
 build/
 
+# MSVC build directories
+obj/
+bin/
+*.tlog
+
 # Temporary files
 *.swp
 *~

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1598,10 +1598,6 @@ s_log (char loglevel, char *string)
     else
 #   endif
 #endif
-    //  Set s_logstream to stdout by default, unless we're using s_logsystem
-    if (!s_logstream)
-        s_logstream = stdout;
-
     if (s_logstream || s_logsender) {
         time_t curtime = time (NULL);
         struct tm *loctime = localtime (&curtime);


### PR DESCRIPTION
This is documented as a means to disable log output to the console, yet it is reset on every call to `s_log()`. This makes the code that follows immediately after the deleted code half dead:

```c
    if (!s_logstream)
        s_logstream = stdout;

    if (s_logstream || s_logsender) {
```

as `s_logstream` can never be `NULL`. This restores rational/documented behavior.