### PR TITLE
Problem: _WIN32_WINNT version is old to use inet_pton()

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -237,9 +237,9 @@
 
 #if (defined (__MSDOS__))
 #   if (defined (__WINDOWS__))
-#       if (_WIN32_WINNT < 0x0501)
+#       if (_WIN32_WINNT < 0x0600)
 #           undef _WIN32_WINNT
-#           define _WIN32_WINNT 0x0501
+#           define _WIN32_WINNT 0x0600
 #       endif
 #       if (!defined (FD_SETSIZE))
 #           define FD_SETSIZE 1024      //  Max. filehandles/sockets


### PR DESCRIPTION
Solution: Increase required _WIN32_WINNT to _WIN32_WINNT_VISTA
(= 0x0600).

inet_pton() (= InetPton) documentation in MSDN says:

> Minimum supported client
>   Windows 8.1, Windows Vista [desktop apps | Windows Store apps]

The current required _WIN32_WINNT is _WIN32_WINNT_WINXP (=
0x0501). inet_pton() isn't declared on Windows XP. So we need to use
_WIN32_WINNT_VISTA (= 0x600) or later to use inet_pton().

inet_pton() is used since 1dd8eb2532d8f0ddd472752308c8e0b0735fac3e