### PR TITLE
Problem: invalid characters at beginning of zproxy.c breaks compilation

### DIFF
--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -1,4 +1,4 @@
-﻿/*  =========================================================================
+/*  =========================================================================
     zproxy - run a steerable proxy in the background
 
     Copyright (c) the Contributors as noted in the AUTHORS file.


### PR DESCRIPTION
Solution: delete invalid characters

Faced this error while cross compiling CZMQ with an older gcc (4.3.5). Just for the record, here is the output with the error:

```
[ 62%] Building C object CMakeFiles/czmq.dir/src/zproxy.c.o
/home/chaicko/czmq/src/zproxy.c:1: error: stray '\357' in program
/home/chaicko/czmq/src/zproxy.c:1: error: stray '\273' in program
/home/chaicko/czmq/src/zproxy.c:1: error: stray '\277' in program
CMakeFiles/czmq.dir/build.make:675: recipe for target 'CMakeFiles/czmq.dir/src/zproxy.c.o' failed
make[2]: *** [CMakeFiles/czmq.dir/src/zproxy.c.o] Error 1
CMakeFiles/Makefile2:60: recipe for target 'CMakeFiles/czmq.dir/all' failed
make[1]: *** [CMakeFiles/czmq.dir/all] Error 2
Makefile:126: recipe for target 'all' failed
make: *** [all] Error 2
```

And the actual diff is:

```
chaicko@gauss:~/czmq$ git diff
diff --git a/src/zproxy.c b/src/zproxy.c
index 36f54a6..00a7363 100644
--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -1,4 +1,4 @@
-<U+FEFF>/*  =========================================================================
+/*  =========================================================================
     zproxy - run a steerable proxy in the background
 
     Copyright (c) the Contributors as noted in the AUTHORS file.
```

Regards