### PR TITLE
Fix compilation with mingw64 using autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,7 +228,7 @@ AC_MSG_CHECKING([whether to install manpages])
 AC_MSG_RESULT([$czmq_install_man])
 
 # Set some default features required by libczmq code.
-CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
+CPPFLAGS="-DCZMQ_INTERNAL_BUILD -D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
 
 # OS-specific tests
 case "${host_os}" in
@@ -283,6 +283,16 @@ case "${host_os}" in
         AC_DEFINE(CZMQ_HAVE_HPUX, 1, [Have HPUX OS])
         ;;
     *mingw32*)
+        AC_DEFINE(CZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
+        AC_DEFINE(CZMQ_HAVE_MINGW32, 1, [Have MinGW32])
+        AC_CHECK_HEADERS(windows.h)
+        czmq_on_mingw32="yes"
+        czmq_install_man="no"
+        ;;
+    *mingw64*)
+        # Define on MINGW64 to enable all libeary features
+        # Disable format error due to incomplete ANSI C
+        CPPFLAGS="-Wno-error=format -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(CZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(CZMQ_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)

--- a/include/czmq_library.h
+++ b/include/czmq_library.h
@@ -38,6 +38,12 @@
 #if defined (__WINDOWS__)
 #   if defined CZMQ_STATIC
 #       define CZMQ_EXPORT
+#   elif defined CZMQ_INTERNAL_BUILD
+#       if defined DLL_EXPORT
+#           define CZMQ_EXPORT __declspec(dllexport)
+#       else
+#           define CZMQ_EXPORT
+#       endif
 #   elif defined CZMQ_EXPORTS
 #       define CZMQ_EXPORT __declspec(dllexport)
 #   else

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -912,7 +912,9 @@ zsys_udp_recv (SOCKET udpsock, char *peername, int peerlen)
 {
     char buffer [UDP_FRAME_MAX];
     in6addr_t address6;
+#if (!defined (__WINDOWS__))
     inaddr_t *address = (inaddr_t *) &address6;
+#endif
     socklen_t address_len = sizeof (in6addr_t);
     ssize_t size = recvfrom (
         udpsock,


### PR DESCRIPTION
HI,
Here the fixes for correctly compile czmq using msys2 + mingw64 gcc.
DLL_EXPORT is automatically generated by libtool. I'm using this symbol + the indication of internal compilation put in the configure.ac in order to enable dllexport or not