### PR TITLE
Test fail on older platform after fixing zproxy issue

### DIFF
--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -543,10 +543,10 @@ zproxy_test (bool verbose)
     proxy = zactor_new (zproxy, NULL);
     assert (proxy);
 
-    sink = zsock_new_sub (">inproc://backend", "whatever");
+    sink = zsock_new_sub (">ipc://backend", "whatever");
     assert (sink);
 
-    zstr_sendx (proxy, "BACKEND", "XPUB", "inproc://backend", NULL);
+    zstr_sendx (proxy, "BACKEND", "XPUB", "ipc://backend", NULL);
     zsock_wait (proxy);
 
     zsock_destroy(&sink);


### PR DESCRIPTION
After #1446 Tests were failing on older zeromq releases because on them connecting before bind in inproc transport is forbidden.

Original issue #1445 