### PR TITLE
Problem: python bindings fail during release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,4 @@ deploy:
   on:
     branch: master
     tags: true
-    condition: $TRAVIS_OS_NAME =~ (linux) && $BUILD_TYPE =~ (default|bindings)
+    condition: $TRAVIS_OS_NAME =~ (linux) && ($BUILD_TYPE =~ (default) || ($BUILD_TYPE =~ (bindings) && $BINDING =~ (jni)))


### PR DESCRIPTION
Solution: don't run deploy step on pyhton bindings as they don't
have any.