### PR TITLE
Problem: zsys_run_as returns -1 for windows even for no-op

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1079,7 +1079,9 @@ zsys_daemonize (const char *workdir)
 
 int
 zsys_run_as (const char *lockfile, const char *group, const char *user)
-{
+{   if (!lockfile && !group && !user) {
+        return 0;
+    }
 #if (defined (__UNIX__))
     //  Switch to effective user ID (who owns executable); for
     //  system services this should be root, so that we can write


### PR DESCRIPTION
Solution: check for no-op and exit early

Hopefully this is ok, I spend my weekdays in Python, it's been a while since I've played with C, though the change is trivial.

This is to address this issue #1498 