### PR TITLE
Problem: internal use of deprecated API

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -531,7 +531,7 @@ zsock_bind (zsock_t *self, const char *format, ...)
     if (zrex_eq (rex, endpoint, "^tcp://.*:(\\d+)$")) {
         assert (zrex_hits (rex) == 2);
         int port = atoi (zrex_hit (rex, 1));
-#if defined (HAVE_LIBSYSTEMD)
+#if defined (HAVE_LIBSYSTEMD) && (ZMQ_VERSION >= ZMQ_MAKE_VERSION (4, 2, 0))
         if (zsys_auto_use_fd ()) {
             int last_handle = SD_LISTEN_FDS_START + sd_listen_fds (0);
             int handle;
@@ -580,7 +580,7 @@ zsock_bind (zsock_t *self, const char *format, ...)
         }
     }
     else {
-#if defined (HAVE_LIBSYSTEMD)
+#if defined (HAVE_LIBSYSTEMD) && (ZMQ_VERSION >= ZMQ_MAKE_VERSION (4, 2, 0))
         if (zsys_auto_use_fd () && zrex_eq (rex, endpoint, "^ipc://(.*)$")) {
             assert (zrex_hits (rex) == 2);
             const char *sock_path;

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -2,7 +2,7 @@
 .#  language. See https://github.com/imatix/gsl for details. This script 
 .#  is licensed under MIT/X11.
 .#
-.output "../api/zsock_option.xml"
+.output "../api/zsock_option.api"
 <!--
 ******************************************************************
 *   GENERATED SOURCE CODE, DO NOT EDIT!!                         *

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -291,10 +291,14 @@ zsys_socket (int type, const char *filename, size_t line_nbr)
         //  Configure socket with process defaults
         zsock_set_linger (handle, (int) s_linger);
 #if (ZMQ_VERSION_MAJOR == 2)
-        //  For ZeroMQ/2.x we use sndhwm for both send and receive
-        //  Use the deprecated zsockopt API as the current zsock_option
-        //  API does not support ZeroMQ/2.x
-        zsocket_set_hwm (handle, s_sndhwm);
+        // TODO: v2/v3 socket api in zsock_option.inc are not public (not
+        // added to include/zsock.h) so we have to use zmq_setsockopt directly
+        // This should be fixed and zsock_set_hwm should be used instead
+#       if defined (ZMQ_HWM)
+        uint64_t value = s_sndhwm;
+        int rc = zmq_setsockopt (handle, ZMQ_HWM, &value, sizeof (uint64_t));
+        assert (rc == 0 || zmq_errno () == ETERM);
+#       endif
 #else
         //  For later versions we use separate SNDHWM and RCVHWM
         zsock_set_sndhwm (handle, (int) s_sndhwm);
@@ -401,10 +405,19 @@ zsys_create_pipe (zsock_t **backend_p)
     assert (backend);
 
 #if (ZMQ_VERSION_MAJOR == 2)
-    //  Use the deprecated zsockopt API as the current zsock_option
-    //  API does not support ZeroMQ/2.x
-    zsocket_set_hwm (zsock_resolve (frontend), zsys_pipehwm ());
-    zsocket_set_hwm (zsock_resolve (backend), zsys_pipehwm ());
+    // TODO: v2/v3 socket api in zsock_option.inc are not public (not
+    // added to include/zsock.h) so we have to use zmq_setsockopt directly
+    // This should be fixed and zsock_set_hwm should be used instead
+#   if defined (ZMQ_HWM)
+    uint64_t value = zsys_pipehwm ();
+    int ret = zmq_setsockopt (zsock_resolve (frontend), ZMQ_HWM, &value,
+        sizeof (uint64_t));
+    assert (ret == 0 || zmq_errno () == ETERM);
+    value = zsys_pipehwm ();
+    ret = zmq_setsockopt (zsock_resolve (backend), ZMQ_HWM, &value,
+        sizeof (uint64_t));
+    assert (ret == 0 || zmq_errno () == ETERM);
+#   endif
 #else
     zsock_set_sndhwm (frontend, (int) zsys_pipehwm ());
     zsock_set_sndhwm (backend, (int) zsys_pipehwm ());

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -84,7 +84,7 @@ static size_t s_open_sockets = 0;
 //  We keep a list of open sockets to report leaks to developers
 static zlist_t *s_sockref_list = NULL;
 
-//  This defines a single zsocket_new() caller instance
+//  This defines a single zsock_new() caller instance
 typedef struct {
     void *handle;
     int type;


### PR DESCRIPTION
Solution: see commits


I'll send the removal of v2 deprecated APIs separately.

Note the hack in zsys.c: would be nice to solve it by making the ZMQ v2/v3 socket options available, as they are currently not.
Unfortunately the way it works is that zsock_opt.gsl generates an API file, which does not have the semantics to add IFDEFS per version.
So for now a bit of a hack will do.
Suggestions welcome!