### PR TITLE
Problem: zsock_vsend leaks zmsg_t on failure

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -899,7 +899,12 @@ zsock_vsend (void *self, const char *picture, va_list argptr)
         }
         picture++;
     }
-    return zmsg_send (&msg, self);
+
+    int rc = zmsg_send (&msg, self);
+    if (rc != 0)
+        zmsg_destroy (&msg);
+
+    return rc;
 }
 
 


### PR DESCRIPTION
Solution: check return code of zmsg_send, and if not 0 then destroy
the zmsg as it's created internally and owned by the API call, not
the user.

Fixes https://github.com/zeromq/czmq/issues/1529