### PR TITLE
Problem: [zhashx] cannot (un)pack anything but string values

### DIFF
--- a/api/zhashx.api
+++ b/api/zhashx.api
@@ -39,6 +39,20 @@
         <return type = "size"/>
     </callback_type>
 
+    <callback_type name = "serializer_fn">
+        Serializes an item to a longstr.
+        The caller takes ownership of the newly created object.
+        <argument name = "item" type = "anything" mutable = "0"/>
+        <return type = "string" fresh = "1" />
+    </callback_type>
+
+    <callback_type name = "deserializer_fn">
+        Deserializes a longstr into an item.
+        The caller takes ownership of the newly created object.
+        <argument name = "item_str" type = "string" />
+        <return type = "anything"/>
+    </callback_type>
+
     <constructor>
         Create a new, empty hash container
     </constructor>
@@ -161,7 +175,7 @@
         else -1 if a file error occurred.
         <argument name = "filename" type = "string" />
         <return type = "integer" />
-    </method>     
+    </method>
 
     <method name = "load">
         Load hash table from a text file in name=value format; hash table must
@@ -174,7 +188,7 @@
     <method name = "refresh">
         When a hash table was loaded from a file by zhashx_load, this method will
         reload the file if it has been modified since, and is "stable", i.e. not
-        still changing. Returns 0 if OK, -1 if there was an error reloading the 
+        still changing. Returns 0 if OK, -1 if there was an error reloading the
         file.
         <return type = "integer" />
     </method>
@@ -203,11 +217,25 @@
         <return type = "zframe" fresh = "1" />
     </method>
 
+    <method name = "pack own" state = "draft">
+        Same as pack but uses a user-defined serializer function to convert items
+        into longstr.
+        <argument name = "serializer" type = "zhashx_serializer_fn" callback = "1"/>
+        <return type = "zframe" fresh = "1" />
+    </method>
+
     <constructor name = "unpack">
         Unpack binary frame into a new hash table. Packed data must follow format
         defined by zhashx_pack. Hash table is set to autofree. An empty frame
         unpacks to an empty hash table.
         <argument name = "frame" type = "zframe" />
+    </constructor>
+
+    <constructor name = "unpack own" state = "draft">
+        Same as unpack but uses a user-defined deserializer function to convert
+        a longstr back into item format.
+        <argument name = "frame" type = "zframe" />
+        <argument name = "deserializer" type = "zhashx_deserializer_fn" callback = "1"/>
     </constructor>
 
     <method name = "dup">

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1413,7 +1413,7 @@ integer my_zhashx.refresh ()
 
 When a hash table was loaded from a file by zhashx_load, this method will
 reload the file if it has been modified since, and is "stable", i.e. not
