### PR TITLE
Problem: new sockopt released in zmq 4.2 but still draft

### DIFF
--- a/api/zsock_option.api
+++ b/api/zsock_option.api
@@ -8,42 +8,42 @@
 ******************************************************************
 -->
 
-<method name = "heartbeat ivl" polymorphic = "1" state = "draft">
+<method name = "heartbeat ivl" polymorphic = "1">
     Get socket option `heartbeat_ivl`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat ivl" polymorphic = "1" state = "draft">
+<method name = "set heartbeat ivl" polymorphic = "1">
     Set socket option `heartbeat_ivl`.
     <argument name = "heartbeat ivl" type = "integer" />
 </method>
 
-<method name = "heartbeat ttl" polymorphic = "1" state = "draft">
+<method name = "heartbeat ttl" polymorphic = "1">
     Get socket option `heartbeat_ttl`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat ttl" polymorphic = "1" state = "draft">
+<method name = "set heartbeat ttl" polymorphic = "1">
     Set socket option `heartbeat_ttl`.
     <argument name = "heartbeat ttl" type = "integer" />
 </method>
 
-<method name = "heartbeat timeout" polymorphic = "1" state = "draft">
+<method name = "heartbeat timeout" polymorphic = "1">
     Get socket option `heartbeat_timeout`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set heartbeat timeout" polymorphic = "1" state = "draft">
+<method name = "set heartbeat timeout" polymorphic = "1">
     Set socket option `heartbeat_timeout`.
     <argument name = "heartbeat timeout" type = "integer" />
 </method>
 
-<method name = "use fd" polymorphic = "1" state = "draft">
+<method name = "use fd" polymorphic = "1">
     Get socket option `use_fd`.
     <return type = "integer" fresh = "1" />
 </method>
 
-<method name = "set use fd" polymorphic = "1" state = "draft">
+<method name = "set use fd" polymorphic = "1">
     Set socket option `use_fd`.
     <argument name = "use fd" type = "integer" />
 </method>

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -298,6 +298,42 @@ CZMQ_EXPORT bool
 CZMQ_EXPORT void *
     zsock_resolve (void *self);
 
+//  Get socket option `heartbeat_ivl`.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_heartbeat_ivl (void *self);
+
+//  Set socket option `heartbeat_ivl`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
+
+//  Get socket option `heartbeat_ttl`.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_heartbeat_ttl (void *self);
+
+//  Set socket option `heartbeat_ttl`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
+
+//  Get socket option `heartbeat_timeout`.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_heartbeat_timeout (void *self);
+
+//  Set socket option `heartbeat_timeout`.
+CZMQ_EXPORT void
+    zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
+
+//  Get socket option `use_fd`.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_use_fd (void *self);
+
+//  Set socket option `use_fd`.
+CZMQ_EXPORT void
+    zsock_set_use_fd (void *self, int use_fd);
+
 //  Get socket option `tos`.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
@@ -775,50 +811,6 @@ CZMQ_EXPORT int
 //  Returns 0 if OK, -1 if failed.                                  
 CZMQ_EXPORT int
     zsock_leave (void *self, const char *group);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Get socket option `heartbeat_ivl`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_ivl (void *self);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Set socket option `heartbeat_ivl`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Get socket option `heartbeat_ttl`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_ttl (void *self);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Set socket option `heartbeat_ttl`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Get socket option `heartbeat_timeout`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_timeout (void *self);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Set socket option `heartbeat_timeout`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Get socket option `use_fd`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_use_fd (void *self);
-
-//  *** Draft method, for development use, may change without warning ***
-//  Set socket option `use_fd`.
-CZMQ_EXPORT void
-    zsock_set_use_fd (void *self, int use_fd);
 
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -181,50 +181,6 @@ CZMQ_EXPORT int
     zsock_leave (void *self, const char *group);
 
 //  *** Draft method, defined for internal use only ***
-//  Get socket option `heartbeat_ivl`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_ivl (void *self);
-
-//  *** Draft method, defined for internal use only ***
-//  Set socket option `heartbeat_ivl`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
-
-//  *** Draft method, defined for internal use only ***
-//  Get socket option `heartbeat_ttl`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_ttl (void *self);
-
-//  *** Draft method, defined for internal use only ***
-//  Set socket option `heartbeat_ttl`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
-
-//  *** Draft method, defined for internal use only ***
-//  Get socket option `heartbeat_timeout`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_heartbeat_timeout (void *self);
-
-//  *** Draft method, defined for internal use only ***
-//  Set socket option `heartbeat_timeout`.
-CZMQ_EXPORT void
-    zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
-
-//  *** Draft method, defined for internal use only ***
-//  Get socket option `use_fd`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_use_fd (void *self);
-
-//  *** Draft method, defined for internal use only ***
-//  Set socket option `use_fd`.
-CZMQ_EXPORT void
-    zsock_set_use_fd (void *self, int use_fd);
-
-//  *** Draft method, defined for internal use only ***
 //  Accepts a void pointer and returns a fresh character string. If source
 //  is null, returns an empty string.                                     
 //  Caller owns return value and must destroy it when done.

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -11,13 +11,13 @@
     <version major = "4" style = "macro">
         <!-- Options that are new in 4.2 -->
         <option name = "heartbeat_ivl"     type = "int"    mode = "rw" test = "DEALER"
-            test_value = "2000" state = "draft" />
+            test_value = "2000" />
         <option name = "heartbeat_ttl"     type = "int"    mode = "rw"  test = "DEALER"
-            test_value = "4000" state = "draft" />
+            test_value = "4000" />
         <option name = "heartbeat_timeout" type = "int"    mode = "rw"  test = "DEALER"
-            test_value = "6000" state = "draft" />
+            test_value = "6000" />
         <option name = "use_fd"            type = "int"    mode = "rw"  test = "REQ"
-            test_value = "3" state = "draft" />
+            test_value = "3" />
 
         <!-- Options that are new in 4.1 -->
         <option name = "tos"               type = "int"    mode = "rw" test = "DEALER" />


### PR DESCRIPTION
Solution: move them from DRAFT to STABLE state following libzmq 4.2.0
release.

Also regenerate with make code.

I think there are a few more new in 4.2 missing?