### PR TITLE
Problem: Brocade has copyright but not in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Corporate Copyright Statements
 ==============================
 
 Copyright (c) 1991-2014 iMatix Corporation 
+Copyright (c) 2014-2016 Brocade Communications Systems Inc.
 
 Contributors
 ============


### PR DESCRIPTION
Solution: add it. Some of the work that I do happens during working
hours and hence the copyright belongs to my employer, Brocade
Communications Systems Inc. Note this in the AUTHORS file.