### PR TITLE
Update ruby binding for referring LIBCZMQ_PATH

### DIFF
--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -22,8 +22,10 @@ module CZMQ
 
     begin
       lib_name = 'libczmq'
-      lib_paths = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
-        .map { |path| "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}" }
+      lib_dirs = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
+      env_path = ENV["#{lib_name.upcase}_PATH"]
+      lib_dirs = [*env_path.split(':'), *lib_dirs] if env_path
+      lib_paths = lib_dirs.map { |path| "#{path}/#{lib_name}.#{::FFI::Platform::LIBSUFFIX}" }
       ffi_lib lib_paths + [lib_name]
       @available = true
     rescue LoadError


### PR DESCRIPTION
I made ruby binding can be refer LIBCZMQ_PATH for looking up libczmq in https://github.com/zeromq/zproject/pull/697 and https://github.com/zeromq/zproject/pull/698 .
To available this feature I want update ruby binding.