### PR TITLE
Problem: Ruby binding outdated (zproject evolved)

### DIFF
--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -991,7 +991,7 @@ module CZMQ
       attach_function :zsock_tcp_accept_filter, [:pointer], :pointer, **opts
       attach_function :zsock_set_tcp_accept_filter, [:pointer, :string], :void, **opts
       attach_function :zsock_rcvmore, [:pointer], :int, **opts
-      attach_function :zsock_fd, [:pointer], :pointer, **opts
+      attach_function :zsock_fd, [:pointer], (::FFI::Platform.unix? ? :int : :uint64_t), **opts
       attach_function :zsock_events, [:pointer], :int, **opts
       attach_function :zsock_last_endpoint, [:pointer], :pointer, **opts
       attach_function :zsock_test, [:bool], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -3391,7 +3391,7 @@ module CZMQ
 
       # Get socket option `fd`.
       #
-      # @return [::FFI::Pointer]
+      # @return [Integer or FFI::Pointer]
       def fd()
         raise DestroyedError unless @ptr
         self_p = @ptr
@@ -3405,7 +3405,7 @@ module CZMQ
       #
       # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
       #   object reference to use this method on
-      # @return [::FFI::Pointer]
+      # @return [Integer or FFI::Pointer]
       def self.fd(self_p)
         self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
         result = ::CZMQ::FFI.zsock_fd(self_p)


### PR DESCRIPTION
The Ruby generator in zproject now correctly handles socket type and
doesn't fallback treat it as a pointer anymore.

Solution: Regenerate binding.