### PR TITLE
Problem: private symbols leaked as public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,6 @@ set(TEST_CLASSES
     zproxy
     zrex
     zsys
-    zgossip_msg
 )
 
 IF (ENABLE_DRAFTS)

--- a/bindings/jni/build.gradle
+++ b/bindings/jni/build.gradle
@@ -123,6 +123,7 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
     publications = ['mavenJava']
     publish = true
+    override = true
     pkg {
         repo = "maven"
         name = "czmq-jni"

--- a/include/czmq_library.h
+++ b/include/czmq_library.h
@@ -49,8 +49,14 @@
 #   else
 #       define CZMQ_EXPORT __declspec(dllimport)
 #   endif
+#   define CZMQ_PRIVATE
 #else
 #   define CZMQ_EXPORT
+#   if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
+#       define CZMQ_PRIVATE __attribute__ ((visibility ("hidden")))
+#   else
+#       define CZMQ_PRIVATE
+#   endif
 #endif
 
 //  Opaque class structures to allow forward references

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -32,7 +32,7 @@
 
 //  *** Draft method, defined for internal use only ***
 //  Unset certificate metadata.
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zcert_unset_meta (zcert_t *self, const char *name);
 
 //  *** Draft callbacks, defined for internal use only ***
@@ -45,130 +45,130 @@ typedef void (zcertstore_destructor) (
 
 //  *** Draft method, defined for internal use only ***
 //  Override the default disk loader with a custom loader fn.
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zcertstore_set_loader (zcertstore_t *self, zcertstore_loader loader, zcertstore_destructor destructor, void *state);
 
 //  *** Draft method, defined for internal use only ***
 //  Empty certificate hashtable. This wrapper exists to be friendly to bindings,
 //  which don't usually have access to struct internals.                        
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zcertstore_empty (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                  
-CZMQ_EXPORT uint32_t
+CZMQ_PRIVATE uint32_t
     zframe_routing_id (zframe_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set routing ID on frame. This is used if/when the frame is sent to a
 //  ZMQ_SERVER socket.                                                  
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zframe_set_routing_id (zframe_t *self, uint32_t routing_id);
 
 //  *** Draft method, defined for internal use only ***
 //  Return frame group of radio-dish pattern.
-CZMQ_EXPORT const char *
+CZMQ_PRIVATE const char *
     zframe_group (zframe_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set group on frame. This is used if/when the frame is sent to a
 //  ZMQ_RADIO socket.                                              
 //  Return -1 on error, 0 on success.                              
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zframe_set_group (zframe_t *self, const char *group);
 
 //  *** Draft method, defined for internal use only ***
 //  Same as pack but uses a user-defined serializer function to convert items
 //  into longstr.                                                            
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zframe_t *
+CZMQ_PRIVATE zframe_t *
     zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer);
 
 //  *** Draft method, defined for internal use only ***
 //  Same as unpack but uses a user-defined deserializer function to convert
 //  a longstr back into item format.                                       
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zhashx_t *
+CZMQ_PRIVATE zhashx_t *
     zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
 
 //  *** Draft method, defined for internal use only ***
 //  Return message routing ID, if the message came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                      
-CZMQ_EXPORT uint32_t
+CZMQ_PRIVATE uint32_t
     zmsg_routing_id (zmsg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set routing ID on message. This is used if/when the message is sent to a
 //  ZMQ_SERVER socket.                                                      
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zmsg_set_routing_id (zmsg_t *self, uint32_t routing_id);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a SERVER socket. Default action is bind.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_server (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a CLIENT socket. Default action is connect.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_client (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a RADIO socket. Default action is bind.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_radio (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a DISH socket. Default action is connect.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_dish (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a GATHER socket. Default action is bind.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_gather (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Create a SCATTER socket. Default action is connect.
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zsock_t *
+CZMQ_PRIVATE zsock_t *
     zsock_new_scatter (const char *endpoint);
 
 //  *** Draft method, defined for internal use only ***
 //  Return socket routing ID if any. This returns 0 if the socket is not
 //  of type ZMQ_SERVER or if no request was already received on it.     
-CZMQ_EXPORT uint32_t
+CZMQ_PRIVATE uint32_t
     zsock_routing_id (zsock_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set routing ID on socket. The socket MUST be of type ZMQ_SERVER.        
 //  This will be used when sending messages on the socket via the zsock API.
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zsock_set_routing_id (zsock_t *self, uint32_t routing_id);
 
 //  *** Draft method, defined for internal use only ***
 //  Join a group for the RADIO-DISH pattern. Call only on ZMQ_DISH.
 //  Returns 0 if OK, -1 if failed.                                 
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zsock_join (void *self, const char *group);
 
 //  *** Draft method, defined for internal use only ***
 //  Leave a group for the RADIO-DISH pattern. Call only on ZMQ_DISH.
 //  Returns 0 if OK, -1 if failed.                                  
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zsock_leave (void *self, const char *group);
 
 //  *** Draft method, defined for internal use only ***
 //  Accepts a void pointer and returns a fresh character string. If source
 //  is null, returns an empty string.                                     
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT char *
+CZMQ_PRIVATE char *
     zstr_str (void *source);
 
 //  *** Draft constants, defined for internal use only ***
@@ -181,88 +181,88 @@ CZMQ_EXPORT char *
 //  *** Draft method, defined for internal use only ***
 //  Create a new empty zgossip_msg
 //  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT zgossip_msg_t *
+CZMQ_PRIVATE zgossip_msg_t *
     zgossip_msg_new (void);
 
 //  *** Draft method, defined for internal use only ***
 //  Destroy a zgossip_msg instance
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_destroy (zgossip_msg_t **self_p);
 
 //  *** Draft method, defined for internal use only ***
 //  Receive a zgossip_msg from the socket. Returns 0 if OK, -1 if
 //  there was an error. Blocks if there is no message waiting.   
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zgossip_msg_recv (zgossip_msg_t *self, zsock_t *input);
 
 //  *** Draft method, defined for internal use only ***
 //  Send the zgossip_msg to the output socket, does not destroy it
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zgossip_msg_send (zgossip_msg_t *self, zsock_t *output);
 
 //  *** Draft method, defined for internal use only ***
 //  Print contents of message to stdout
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_print (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the message routing id, as a frame
-CZMQ_EXPORT zframe_t *
+CZMQ_PRIVATE zframe_t *
     zgossip_msg_routing_id (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set the message routing id from a frame
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_set_routing_id (zgossip_msg_t *self, zframe_t *routing_id);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the zgossip_msg message id
-CZMQ_EXPORT int
+CZMQ_PRIVATE int
     zgossip_msg_id (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set the zgossip_msg message id
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_set_id (zgossip_msg_t *self, int id);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the zgossip_msg message id as printable text
-CZMQ_EXPORT const char *
+CZMQ_PRIVATE const char *
     zgossip_msg_command (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the key field
-CZMQ_EXPORT const char *
+CZMQ_PRIVATE const char *
     zgossip_msg_key (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set the key field
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_set_key (zgossip_msg_t *self, const char *key);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the value field
-CZMQ_EXPORT const char *
+CZMQ_PRIVATE const char *
     zgossip_msg_value (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set the value field
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_set_value (zgossip_msg_t *self, const char *value);
 
 //  *** Draft method, defined for internal use only ***
 //  Get the ttl field
-CZMQ_EXPORT uint32_t
+CZMQ_PRIVATE uint32_t
     zgossip_msg_ttl (zgossip_msg_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Set the ttl field
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_set_ttl (zgossip_msg_t *self, uint32_t ttl);
 
 //  *** Draft method, defined for internal use only ***
 //  Self test of this class.
-CZMQ_EXPORT void
+CZMQ_PRIVATE void
     zgossip_msg_test (bool verbose);
 
 #endif // CZMQ_BUILD_DRAFT_API

--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -58,7 +58,6 @@ all_tests [] = {
     { "zproxy", zproxy_test },
     { "zrex", zrex_test },
     { "zsys", zsys_test },
-    { "zgossip_msg", zgossip_msg_test },
 #ifdef CZMQ_BUILD_DRAFT_API
     { "zproc", zproc_test },
     { "ztimerset", ztimerset_test },

--- a/src/zgossip.c
+++ b/src/zgossip.c
@@ -482,4 +482,7 @@ zgossip_test (bool verbose)
 
     //  @end
     printf ("OK\n");
+
+    // zgossip_msg is a private class used by zgossip, so we run the test here
+    zgossip_msg_test (verbose);
 }


### PR DESCRIPTION
Solution: regenerate from zproject

Also call zgossip_msg_test from zgossip_test. Any better solution to run private classes tests is welcome!

Fixes https://github.com/zeromq/czmq/issues/1548