### PR TITLE
Problem: Contribution guidelines are easily missed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Pull Request Notice
+
+Before sending a pull request make sure each commit solve one clear, minimal,
+plausible problem. Further each commit should have the following format:
+
+```
+Problem: X is broken
+
+Solution: do Y and Z to fix X
+```
+
+If you are new please have a look at our contributing guidelines:
+[CONTRIBUTING.md](https://github.com/zeromq/czmq/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Solution: Use github pull request templates to make sure new users don't
miss out on reading our contribution guidelines.

(If this works out, we might consider adding those to zproject!)