### PR TITLE
Problem: zlist_push doesn't return -1

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -206,6 +206,9 @@ zlist_append (zlist_t *self, void *item)
 int
 zlist_push (zlist_t *self, void *item)
 {
+    if (!item)
+        return -1;
+
     node_t *node = (node_t *) zmalloc (sizeof (node_t));
     assert (node);
 


### PR DESCRIPTION
This is inconsistent with its description and with behaviour of zlist_append, which returns -1 for a NULL item.

Solution: make zlist_push return -1 for a NULL item.