### PR TITLE
Problem: zlist_dup doesn't create copy autofree list if copied list was autofree

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -333,6 +333,9 @@ zlist_dup (zlist_t *self)
     zlist_t *copy = zlist_new ();
     assert (copy);
 
+    if (self->autofree)
+        zlist_autofree(copy);
+
     node_t *node;
     for (node = self->head; node; node = node->next) {
         if (zlist_append (copy, node->item) == -1) {


### PR DESCRIPTION
Fix: add checking autofree to zlist_dup and if it is set, create autofree copy list