### PR TITLE
Problem: Travis CI OSX builds are broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ addons:
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew reinstall ossp-uuid binutils ; fi
+# workaround for Travis OSX CI bug, hasn't been fixed in a month so time for a hack
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew uninstall libtool && brew install libtool ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so

--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ Svein L. Ellingsen
 oikosdev
 J. Ritchie Carroll
 Patrik Wenger
+Luca Boccassi


### PR DESCRIPTION
Solution: add a workaround to reinstall libtool. Travis hasn't fixed
the issue in a month, so time for a little hack until they sort it.