### PR TITLE
Problem: zlist_dup does not copy comparison function.

### DIFF
--- a/src/zlist.c
+++ b/src/zlist.c
@@ -339,6 +339,8 @@ zlist_dup (zlist_t *self)
     if (self->autofree)
         zlist_autofree(copy);
 
+    copy->compare_fn = self->compare_fn;
+
     node_t *node;
     for (node = self->head; node; node = node->next) {
         if (zlist_append (copy, node->item) == -1) {


### PR DESCRIPTION
Solution: Assign the source list's compare_fn to the copy list's compare_fn.