-still changing. Returns 0 if OK, -1 if there was an error reloading the 
+still changing. Returns 0 if OK, -1 if there was an error reloading the
 file.
 
 ```

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -122,6 +122,16 @@ typedef void (zhashx_free_fn) (
 typedef size_t (zhashx_hash_fn) (
     const void *key);
 
+// Serializes an item to a longstr.                       
+// The caller takes ownership of the newly created object.
+typedef char * (zhashx_serializer_fn) (
+    const void *item);
+
+// Deserializes a longstr into an item.                   
+// The caller takes ownership of the newly created object.
+typedef void * (zhashx_deserializer_fn) (
+    const char *item_str);
+
 // Callback function for zhashx_foreach method.                              
 // This callback is deprecated and you should use zhashx_first/_next instead.
 typedef int (zhashx_foreach_fn) (
@@ -1280,6 +1290,11 @@ void
 zhashx_t *
     zhashx_unpack (zframe_t *frame);
 
+// Same as unpack but uses a user-defined deserializer function to convert
+// a longstr back into item format.                                       
+zhashx_t *
+    zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
+
 // Insert item into hash table with specified key and item.               
 // If key is already present returns -1 and leaves existing item unchanged
 // Returns 0 on success.                                                  
@@ -1408,6 +1423,11 @@ int
 // strings.                                                             
 zframe_t *
     zhashx_pack (zhashx_t *self);
+
+// Same as pack but uses a user-defined serializer function to convert items
+// into longstr.                                                            
+zframe_t *
+    zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer);
 
 // Make a copy of the list; items are duplicated if you set a duplicator 
 // for the list, otherwise not. Copying a null reference returns a null  

--- a/bindings/qml/src/QmlZhashx.cpp
+++ b/bindings/qml/src/QmlZhashx.cpp
@@ -180,6 +180,15 @@ QmlZframe *QmlZhashx::pack () {
 };
 
 ///
+//  Same as pack but uses a user-defined serializer function to convert items
+//  into longstr.                                                            
+QmlZframe *QmlZhashx::packOwn (zhashx_serializer_fn serializer) {
+    QmlZframe *retQ_ = new QmlZframe ();
+    retQ_->self = zhashx_pack_own (self, serializer);
+    return retQ_;
+};
+
+///
 //  Make a copy of the list; items are duplicated if you set a duplicator 
 //  for the list, otherwise not. Copying a null reference returns a null  
 //  reference. Note that this method's behavior changed slightly for CZMQ 
@@ -287,6 +296,15 @@ QmlZhashx *QmlZhashxAttached::construct () {
 QmlZhashx *QmlZhashxAttached::unpack (QmlZframe *frame) {
     QmlZhashx *qmlSelf = new QmlZhashx ();
     qmlSelf->self = zhashx_unpack (frame->self);
+    return qmlSelf;
+};
+
+///
+//  Same as unpack but uses a user-defined deserializer function to convert
+//  a longstr back into item format.                                       
+QmlZhashx *QmlZhashxAttached::unpackOwn (QmlZframe *frame, zhashx_deserializer_fn deserializer) {
+    QmlZhashx *qmlSelf = new QmlZhashx ();
+    qmlSelf->self = zhashx_unpack_own (frame->self, deserializer);
     return qmlSelf;
 };
 

--- a/bindings/qml/src/QmlZhashx.h
+++ b/bindings/qml/src/QmlZhashx.h
@@ -139,6 +139,10 @@ public slots:
     //  strings.                                                             
     QmlZframe *pack ();
 
+    //  Same as pack but uses a user-defined serializer function to convert items
+    //  into longstr.                                                            
+    QmlZframe *packOwn (zhashx_serializer_fn serializer);
+
     //  Make a copy of the list; items are duplicated if you set a duplicator 
     //  for the list, otherwise not. Copying a null reference returns a null  
     //  reference. Note that this method's behavior changed slightly for CZMQ 
@@ -208,6 +212,10 @@ public slots:
     //  defined by zhashx_pack. Hash table is set to autofree. An empty frame    
     //  unpacks to an empty hash table.                                          
     QmlZhashx *unpack (QmlZframe *frame);
+
+    //  Same as unpack but uses a user-defined deserializer function to convert
+    //  a longstr back into item format.                                       
+    QmlZhashx *unpackOwn (QmlZframe *frame, zhashx_deserializer_fn deserializer);
 
     //  Destroy a hash container and all items in it
     void destruct (QmlZhashx *qmlSelf);

--- a/bindings/qt/src/qzhashx.cpp
+++ b/bindings/qt/src/qzhashx.cpp
@@ -32,6 +32,14 @@ QZhashx* QZhashx::unpack (QZframe *frame, QObject *qObjParent)
 }
 
 ///
+//  Same as unpack but uses a user-defined deserializer function to convert
+//  a longstr back into item format.                                       
+QZhashx* QZhashx::unpackOwn (QZframe *frame, zhashx_deserializer_fn deserializer, QObject *qObjParent)
+{
+    return new QZhashx (zhashx_unpack_own (frame->self, deserializer), qObjParent);
+}
+
+///
 //  Destroy a hash container and all items in it
 QZhashx::~QZhashx ()
 {
@@ -236,6 +244,15 @@ int QZhashx::refresh ()
 QZframe * QZhashx::pack ()
 {
     QZframe *rv = new QZframe (zhashx_pack (self));
+    return rv;
+}
+
+///
+//  Same as pack but uses a user-defined serializer function to convert items
+//  into longstr.                                                            
+QZframe * QZhashx::packOwn (zhashx_serializer_fn serializer)
+{
+    QZframe *rv = new QZframe (zhashx_pack_own (self, serializer));
     return rv;
 }
 

--- a/bindings/qt/src/qzhashx.h
+++ b/bindings/qt/src/qzhashx.h
@@ -25,6 +25,10 @@ public:
     //  unpacks to an empty hash table.                                          
     static QZhashx* unpack (QZframe *frame, QObject *qObjParent = 0);
 
+    //  Same as unpack but uses a user-defined deserializer function to convert
+    //  a longstr back into item format.                                       
+    static QZhashx* unpackOwn (QZframe *frame, zhashx_deserializer_fn deserializer, QObject *qObjParent = 0);
+
     //  Destroy a hash container and all items in it
     ~QZhashx ();
 
@@ -138,6 +142,10 @@ public:
     //  Comments are not included in the packed data. Item values MUST be    
     //  strings.                                                             
     QZframe * pack ();
+
+    //  Same as pack but uses a user-defined serializer function to convert items
+    //  into longstr.                                                            
+    QZframe * packOwn (zhashx_serializer_fn serializer);
 
     //  Make a copy of the list; items are duplicated if you set a duplicator 
     //  for the list, otherwise not. Copying a null reference returns a null  

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -348,6 +348,14 @@ module CZMQ
 
       attach_function :zhashx_new, [], :pointer, **opts
       attach_function :zhashx_unpack, [:pointer], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zhashx_unpack_own, [:pointer, :pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zhashx_unpack_own() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zhashx_destroy, [:pointer], :void, **opts
       attach_function :zhashx_insert, [:pointer, :pointer, :pointer], :int, **opts
       attach_function :zhashx_update, [:pointer, :pointer, :pointer], :void, **opts
@@ -367,6 +375,14 @@ module CZMQ
       attach_function :zhashx_load, [:pointer, :string], :int, **opts
       attach_function :zhashx_refresh, [:pointer], :int, **opts
       attach_function :zhashx_pack, [:pointer], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zhashx_pack_own, [:pointer, :pointer], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The function zhashx_pack_own() can't be used through " +
+               "this Ruby binding because it's not available."
+        end
+      end
       attach_function :zhashx_dup, [:pointer], :pointer, **opts
       attach_function :zhashx_set_destructor, [:pointer, :pointer], :void, **opts
       attach_function :zhashx_set_duplicator, [:pointer, :pointer], :void, **opts

--- a/doc/mkman
+++ b/doc/mkman
@@ -136,7 +136,7 @@ END
     printf "Generating $outp.doc...\n";
     die "Can't create $outp.doc: $!"
         unless open (OUTPUT, ">$outp.doc");
-    print OUTPUT "#### $oupt - $title\n\n";
+    print OUTPUT "#### $outp - $title\n\n";
     print OUTPUT pull ("$source\@header,left");
     print OUTPUT "\n";
     print OUTPUT pull ("$source\@discuss,left");

--- a/include/zhashx.h
+++ b/include/zhashx.h
@@ -24,6 +24,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-drafts to enable.
 //  This class has legacy methods, which will be removed over time. You
 //  should not use them, and migrate any code that is still using them.
 // Destroy an item
@@ -45,6 +47,16 @@ typedef void (zhashx_free_fn) (
 // compare two items, for sorting
 typedef size_t (zhashx_hash_fn) (
     const void *key);
+
+// Serializes an item to a longstr.                       
+// The caller takes ownership of the newly created object.
+typedef char * (zhashx_serializer_fn) (
+    const void *item);
+
+// Deserializes a longstr into an item.                   
+// The caller takes ownership of the newly created object.
+typedef void * (zhashx_deserializer_fn) (
+    const char *item_str);
 
 // Callback function for zhashx_foreach method.                              
 // This callback is deprecated and you should use zhashx_first/_next instead.
@@ -261,6 +273,21 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zhashx_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Same as unpack but uses a user-defined deserializer function to convert
+//  a longstr back into item format.                                       
+CZMQ_EXPORT zhashx_t *
+    zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Same as pack but uses a user-defined serializer function to convert items
+//  into longstr.                                                            
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT zframe_t *
+    zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @ignore
 CZMQ_EXPORT void
     zhashx_comment (zhashx_t *self, const char *format, ...) CHECK_PRINTF (2);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -79,6 +79,20 @@ CZMQ_EXPORT int
     zframe_set_group (zframe_t *self, const char *group);
 
 //  *** Draft method, defined for internal use only ***
+//  Same as pack but uses a user-defined serializer function to convert items
+//  into longstr.                                                            
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT zframe_t *
+    zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer);
+
+//  *** Draft method, defined for internal use only ***
+//  Same as unpack but uses a user-defined deserializer function to convert
+//  a longstr back into item format.                                       
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT zhashx_t *
+    zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
+
+//  *** Draft method, defined for internal use only ***
 //  By default the reactor stops if the process receives a SIGINT or SIGTERM 
 //  signal. This makes it impossible to shut-down message based architectures
 //  like zactors. This method lets you switch off break handling. The default


### PR DESCRIPTION
Solution: Allow to supply own serializer and deserializer methods to
pack and unpack arbitrary values.