### PR TITLE
Problem: zsock options could be available at build time but not at runtime

### DIFF
--- a/api/zsock_option.api
+++ b/api/zsock_option.api
@@ -8,6 +8,8 @@
 ******************************************************************
 -->
 
+<!-- The following socket options are available in libzmq from version 4.2.0 -->
+
 <method name = "heartbeat ivl" polymorphic = "1">
     Get socket option `heartbeat_ivl`.
     <return type = "integer" fresh = "1" />
@@ -153,6 +155,8 @@
     <argument name = "vmci connect timeout" type = "integer" />
 </method>
 
+<!-- The following socket options are available in libzmq from version 4.1.0 -->
+
 <method name = "tos" polymorphic = "1">
     Get socket option `tos`.
     <return type = "integer" fresh = "1" />
@@ -202,6 +206,8 @@
     Set socket option `xpub_nodrop`.
     <argument name = "xpub nodrop" type = "integer" />
 </method>
+
+<!-- The following socket options are available in libzmq from version 4.0.0 -->
 
 <method name = "set router mandatory" polymorphic = "1">
     Set socket option `router_mandatory`.
@@ -388,25 +394,7 @@
     <argument name = "immediate" type = "integer" />
 </method>
 
-<method name = "set router raw" polymorphic = "1">
-    Set socket option `router_raw`.
-    <argument name = "router raw" type = "integer" />
-</method>
-
-<method name = "ipv4only" polymorphic = "1">
-    Get socket option `ipv4only`.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set ipv4only" polymorphic = "1">
-    Set socket option `ipv4only`.
-    <argument name = "ipv4only" type = "integer" />
-</method>
-
-<method name = "set delay attach on connect" polymorphic = "1">
-    Set socket option `delay_attach_on_connect`.
-    <argument name = "delay attach on connect" type = "integer" />
-</method>
+<!-- The following socket options are available in libzmq from version 3.0.0 -->
 
 <method name = "type" polymorphic = "1">
     Get socket option `type`.
@@ -656,4 +644,24 @@
 <method name = "last endpoint" polymorphic = "1">
     Get socket option `last_endpoint`.
     <return type = "string" fresh = "1" />
+</method>
+
+<method name = "set router raw" polymorphic = "1">
+    Set socket option `router_raw`.
+    <argument name = "router raw" type = "integer" />
+</method>
+
+<method name = "ipv4only" polymorphic = "1">
+    Get socket option `ipv4only`.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set ipv4only" polymorphic = "1">
+    Set socket option `ipv4only`.
+    <argument name = "ipv4only" type = "integer" />
+</method>
+
+<method name = "set delay attach on connect" polymorphic = "1">
+    Set socket option `delay_attach_on_connect`.
+    <argument name = "delay attach on connect" type = "integer" />
 </method>

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zsock.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zsock.c
@@ -892,31 +892,6 @@ Java_org_zeromq_czmq_Zsock__1_1setImmediate (JNIEnv *env, jclass c, jlong self, 
     zsock_set_immediate ((zsock_t *) (intptr_t) self, (int) immediate);
 }
 
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zsock__1_1setRouterRaw (JNIEnv *env, jclass c, jlong self, jint router_raw)
-{
-    zsock_set_router_raw ((zsock_t *) (intptr_t) self, (int) router_raw);
-}
-
-JNIEXPORT jint JNICALL
-Java_org_zeromq_czmq_Zsock__1_1ipv4only (JNIEnv *env, jclass c, jlong self)
-{
-    jint ipv4only_ = (jint) zsock_ipv4only ((zsock_t *) (intptr_t) self);
-    return ipv4only_;
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zsock__1_1setIpv4only (JNIEnv *env, jclass c, jlong self, jint ipv4only)
-{
-    zsock_set_ipv4only ((zsock_t *) (intptr_t) self, (int) ipv4only);
-}
-
-JNIEXPORT void JNICALL
-Java_org_zeromq_czmq_Zsock__1_1setDelayAttachOnConnect (JNIEnv *env, jclass c, jlong self, jint delay_attach_on_connect)
-{
-    zsock_set_delay_attach_on_connect ((zsock_t *) (intptr_t) self, (int) delay_attach_on_connect);
-}
-
 JNIEXPORT jint JNICALL
 Java_org_zeromq_czmq_Zsock__1_1type (JNIEnv *env, jclass c, jlong self)
 {
@@ -1248,6 +1223,31 @@ Java_org_zeromq_czmq_Zsock__1_1lastEndpoint (JNIEnv *env, jclass c, jlong self)
     jstring return_string_ = (*env)->NewStringUTF (env, last_endpoint_);
     zstr_free (&last_endpoint_);
     return return_string_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsock__1_1setRouterRaw (JNIEnv *env, jclass c, jlong self, jint router_raw)
+{
+    zsock_set_router_raw ((zsock_t *) (intptr_t) self, (int) router_raw);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zsock__1_1ipv4only (JNIEnv *env, jclass c, jlong self)
+{
+    jint ipv4only_ = (jint) zsock_ipv4only ((zsock_t *) (intptr_t) self);
+    return ipv4only_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsock__1_1setIpv4only (JNIEnv *env, jclass c, jlong self, jint ipv4only)
+{
+    zsock_set_ipv4only ((zsock_t *) (intptr_t) self, (int) ipv4only);
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsock__1_1setDelayAttachOnConnect (JNIEnv *env, jclass c, jlong self, jint delay_attach_on_connect)
+{
+    zsock_set_delay_attach_on_connect ((zsock_t *) (intptr_t) self, (int) delay_attach_on_connect);
 }
 
 JNIEXPORT void JNICALL

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -977,34 +977,6 @@ public class Zsock implements AutoCloseable{
         __setImmediate (self, immediate);
     }
     /*
-    Set socket option `router_raw`.
-    */
-    native static void __setRouterRaw (long self, int routerRaw);
-    public void setRouterRaw (int routerRaw) {
-        __setRouterRaw (self, routerRaw);
-    }
-    /*
-    Get socket option `ipv4only`.
-    */
-    native static int __ipv4only (long self);
-    public int ipv4only () {
-        return __ipv4only (self);
-    }
-    /*
-    Set socket option `ipv4only`.
-    */
-    native static void __setIpv4only (long self, int ipv4only);
-    public void setIpv4only (int ipv4only) {
-        __setIpv4only (self, ipv4only);
-    }
-    /*
-    Set socket option `delay_attach_on_connect`.
-    */
-    native static void __setDelayAttachOnConnect (long self, int delayAttachOnConnect);
-    public void setDelayAttachOnConnect (int delayAttachOnConnect) {
-        __setDelayAttachOnConnect (self, delayAttachOnConnect);
-    }
-    /*
     Get socket option `type`.
     */
     native static int __type (long self);
@@ -1346,6 +1318,34 @@ public class Zsock implements AutoCloseable{
     native static String __lastEndpoint (long self);
     public String lastEndpoint () {
         return __lastEndpoint (self);
+    }
+    /*
+    Set socket option `router_raw`.
+    */
+    native static void __setRouterRaw (long self, int routerRaw);
+    public void setRouterRaw (int routerRaw) {
+        __setRouterRaw (self, routerRaw);
+    }
+    /*
+    Get socket option `ipv4only`.
+    */
+    native static int __ipv4only (long self);
+    public int ipv4only () {
+        return __ipv4only (self);
+    }
+    /*
+    Set socket option `ipv4only`.
+    */
+    native static void __setIpv4only (long self, int ipv4only);
+    public void setIpv4only (int ipv4only) {
+        __setIpv4only (self, ipv4only);
+    }
+    /*
+    Set socket option `delay_attach_on_connect`.
+    */
+    native static void __setDelayAttachOnConnect (long self, int delayAttachOnConnect);
+    public void setDelayAttachOnConnect (int delayAttachOnConnect) {
+        __setDelayAttachOnConnect (self, delayAttachOnConnect);
     }
     /*
     Self test of this class.

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2868,30 +2868,6 @@ nothing my_zsock.setImmediate (Number)
 Set socket option `immediate`.
 
 ```
-nothing my_zsock.setRouterRaw (Number)
-```
-
-Set socket option `router_raw`.
-
-```
-integer my_zsock.ipv4only ()
-```
-
-Get socket option `ipv4only`.
-
-```
-nothing my_zsock.setIpv4only (Number)
-```
-
-Set socket option `ipv4only`.
-
-```
-nothing my_zsock.setDelayAttachOnConnect (Number)
-```
-
-Set socket option `delay_attach_on_connect`.
-
-```
 integer my_zsock.type ()
 ```
 
@@ -3184,6 +3160,30 @@ string my_zsock.lastEndpoint ()
 ```
 
 Get socket option `last_endpoint`.
+
+```
+nothing my_zsock.setRouterRaw (Number)
+```
+
+Set socket option `router_raw`.
+
+```
+integer my_zsock.ipv4only ()
+```
+
+Get socket option `ipv4only`.
+
+```
+nothing my_zsock.setIpv4only (Number)
+```
+
+Set socket option `ipv4only`.
+
+```
+nothing my_zsock.setDelayAttachOnConnect (Number)
+```
+
+Set socket option `delay_attach_on_connect`.
 
 ```
 nothing my_zsock.test (Boolean)

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -4145,10 +4145,6 @@ NAN_MODULE_INIT (Zsock::Init) {
     Nan::SetPrototypeMethod (tpl, "setIpv6", _set_ipv6);
     Nan::SetPrototypeMethod (tpl, "immediate", _immediate);
     Nan::SetPrototypeMethod (tpl, "setImmediate", _set_immediate);
-    Nan::SetPrototypeMethod (tpl, "setRouterRaw", _set_router_raw);
-    Nan::SetPrototypeMethod (tpl, "ipv4only", _ipv4only);
-    Nan::SetPrototypeMethod (tpl, "setIpv4only", _set_ipv4only);
-    Nan::SetPrototypeMethod (tpl, "setDelayAttachOnConnect", _set_delay_attach_on_connect);
     Nan::SetPrototypeMethod (tpl, "type", _type);
     Nan::SetPrototypeMethod (tpl, "sndhwm", _sndhwm);
     Nan::SetPrototypeMethod (tpl, "setSndhwm", _set_sndhwm);
@@ -4198,6 +4194,10 @@ NAN_MODULE_INIT (Zsock::Init) {
     Nan::SetPrototypeMethod (tpl, "rcvmore", _rcvmore);
     Nan::SetPrototypeMethod (tpl, "events", _events);
     Nan::SetPrototypeMethod (tpl, "lastEndpoint", _last_endpoint);
+    Nan::SetPrototypeMethod (tpl, "setRouterRaw", _set_router_raw);
+    Nan::SetPrototypeMethod (tpl, "ipv4only", _ipv4only);
+    Nan::SetPrototypeMethod (tpl, "setIpv4only", _set_ipv4only);
+    Nan::SetPrototypeMethod (tpl, "setDelayAttachOnConnect", _set_delay_attach_on_connect);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -5314,51 +5314,6 @@ NAN_METHOD (Zsock::_set_immediate) {
     zsock_set_immediate (zsock->self, (int) immediate);
 }
 
-NAN_METHOD (Zsock::_set_router_raw) {
-    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
-    if (info [0]->IsUndefined ())
-        return Nan::ThrowTypeError ("method requires a `router raw`");
-
-    int router_raw;
-    if (info [0]->IsNumber ())
-        router_raw = Nan::To<int>(info [0]).FromJust ();
-    else
-        return Nan::ThrowTypeError ("`router raw` must be a number");
-    zsock_set_router_raw (zsock->self, (int) router_raw);
-}
-
-NAN_METHOD (Zsock::_ipv4only) {
-    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
-    int result = zsock_ipv4only (zsock->self);
-    info.GetReturnValue ().Set (Nan::New<Number>(result));
-}
-
-NAN_METHOD (Zsock::_set_ipv4only) {
-    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
-    if (info [0]->IsUndefined ())
-        return Nan::ThrowTypeError ("method requires a `ipv4only`");
-
-    int ipv4only;
-    if (info [0]->IsNumber ())
-        ipv4only = Nan::To<int>(info [0]).FromJust ();
-    else
-        return Nan::ThrowTypeError ("`ipv4only` must be a number");
-    zsock_set_ipv4only (zsock->self, (int) ipv4only);
-}
-
-NAN_METHOD (Zsock::_set_delay_attach_on_connect) {
-    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
-    if (info [0]->IsUndefined ())
-        return Nan::ThrowTypeError ("method requires a `delay attach on connect`");
-
-    int delay_attach_on_connect;
-    if (info [0]->IsNumber ())
-        delay_attach_on_connect = Nan::To<int>(info [0]).FromJust ();
-    else
-        return Nan::ThrowTypeError ("`delay attach on connect` must be a number");
-    zsock_set_delay_attach_on_connect (zsock->self, (int) delay_attach_on_connect);
-}
-
 NAN_METHOD (Zsock::_type) {
     Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
     int result = zsock_type (zsock->self);
@@ -5827,6 +5782,51 @@ NAN_METHOD (Zsock::_last_endpoint) {
     Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
     char *result = (char *) zsock_last_endpoint (zsock->self);
     info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
+}
+
+NAN_METHOD (Zsock::_set_router_raw) {
+    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `router raw`");
+
+    int router_raw;
+    if (info [0]->IsNumber ())
+        router_raw = Nan::To<int>(info [0]).FromJust ();
+    else
+        return Nan::ThrowTypeError ("`router raw` must be a number");
+    zsock_set_router_raw (zsock->self, (int) router_raw);
+}
+
+NAN_METHOD (Zsock::_ipv4only) {
+    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
+    int result = zsock_ipv4only (zsock->self);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zsock::_set_ipv4only) {
+    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `ipv4only`");
+
+    int ipv4only;
+    if (info [0]->IsNumber ())
+        ipv4only = Nan::To<int>(info [0]).FromJust ();
+    else
+        return Nan::ThrowTypeError ("`ipv4only` must be a number");
+    zsock_set_ipv4only (zsock->self, (int) ipv4only);
+}
+
+NAN_METHOD (Zsock::_set_delay_attach_on_connect) {
+    Zsock *zsock = Nan::ObjectWrap::Unwrap <Zsock> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `delay attach on connect`");
+
+    int delay_attach_on_connect;
+    if (info [0]->IsNumber ())
+        delay_attach_on_connect = Nan::To<int>(info [0]).FromJust ();
+    else
+        return Nan::ThrowTypeError ("`delay attach on connect` must be a number");
+    zsock_set_delay_attach_on_connect (zsock->self, (int) delay_attach_on_connect);
 }
 
 NAN_METHOD (Zsock::_test) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -679,10 +679,6 @@ class Zsock: public Nan::ObjectWrap {
     static NAN_METHOD (_set_ipv6);
     static NAN_METHOD (_immediate);
     static NAN_METHOD (_set_immediate);
-    static NAN_METHOD (_set_router_raw);
-    static NAN_METHOD (_ipv4only);
-    static NAN_METHOD (_set_ipv4only);
-    static NAN_METHOD (_set_delay_attach_on_connect);
     static NAN_METHOD (_type);
     static NAN_METHOD (_sndhwm);
     static NAN_METHOD (_set_sndhwm);
@@ -732,6 +728,10 @@ class Zsock: public Nan::ObjectWrap {
     static NAN_METHOD (_rcvmore);
     static NAN_METHOD (_events);
     static NAN_METHOD (_last_endpoint);
+    static NAN_METHOD (_set_router_raw);
+    static NAN_METHOD (_ipv4only);
+    static NAN_METHOD (_set_ipv4only);
+    static NAN_METHOD (_set_delay_attach_on_connect);
     static NAN_METHOD (_test);
 };
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -5004,14 +5004,6 @@ lib.zsock_immediate.restype = c_int
 lib.zsock_immediate.argtypes = [zsock_p]
 lib.zsock_set_immediate.restype = None
 lib.zsock_set_immediate.argtypes = [zsock_p, c_int]
-lib.zsock_set_router_raw.restype = None
-lib.zsock_set_router_raw.argtypes = [zsock_p, c_int]
-lib.zsock_ipv4only.restype = c_int
-lib.zsock_ipv4only.argtypes = [zsock_p]
-lib.zsock_set_ipv4only.restype = None
-lib.zsock_set_ipv4only.argtypes = [zsock_p, c_int]
-lib.zsock_set_delay_attach_on_connect.restype = None
-lib.zsock_set_delay_attach_on_connect.argtypes = [zsock_p, c_int]
 lib.zsock_type.restype = c_int
 lib.zsock_type.argtypes = [zsock_p]
 lib.zsock_sndhwm.restype = c_int
@@ -5112,6 +5104,14 @@ lib.zsock_events.restype = c_int
 lib.zsock_events.argtypes = [zsock_p]
 lib.zsock_last_endpoint.restype = POINTER(c_char)
 lib.zsock_last_endpoint.argtypes = [zsock_p]
+lib.zsock_set_router_raw.restype = None
+lib.zsock_set_router_raw.argtypes = [zsock_p, c_int]
+lib.zsock_ipv4only.restype = c_int
+lib.zsock_ipv4only.argtypes = [zsock_p]
+lib.zsock_set_ipv4only.restype = None
+lib.zsock_set_ipv4only.argtypes = [zsock_p, c_int]
+lib.zsock_set_delay_attach_on_connect.restype = None
+lib.zsock_set_delay_attach_on_connect.argtypes = [zsock_p, c_int]
 lib.zsock_test.restype = None
 lib.zsock_test.argtypes = [c_bool]
 
@@ -6024,30 +6024,6 @@ return the supplied value. Takes a polymorphic socket reference.
         """
         return lib.zsock_set_immediate(self._as_parameter_, immediate)
 
-    def set_router_raw(self, router_raw):
-        """
-        Set socket option `router_raw`.
-        """
-        return lib.zsock_set_router_raw(self._as_parameter_, router_raw)
-
-    def ipv4only(self):
-        """
-        Get socket option `ipv4only`.
-        """
-        return lib.zsock_ipv4only(self._as_parameter_)
-
-    def set_ipv4only(self, ipv4only):
-        """
-        Set socket option `ipv4only`.
-        """
-        return lib.zsock_set_ipv4only(self._as_parameter_, ipv4only)
-
-    def set_delay_attach_on_connect(self, delay_attach_on_connect):
-        """
-        Set socket option `delay_attach_on_connect`.
-        """
-        return lib.zsock_set_delay_attach_on_connect(self._as_parameter_, delay_attach_on_connect)
-
     def type(self):
         """
         Get socket option `type`.
@@ -6347,6 +6323,30 @@ return the supplied value. Takes a polymorphic socket reference.
         Get socket option `last_endpoint`.
         """
         return return_fresh_string(lib.zsock_last_endpoint(self._as_parameter_))
+
+    def set_router_raw(self, router_raw):
+        """
+        Set socket option `router_raw`.
+        """
+        return lib.zsock_set_router_raw(self._as_parameter_, router_raw)
+
+    def ipv4only(self):
+        """
+        Get socket option `ipv4only`.
+        """
+        return lib.zsock_ipv4only(self._as_parameter_)
+
+    def set_ipv4only(self, ipv4only):
+        """
+        Set socket option `ipv4only`.
+        """
+        return lib.zsock_set_ipv4only(self._as_parameter_, ipv4only)
+
+    def set_delay_attach_on_connect(self, delay_attach_on_connect):
+        """
+        Set socket option `delay_attach_on_connect`.
+        """
+        return lib.zsock_set_delay_attach_on_connect(self._as_parameter_, delay_attach_on_connect)
 
     @staticmethod
     def test(verbose):

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -2867,22 +2867,6 @@ int
 void
     zsock_set_immediate (void *self, int immediate);
 
-// Set socket option `router_raw`.
-void
-    zsock_set_router_raw (void *self, int router_raw);
-
-// Get socket option `ipv4only`.
-int
-    zsock_ipv4only (void *self);
-
-// Set socket option `ipv4only`.
-void
-    zsock_set_ipv4only (void *self, int ipv4only);
-
-// Set socket option `delay_attach_on_connect`.
-void
-    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
-
 // Get socket option `type`.
 int
     zsock_type (void *self);
@@ -3082,6 +3066,22 @@ int
 // Get socket option `last_endpoint`.
 char *
     zsock_last_endpoint (void *self);
+
+// Set socket option `router_raw`.
+void
+    zsock_set_router_raw (void *self, int router_raw);
+
+// Get socket option `ipv4only`.
+int
+    zsock_ipv4only (void *self);
+
+// Set socket option `ipv4only`.
+void
+    zsock_set_ipv4only (void *self, int ipv4only);
+
+// Set socket option `delay_attach_on_connect`.
+void
+    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 
 // Self test of this class.
 void

--- a/bindings/qml/src/QmlZsock.cpp
+++ b/bindings/qml/src/QmlZsock.cpp
@@ -746,30 +746,6 @@ void QmlZsock::setImmediate (int immediate) {
 };
 
 ///
-//  Set socket option `router_raw`.
-void QmlZsock::setRouterRaw (int routerRaw) {
-    zsock_set_router_raw (self, routerRaw);
-};
-
-///
-//  Get socket option `ipv4only`.
-int QmlZsock::ipv4only () {
-    return zsock_ipv4only (self);
-};
-
-///
-//  Set socket option `ipv4only`.
-void QmlZsock::setIpv4only (int ipv4only) {
-    zsock_set_ipv4only (self, ipv4only);
-};
-
-///
-//  Set socket option `delay_attach_on_connect`.
-void QmlZsock::setDelayAttachOnConnect (int delayAttachOnConnect) {
-    zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);
-};
-
-///
 //  Get socket option `type`.
 int QmlZsock::type () {
     return zsock_type (self);
@@ -1076,6 +1052,30 @@ QString QmlZsock::lastEndpoint () {
     QString retQStr_ = QString (retStr_);
     free (retStr_);
     return retQStr_;
+};
+
+///
+//  Set socket option `router_raw`.
+void QmlZsock::setRouterRaw (int routerRaw) {
+    zsock_set_router_raw (self, routerRaw);
+};
+
+///
+//  Get socket option `ipv4only`.
+int QmlZsock::ipv4only () {
+    return zsock_ipv4only (self);
+};
+
+///
+//  Set socket option `ipv4only`.
+void QmlZsock::setIpv4only (int ipv4only) {
+    zsock_set_ipv4only (self, ipv4only);
+};
+
+///
+//  Set socket option `delay_attach_on_connect`.
+void QmlZsock::setDelayAttachOnConnect (int delayAttachOnConnect) {
+    zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);
 };
 
 

--- a/bindings/qml/src/QmlZsock.h
+++ b/bindings/qml/src/QmlZsock.h
@@ -447,18 +447,6 @@ public slots:
     //  Set socket option `immediate`.
     void setImmediate (int immediate);
 
-    //  Set socket option `router_raw`.
-    void setRouterRaw (int routerRaw);
-
-    //  Get socket option `ipv4only`.
-    int ipv4only ();
-
-    //  Set socket option `ipv4only`.
-    void setIpv4only (int ipv4only);
-
-    //  Set socket option `delay_attach_on_connect`.
-    void setDelayAttachOnConnect (int delayAttachOnConnect);
-
     //  Get socket option `type`.
     int type ();
 
@@ -608,6 +596,18 @@ public slots:
 
     //  Get socket option `last_endpoint`.
     QString lastEndpoint ();
+
+    //  Set socket option `router_raw`.
+    void setRouterRaw (int routerRaw);
+
+    //  Get socket option `ipv4only`.
+    int ipv4only ();
+
+    //  Set socket option `ipv4only`.
+    void setIpv4only (int ipv4only);
+
+    //  Set socket option `delay_attach_on_connect`.
+    void setDelayAttachOnConnect (int delayAttachOnConnect);
 };
 
 class QmlZsockAttached : public QObject

--- a/bindings/qt/src/qzsock.cpp
+++ b/bindings/qt/src/qzsock.cpp
@@ -1065,38 +1065,6 @@ void QZsock::setImmediate (int immediate)
 }
 
 ///
-//  Set socket option `router_raw`.
-void QZsock::setRouterRaw (int routerRaw)
-{
-    zsock_set_router_raw (self, routerRaw);
-    
-}
-
-///
-//  Get socket option `ipv4only`.
-int QZsock::ipv4only ()
-{
-    int rv = zsock_ipv4only (self);
-    return rv;
-}
-
-///
-//  Set socket option `ipv4only`.
-void QZsock::setIpv4only (int ipv4only)
-{
-    zsock_set_ipv4only (self, ipv4only);
-    
-}
-
-///
-//  Set socket option `delay_attach_on_connect`.
-void QZsock::setDelayAttachOnConnect (int delayAttachOnConnect)
-{
-    zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);
-    
-}
-
-///
 //  Get socket option `type`.
 int QZsock::type ()
 {
@@ -1500,6 +1468,38 @@ QString QZsock::lastEndpoint ()
     QString rv = QString (retStr_);
     zstr_free (&retStr_);
     return rv;
+}
+
+///
+//  Set socket option `router_raw`.
+void QZsock::setRouterRaw (int routerRaw)
+{
+    zsock_set_router_raw (self, routerRaw);
+    
+}
+
+///
+//  Get socket option `ipv4only`.
+int QZsock::ipv4only ()
+{
+    int rv = zsock_ipv4only (self);
+    return rv;
+}
+
+///
+//  Set socket option `ipv4only`.
+void QZsock::setIpv4only (int ipv4only)
+{
+    zsock_set_ipv4only (self, ipv4only);
+    
+}
+
+///
+//  Set socket option `delay_attach_on_connect`.
+void QZsock::setDelayAttachOnConnect (int delayAttachOnConnect)
+{
+    zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);
+    
 }
 
 ///

--- a/bindings/qt/src/qzsock.h
+++ b/bindings/qt/src/qzsock.h
@@ -477,18 +477,6 @@ public:
     //  Set socket option `immediate`.
     void setImmediate (int immediate);
 
-    //  Set socket option `router_raw`.
-    void setRouterRaw (int routerRaw);
-
-    //  Get socket option `ipv4only`.
-    int ipv4only ();
-
-    //  Set socket option `ipv4only`.
-    void setIpv4only (int ipv4only);
-
-    //  Set socket option `delay_attach_on_connect`.
-    void setDelayAttachOnConnect (int delayAttachOnConnect);
-
     //  Get socket option `type`.
     int type ();
 
@@ -638,6 +626,18 @@ public:
 
     //  Get socket option `last_endpoint`.
     QString lastEndpoint ();
+
+    //  Set socket option `router_raw`.
+    void setRouterRaw (int routerRaw);
+
+    //  Get socket option `ipv4only`.
+    int ipv4only ();
+
+    //  Set socket option `ipv4only`.
+    void setIpv4only (int ipv4only);
+
+    //  Set socket option `delay_attach_on_connect`.
+    void setDelayAttachOnConnect (int delayAttachOnConnect);
 
     //  Self test of this class.
     static void test (bool verbose);

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -1015,10 +1015,6 @@ module CZMQ
       attach_function :zsock_set_ipv6, [:pointer, :int], :void, **opts
       attach_function :zsock_immediate, [:pointer], :int, **opts
       attach_function :zsock_set_immediate, [:pointer, :int], :void, **opts
-      attach_function :zsock_set_router_raw, [:pointer, :int], :void, **opts
-      attach_function :zsock_ipv4only, [:pointer], :int, **opts
-      attach_function :zsock_set_ipv4only, [:pointer, :int], :void, **opts
-      attach_function :zsock_set_delay_attach_on_connect, [:pointer, :int], :void, **opts
       attach_function :zsock_type, [:pointer], :int, **opts
       attach_function :zsock_sndhwm, [:pointer], :int, **opts
       attach_function :zsock_set_sndhwm, [:pointer, :int], :void, **opts
@@ -1069,6 +1065,10 @@ module CZMQ
       attach_function :zsock_fd, [:pointer], (::FFI::Platform.unix? ? :int : :uint64_t), **opts
       attach_function :zsock_events, [:pointer], :int, **opts
       attach_function :zsock_last_endpoint, [:pointer], :pointer, **opts
+      attach_function :zsock_set_router_raw, [:pointer, :int], :void, **opts
+      attach_function :zsock_ipv4only, [:pointer], :int, **opts
+      attach_function :zsock_set_ipv4only, [:pointer, :int], :void, **opts
+      attach_function :zsock_set_delay_attach_on_connect, [:pointer, :int], :void, **opts
       attach_function :zsock_test, [:bool], :void, **opts
 
       require_relative 'ffi/zsock'

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -2818,110 +2818,6 @@ module CZMQ
         result
       end
 
-      # Set socket option `router_raw`.
-      #
-      # @param router_raw [Integer, #to_int, #to_i]
-      # @return [void]
-      def set_router_raw(router_raw)
-        raise DestroyedError unless @ptr
-        self_p = @ptr
-        router_raw = Integer(router_raw)
-        result = ::CZMQ::FFI.zsock_set_router_raw(self_p, router_raw)
-        result
-      end
-
-      # Set socket option `router_raw`.
-      #
-      # This is the polymorphic version of #set_router_raw.
-      #
-      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
-      #   object reference to use this method on
-      # @param router_raw [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_router_raw(self_p, router_raw)
-        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
-        router_raw = Integer(router_raw)
-        result = ::CZMQ::FFI.zsock_set_router_raw(self_p, router_raw)
-        result
-      end
-
-      # Get socket option `ipv4only`.
-      #
-      # @return [Integer]
-      def ipv4only()
-        raise DestroyedError unless @ptr
-        self_p = @ptr
-        result = ::CZMQ::FFI.zsock_ipv4only(self_p)
-        result
-      end
-
-      # Get socket option `ipv4only`.
-      #
-      # This is the polymorphic version of #ipv4only.
-      #
-      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
-      #   object reference to use this method on
-      # @return [Integer]
-      def self.ipv4only(self_p)
-        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
-        result = ::CZMQ::FFI.zsock_ipv4only(self_p)
-        result
-      end
-
-      # Set socket option `ipv4only`.
-      #
-      # @param ipv4only [Integer, #to_int, #to_i]
-      # @return [void]
-      def set_ipv4only(ipv4only)
-        raise DestroyedError unless @ptr
-        self_p = @ptr
-        ipv4only = Integer(ipv4only)
-        result = ::CZMQ::FFI.zsock_set_ipv4only(self_p, ipv4only)
-        result
-      end
-
-      # Set socket option `ipv4only`.
-      #
-      # This is the polymorphic version of #set_ipv4only.
-      #
-      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
-      #   object reference to use this method on
-      # @param ipv4only [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_ipv4only(self_p, ipv4only)
-        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
-        ipv4only = Integer(ipv4only)
-        result = ::CZMQ::FFI.zsock_set_ipv4only(self_p, ipv4only)
-        result
-      end
-
-      # Set socket option `delay_attach_on_connect`.
-      #
-      # @param delay_attach_on_connect [Integer, #to_int, #to_i]
-      # @return [void]
-      def set_delay_attach_on_connect(delay_attach_on_connect)
-        raise DestroyedError unless @ptr
-        self_p = @ptr
-        delay_attach_on_connect = Integer(delay_attach_on_connect)
-        result = ::CZMQ::FFI.zsock_set_delay_attach_on_connect(self_p, delay_attach_on_connect)
-        result
-      end
-
-      # Set socket option `delay_attach_on_connect`.
-      #
-      # This is the polymorphic version of #set_delay_attach_on_connect.
-      #
-      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
-      #   object reference to use this method on
-      # @param delay_attach_on_connect [Integer, #to_int, #to_i]
-      # @return [void]
-      def self.set_delay_attach_on_connect(self_p, delay_attach_on_connect)
-        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
-        delay_attach_on_connect = Integer(delay_attach_on_connect)
-        result = ::CZMQ::FFI.zsock_set_delay_attach_on_connect(self_p, delay_attach_on_connect)
-        result
-      end
-
       # Get socket option `type`.
       #
       # @return [Integer]
@@ -4163,6 +4059,110 @@ module CZMQ
         self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
         result = ::CZMQ::FFI.zsock_last_endpoint(self_p)
         result = ::FFI::AutoPointer.new(result, LibC.method(:free))
+        result
+      end
+
+      # Set socket option `router_raw`.
+      #
+      # @param router_raw [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_router_raw(router_raw)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        router_raw = Integer(router_raw)
+        result = ::CZMQ::FFI.zsock_set_router_raw(self_p, router_raw)
+        result
+      end
+
+      # Set socket option `router_raw`.
+      #
+      # This is the polymorphic version of #set_router_raw.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param router_raw [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_router_raw(self_p, router_raw)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        router_raw = Integer(router_raw)
+        result = ::CZMQ::FFI.zsock_set_router_raw(self_p, router_raw)
+        result
+      end
+
+      # Get socket option `ipv4only`.
+      #
+      # @return [Integer]
+      def ipv4only()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zsock_ipv4only(self_p)
+        result
+      end
+
+      # Get socket option `ipv4only`.
+      #
+      # This is the polymorphic version of #ipv4only.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @return [Integer]
+      def self.ipv4only(self_p)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        result = ::CZMQ::FFI.zsock_ipv4only(self_p)
+        result
+      end
+
+      # Set socket option `ipv4only`.
+      #
+      # @param ipv4only [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_ipv4only(ipv4only)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        ipv4only = Integer(ipv4only)
+        result = ::CZMQ::FFI.zsock_set_ipv4only(self_p, ipv4only)
+        result
+      end
+
+      # Set socket option `ipv4only`.
+      #
+      # This is the polymorphic version of #set_ipv4only.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param ipv4only [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_ipv4only(self_p, ipv4only)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        ipv4only = Integer(ipv4only)
+        result = ::CZMQ::FFI.zsock_set_ipv4only(self_p, ipv4only)
+        result
+      end
+
+      # Set socket option `delay_attach_on_connect`.
+      #
+      # @param delay_attach_on_connect [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_delay_attach_on_connect(delay_attach_on_connect)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        delay_attach_on_connect = Integer(delay_attach_on_connect)
+        result = ::CZMQ::FFI.zsock_set_delay_attach_on_connect(self_p, delay_attach_on_connect)
+        result
+      end
+
+      # Set socket option `delay_attach_on_connect`.
+      #
+      # This is the polymorphic version of #set_delay_attach_on_connect.
+      #
+      # @param self_p [CZMQ::Zsock, #__ptr, ::FFI::Pointer, nil]
+      #   object reference to use this method on
+      # @param delay_attach_on_connect [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_delay_attach_on_connect(self_p, delay_attach_on_connect)
+        self_p = self_p.__ptr if self_p.respond_to?(:__ptr)
+        delay_attach_on_connect = Integer(delay_attach_on_connect)
+        result = ::CZMQ::FFI.zsock_set_delay_attach_on_connect(self_p, delay_attach_on_connect)
         result
       end
 

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -633,23 +633,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zsock_set_immediate (void *self, int immediate);
 
-//  Set socket option `router_raw`.
-CZMQ_EXPORT void
-    zsock_set_router_raw (void *self, int router_raw);
-
-//  Get socket option `ipv4only`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_ipv4only (void *self);
-
-//  Set socket option `ipv4only`.
-CZMQ_EXPORT void
-    zsock_set_ipv4only (void *self, int ipv4only);
-
-//  Set socket option `delay_attach_on_connect`.
-CZMQ_EXPORT void
-    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
-
 //  Get socket option `type`.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
@@ -875,6 +858,23 @@ CZMQ_EXPORT int
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_last_endpoint (void *self);
+
+//  Set socket option `router_raw`.
+CZMQ_EXPORT void
+    zsock_set_router_raw (void *self, int router_raw);
+
+//  Get socket option `ipv4only`.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_ipv4only (void *self);
+
+//  Set socket option `ipv4only`.
+CZMQ_EXPORT void
+    zsock_set_ipv4only (void *self, int ipv4only);
+
+//  Set socket option `delay_attach_on_connect`.
+CZMQ_EXPORT void
+    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 
 //  Self test of this class.
 CZMQ_EXPORT void

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -8,7 +8,7 @@
     License, v. 2.0. If a copy of the MPL was not distributed with this
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
     -->
-    <version major = "4" style = "macro">
+    <version major = "4" minor = "2" style = "macro">
         <!-- Options that are new in 4.2 -->
         <option name = "heartbeat_ivl"     type = "int"    mode = "rw" test = "DEALER"
             test_value = "2000" />
@@ -54,7 +54,9 @@
         <option name = "vmci_buffer_min_size" type = "uint64" mode = "rw" />
         <option name = "vmci_buffer_max_size" type = "uint64" mode = "rw" />
         <option name = "vmci_connect_timeout" type = "int" mode = "rw" />
+    </version>
 
+    <version major = "4" minor = "1" style = "macro">
         <!-- Options that are new in 4.1 -->
         <option name = "tos"               type = "int"    mode = "rw" test = "DEALER" />
         <option name = "router_handover"   type = "int"    mode = "w"  test = "ROUTER">
@@ -74,7 +76,9 @@
             <restrict type = "XPUB" />
             <restrict type = "PUB" />
         </option>
-        
+    </version>
+
+    <version major = "4" style = "macro">
         <!-- Options that are new in 4.0 -->
         <option name = "router_mandatory"  type = "int"    mode = "w"  test = "ROUTER">
             <restrict type = "ROUTER" />
@@ -122,63 +126,10 @@
         <!-- New names for deprecated 3.x options -->
         <option name = "ipv6"              type = "int"    mode = "rw" test = "SUB" />
         <option name = "immediate"         type = "int"    mode = "rw" test = "DEALER" />
-
-        <!-- Deprecated 3.x options -->
-        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
-        </option>
-        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
-        <option name = "delay_attach_on_connect"
-                                           type = "int"    mode = "w"  test = "PUB" />
-
-        <!-- Options that are the same in 3.x -->
-        <include name = "3-x options" />
     </version>
     
     <version major = "3" style = "macro">
         <!-- Options that are carried forward to 4.0 -->
-        <include name = "3-x options" />
-        
-        <!-- Options that are deprecated in 4.0 -->
-        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
-        </option>
-        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
-        <option name = "delay_attach_on_connect"
-                                           type = "int"    mode = "w"  test = "PUB" />
-    </version>
-
-    <!-- Legacy version 2 -->
-    <version major = "2" style = "macro">
-        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "identity"          type = "string" mode = "rw" test = "SUB" />
-        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
-        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
-        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
-        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
-        </option>
-        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
-        </option>
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
-        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" />
-        <option name = "fd"                type = "socket" mode = "r"  test = "SUB" />
-        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" />
-    </version>
-    
-    <macro name = "3-x options">
         <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
         <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />
         <option name = "rcvhwm"            type = "int"    mode = "rw" test = "SUB" />
@@ -222,5 +173,43 @@
         <option name = "fd"                type = "socket" mode = "r"  test = "SUB" />
         <option name = "events"            type = "int"    mode = "r"  test = "SUB" />
         <option name = "last_endpoint"     type = "string" mode = "r"  test = "SUB" />
-    </macro>
+
+        <!-- Options that are deprecated in 4.0 -->
+        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER" >
+            <restrict type = "ROUTER" />
+        </option>
+        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "delay_attach_on_connect"
+                                           type = "int"    mode = "w"  test = "PUB" />
+    </version>
+
+    <!-- Legacy version 2 -->
+    <version major = "2" major_removed = "3" style = "macro">
+        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "identity"          type = "string" mode = "rw" test = "SUB" />
+        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
+        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
+        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
+        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
+        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
+        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
+        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
+            <restrict type = "SUB" />
+        </option>
+        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
+            <restrict type = "SUB" />
+        </option>
+        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
+        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" />
+        <option name = "fd"                type = "socket" mode = "r"  test = "SUB" />
+        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" />
+    </version>
 </options>

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -18,7 +18,58 @@
 .  endif
 .  return ''
 .endfunction
-.for version where major = "4"
+.macro runtime_check(version, option, return)
+.   if defined (my.option.major)
+.      my.major = my.option.major
+.   else
+.      my.major = my.version.major
+.   endif
+.   if defined (my.option.minor)
+.      my.minor = my.option.minor
+.   elsif defined (my.version.minor)
+.      my.minor = my.version.minor
+.   else
+.      my.minor = 0
+.   endif
+.   if defined (my.option.major_removed)
+.      my.major_removed = my.option.major_removed
+.   elsif defined (my.version.major_removed)
+.      my.major_removed = my.version.major_removed
+.   endif
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION ($(my.major), $(my.minor), 0)\
+.   if defined (my.major_removed)
+
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION ($(my.major_removed), 0, 0)\
+.   endif
+) {
+        zsys_error ("zsock $(my.option.name) option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= $(my.major).$(my.minor).0\
+.   if defined (my.major_removed)
+ and < $(my.major_removed).0.0\
+.   endif
+\\n", major, minor, patch, NULL);
+.   if defined (my.return)
+        return $(my.return);
+.   else
+        return;
+.   endif
+    }
+.endmacro
+.# The bindings break against the latest version if a symbol cannot be found
+.for version where ! defined (major_removed)
+
+<!-- The following socket options are available in libzmq from version $(major).\
+.   if defined (.minor)
+$(minor).0 \
+.   else
+0.0 \
+.   endif
+.   if defined (.major_removed)
+to $(major_removed).0.0 \
+.   endif
+-->
 .   for option
 .       if mode = "rw" | mode = "r"
 
@@ -66,11 +117,18 @@
 */
 
 .for version
-#if (ZMQ_VERSION_MAJOR == $(major))
-.   for option
-.       if defined (.minor)
-#   if (ZMQ_VERSION_MINOR == $(minor))
-.       endif
+.   if defined (.major_removed)
+#if (ZMQ_VERSION_MAJOR >= $(major)) && (ZMQ_VERSION_MAJOR < $(major_removed))
+.   else
+#if (ZMQ_VERSION_MAJOR >= $(major))
+.   endif
+.   if defined (.minor)
+#   if (ZMQ_VERSION_MINOR >= $(minor))
+.   endif
+.       for option
+.           if defined (option.major_removed)
+#   if (ZMQ_VERSION_MAJOR < $(option.major_removed))
+.           endif
 .       if mode = "rw" | mode = "w"
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_$(NAME) value
@@ -83,6 +141,7 @@ zsock_set_$(name) (void *self, $(ctype_const:) $(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
+.       runtime_check (version, option)
 .           if count (restrict)
 .               for restrict
 .                   if first()
@@ -134,6 +193,7 @@ zsock_set_$(name)_bin (void *self, const byte *$(name))
 .       if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .       endif
+.       runtime_check (version, option)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), 32);
     assert (rc == 0 || zmq_errno () == ETERM);
 .       if style = "macro"
@@ -156,6 +216,7 @@ zsock_$(name) (void *self)
 .           if style = "macro"
 #   if defined (ZMQ_$(NAME))
 .           endif
+.       runtime_check (version, option, 0)
 .           if type = "uint64"
     uint64_t $(name);
     size_t option_len = sizeof (uint64_t);
@@ -202,10 +263,13 @@ zsock_$(name) (void *self)
 }
 
 .       endif
-.       if defined (.minor)
+.           if defined (option.major_removed)
 #   endif
-.       endif
-.   endfor
+.           endif
+.       endfor
+.   if defined (.minor)
+#   endif
+.   endif
 .   for source
 $(string.trim(.):)
 
@@ -225,10 +289,17 @@ zsock_option_test (bool verbose)
     //  @selftest
     zsock_t *self;
 .for version
-#if (ZMQ_VERSION_MAJOR == $(major))
+.   if defined (.major_removed)
+#if (ZMQ_VERSION_MAJOR >= $(major)) && (ZMQ_VERSION_MAJOR < $(major_removed))
+.   else
+#if (ZMQ_VERSION_MAJOR >= $(major))
+.   endif
+.   if defined (.minor)
+#   if (ZMQ_VERSION_MINOR >= $(minor))
+.   endif
 .   for option where defined (test)
-.       if defined (.minor)
-#   if (ZMQ_VERSION_MINOR == $(minor))
+.       if defined (option.major_removed)
+#   if (ZMQ_VERSION_MAJOR < $(option.major_removed))
 .       endif
 .       if style = "macro"
 #     if defined (ZMQ_$(NAME))
@@ -258,15 +329,18 @@ zsock_option_test (bool verbose)
 .       if style = "macro"
 #     endif
 .       endif
-.       if defined (.minor)
+.       if defined (option.major_removed)
 #   endif
 .       endif
 .   endfor
+.   if defined (.minor)
+#   endif
+.   endif
+#endif
 .   for selftest
 
 $(string.trim(.):)
 .   endfor
-#endif
 
 .endfor
     //  @end

--- a/src/zsock_option.inc
+++ b/src/zsock_option.inc
@@ -19,7 +19,8 @@
     =========================================================================
 */
 
-#if (ZMQ_VERSION_MAJOR == 4)
+#if (ZMQ_VERSION_MAJOR >= 4)
+#   if (ZMQ_VERSION_MINOR >= 2)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_HEARTBEAT_IVL value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -29,6 +30,13 @@ zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -44,6 +52,13 @@ zsock_heartbeat_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int heartbeat_ivl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, &option_len);
@@ -62,6 +77,13 @@ zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_TTL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_ttl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -77,6 +99,13 @@ zsock_heartbeat_ttl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_TTL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_ttl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int heartbeat_ttl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TTL, &heartbeat_ttl, &option_len);
@@ -95,6 +124,13 @@ zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -110,6 +146,13 @@ zsock_heartbeat_timeout (void *self)
 {
     assert (self);
 #   if defined (ZMQ_HEARTBEAT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock heartbeat_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int heartbeat_timeout;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_HEARTBEAT_TIMEOUT, &heartbeat_timeout, &option_len);
@@ -128,6 +171,13 @@ zsock_set_use_fd (void *self, int use_fd)
 {
     assert (self);
 #   if defined (ZMQ_USE_FD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock use_fd option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_USE_FD, &use_fd, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -143,6 +193,13 @@ zsock_use_fd (void *self)
 {
     assert (self);
 #   if defined (ZMQ_USE_FD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock use_fd option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int use_fd;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_USE_FD, &use_fd, &option_len);
@@ -161,6 +218,13 @@ zsock_set_xpub_manual (void *self, int xpub_manual)
 {
     assert (self);
 #   if defined (ZMQ_XPUB_MANUAL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock xpub_manual option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB) {
         printf ("ZMQ_XPUB_MANUAL is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -180,6 +244,13 @@ zsock_set_xpub_welcome_msg (void *self, const char * xpub_welcome_msg)
 {
     assert (self);
 #   if defined (ZMQ_XPUB_WELCOME_MSG)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock xpub_welcome_msg option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB) {
         printf ("ZMQ_XPUB_WELCOME_MSG is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -199,6 +270,13 @@ zsock_set_stream_notify (void *self, int stream_notify)
 {
     assert (self);
 #   if defined (ZMQ_STREAM_NOTIFY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock stream_notify option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_STREAM) {
         printf ("ZMQ_STREAM_NOTIFY is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -218,6 +296,13 @@ zsock_set_invert_matching (void *self, int invert_matching)
 {
     assert (self);
 #   if defined (ZMQ_INVERT_MATCHING)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock invert_matching option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB
     &&  zsock_type (self) != ZMQ_PUB
     &&  zsock_type (self) != ZMQ_SUB) {
@@ -239,6 +324,13 @@ zsock_invert_matching (void *self)
 {
     assert (self);
 #   if defined (ZMQ_INVERT_MATCHING)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock invert_matching option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int invert_matching;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_INVERT_MATCHING, &invert_matching, &option_len);
@@ -257,6 +349,13 @@ zsock_set_xpub_verboser (void *self, int xpub_verboser)
 {
     assert (self);
 #   if defined (ZMQ_XPUB_VERBOSER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock xpub_verboser option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB) {
         printf ("ZMQ_XPUB_VERBOSER is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -276,6 +375,13 @@ zsock_set_connect_timeout (void *self, int connect_timeout)
 {
     assert (self);
 #   if defined (ZMQ_CONNECT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock connect_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CONNECT_TIMEOUT, &connect_timeout, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -291,6 +397,13 @@ zsock_connect_timeout (void *self)
 {
     assert (self);
 #   if defined (ZMQ_CONNECT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock connect_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int connect_timeout;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_CONNECT_TIMEOUT, &connect_timeout, &option_len);
@@ -309,6 +422,13 @@ zsock_set_tcp_maxrt (void *self, int tcp_maxrt)
 {
     assert (self);
 #   if defined (ZMQ_TCP_MAXRT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock tcp_maxrt option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_MAXRT, &tcp_maxrt, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -324,6 +444,13 @@ zsock_tcp_maxrt (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_MAXRT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock tcp_maxrt option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tcp_maxrt;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_MAXRT, &tcp_maxrt, &option_len);
@@ -342,6 +469,13 @@ zsock_thread_safe (void *self)
 {
     assert (self);
 #   if defined (ZMQ_THREAD_SAFE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock thread_safe option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int thread_safe;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_THREAD_SAFE, &thread_safe, &option_len);
@@ -360,6 +494,13 @@ zsock_set_multicast_maxtpdu (void *self, int multicast_maxtpdu)
 {
     assert (self);
 #   if defined (ZMQ_MULTICAST_MAXTPDU)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock multicast_maxtpdu option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MULTICAST_MAXTPDU, &multicast_maxtpdu, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -375,6 +516,13 @@ zsock_multicast_maxtpdu (void *self)
 {
     assert (self);
 #   if defined (ZMQ_MULTICAST_MAXTPDU)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock multicast_maxtpdu option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int multicast_maxtpdu;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MULTICAST_MAXTPDU, &multicast_maxtpdu, &option_len);
@@ -393,6 +541,13 @@ zsock_set_vmci_buffer_size (void *self, int vmci_buffer_size)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = vmci_buffer_size;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_SIZE, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -409,6 +564,13 @@ zsock_vmci_buffer_size (void *self)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t vmci_buffer_size;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_SIZE, &vmci_buffer_size, &option_len);
@@ -427,6 +589,13 @@ zsock_set_vmci_buffer_min_size (void *self, int vmci_buffer_min_size)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_MIN_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_min_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = vmci_buffer_min_size;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_MIN_SIZE, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -443,6 +612,13 @@ zsock_vmci_buffer_min_size (void *self)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_MIN_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_min_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t vmci_buffer_min_size;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_MIN_SIZE, &vmci_buffer_min_size, &option_len);
@@ -461,6 +637,13 @@ zsock_set_vmci_buffer_max_size (void *self, int vmci_buffer_max_size)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_MAX_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_max_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = vmci_buffer_max_size;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_MAX_SIZE, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -477,6 +660,13 @@ zsock_vmci_buffer_max_size (void *self)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_BUFFER_MAX_SIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_buffer_max_size option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t vmci_buffer_max_size;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_VMCI_BUFFER_MAX_SIZE, &vmci_buffer_max_size, &option_len);
@@ -495,6 +685,13 @@ zsock_set_vmci_connect_timeout (void *self, int vmci_connect_timeout)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_CONNECT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_connect_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_VMCI_CONNECT_TIMEOUT, &vmci_connect_timeout, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -510,6 +707,13 @@ zsock_vmci_connect_timeout (void *self)
 {
     assert (self);
 #   if defined (ZMQ_VMCI_CONNECT_TIMEOUT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 2, 0)) {
+        zsys_error ("zsock vmci_connect_timeout option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.2.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int vmci_connect_timeout;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_VMCI_CONNECT_TIMEOUT, &vmci_connect_timeout, &option_len);
@@ -519,6 +723,11 @@ zsock_vmci_connect_timeout (void *self)
 #   endif
 }
 
+#   endif
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 4)
+#   if (ZMQ_VERSION_MINOR >= 1)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_TOS value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -528,6 +737,13 @@ zsock_set_tos (void *self, int tos)
 {
     assert (self);
 #   if defined (ZMQ_TOS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock tos option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TOS, &tos, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -543,6 +759,13 @@ zsock_tos (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TOS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock tos option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tos;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TOS, &tos, &option_len);
@@ -561,6 +784,13 @@ zsock_set_router_handover (void *self, int router_handover)
 {
     assert (self);
 #   if defined (ZMQ_ROUTER_HANDOVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock router_handover option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_ROUTER) {
         printf ("ZMQ_ROUTER_HANDOVER is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -580,6 +810,13 @@ zsock_set_connect_rid (void *self, const char * connect_rid)
 {
     assert (self);
 #   if defined (ZMQ_CONNECT_RID)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock connect_rid option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_ROUTER
     &&  zsock_type (self) != ZMQ_STREAM) {
         printf ("ZMQ_CONNECT_RID is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
@@ -599,6 +836,13 @@ void
 zsock_set_connect_rid_bin (void *self, const byte *connect_rid)
 {
 #   if defined (ZMQ_CONNECT_RID)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock connect_rid option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CONNECT_RID, connect_rid, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -614,6 +858,13 @@ zsock_set_handshake_ivl (void *self, int handshake_ivl)
 {
     assert (self);
 #   if defined (ZMQ_HANDSHAKE_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock handshake_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HANDSHAKE_IVL, &handshake_ivl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -629,6 +880,13 @@ zsock_handshake_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_HANDSHAKE_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock handshake_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int handshake_ivl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_HANDSHAKE_IVL, &handshake_ivl, &option_len);
@@ -647,6 +905,13 @@ zsock_set_socks_proxy (void *self, const char * socks_proxy)
 {
     assert (self);
 #   if defined (ZMQ_SOCKS_PROXY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock socks_proxy option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SOCKS_PROXY, socks_proxy, strlen (socks_proxy));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -662,6 +927,13 @@ zsock_socks_proxy (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SOCKS_PROXY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock socks_proxy option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *socks_proxy = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SOCKS_PROXY, socks_proxy, &option_len);
@@ -680,6 +952,13 @@ zsock_set_xpub_nodrop (void *self, int xpub_nodrop)
 {
     assert (self);
 #   if defined (ZMQ_XPUB_NODROP)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 1, 0)) {
+        zsys_error ("zsock xpub_nodrop option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.1.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB
     &&  zsock_type (self) != ZMQ_PUB) {
         printf ("ZMQ_XPUB_NODROP is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
@@ -691,6 +970,10 @@ zsock_set_xpub_nodrop (void *self, int xpub_nodrop)
 }
 
 
+#   endif
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 4)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_ROUTER_MANDATORY value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -700,6 +983,13 @@ zsock_set_router_mandatory (void *self, int router_mandatory)
 {
     assert (self);
 #   if defined (ZMQ_ROUTER_MANDATORY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock router_mandatory option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_ROUTER) {
         printf ("ZMQ_ROUTER_MANDATORY is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -719,6 +1009,13 @@ zsock_set_probe_router (void *self, int probe_router)
 {
     assert (self);
 #   if defined (ZMQ_PROBE_ROUTER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock probe_router option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_ROUTER
     &&  zsock_type (self) != ZMQ_DEALER
     &&  zsock_type (self) != ZMQ_REQ) {
@@ -740,6 +1037,13 @@ zsock_set_req_relaxed (void *self, int req_relaxed)
 {
     assert (self);
 #   if defined (ZMQ_REQ_RELAXED)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock req_relaxed option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_REQ) {
         printf ("ZMQ_REQ_RELAXED is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -759,6 +1063,13 @@ zsock_set_req_correlate (void *self, int req_correlate)
 {
     assert (self);
 #   if defined (ZMQ_REQ_CORRELATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock req_correlate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_REQ) {
         printf ("ZMQ_REQ_CORRELATE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -778,6 +1089,13 @@ zsock_set_conflate (void *self, int conflate)
 {
     assert (self);
 #   if defined (ZMQ_CONFLATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock conflate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_PUSH
     &&  zsock_type (self) != ZMQ_PULL
     &&  zsock_type (self) != ZMQ_PUB
@@ -801,6 +1119,13 @@ zsock_set_zap_domain (void *self, const char * zap_domain)
 {
     assert (self);
 #   if defined (ZMQ_ZAP_DOMAIN)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock zap_domain option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, strlen (zap_domain));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -816,6 +1141,13 @@ zsock_zap_domain (void *self)
 {
     assert (self);
 #   if defined (ZMQ_ZAP_DOMAIN)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock zap_domain option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *zap_domain = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_ZAP_DOMAIN, zap_domain, &option_len);
@@ -834,6 +1166,13 @@ zsock_mechanism (void *self)
 {
     assert (self);
 #   if defined (ZMQ_MECHANISM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock mechanism option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int mechanism;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MECHANISM, &mechanism, &option_len);
@@ -852,6 +1191,13 @@ zsock_set_plain_server (void *self, int plain_server)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_PLAIN_SERVER, &plain_server, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -867,6 +1213,13 @@ zsock_plain_server (void *self)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int plain_server;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_PLAIN_SERVER, &plain_server, &option_len);
@@ -885,6 +1238,13 @@ zsock_set_plain_username (void *self, const char * plain_username)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_USERNAME)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_username option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_PLAIN_USERNAME, plain_username, strlen (plain_username));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -900,6 +1260,13 @@ zsock_plain_username (void *self)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_USERNAME)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_username option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *plain_username = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_PLAIN_USERNAME, plain_username, &option_len);
@@ -918,6 +1285,13 @@ zsock_set_plain_password (void *self, const char * plain_password)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_PASSWORD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_password option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_PLAIN_PASSWORD, plain_password, strlen (plain_password));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -933,6 +1307,13 @@ zsock_plain_password (void *self)
 {
     assert (self);
 #   if defined (ZMQ_PLAIN_PASSWORD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock plain_password option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *plain_password = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_PLAIN_PASSWORD, plain_password, &option_len);
@@ -951,6 +1332,13 @@ zsock_set_curve_server (void *self, int curve_server)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVER, &curve_server, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -966,6 +1354,13 @@ zsock_curve_server (void *self)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int curve_server;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_CURVE_SERVER, &curve_server, &option_len);
@@ -984,6 +1379,13 @@ zsock_set_curve_publickey (void *self, const char * curve_publickey)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_PUBLICKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_publickey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_PUBLICKEY, curve_publickey, strlen (curve_publickey));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -998,6 +1400,13 @@ void
 zsock_set_curve_publickey_bin (void *self, const byte *curve_publickey)
 {
 #   if defined (ZMQ_CURVE_PUBLICKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_publickey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_PUBLICKEY, curve_publickey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1013,6 +1422,13 @@ zsock_curve_publickey (void *self)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_PUBLICKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_publickey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 40 + 1;     //  Z85 key + terminator
     char *curve_publickey = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_CURVE_PUBLICKEY, curve_publickey, &option_len);
@@ -1031,6 +1447,13 @@ zsock_set_curve_secretkey (void *self, const char * curve_secretkey)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SECRETKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_secretkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SECRETKEY, curve_secretkey, strlen (curve_secretkey));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1045,6 +1468,13 @@ void
 zsock_set_curve_secretkey_bin (void *self, const byte *curve_secretkey)
 {
 #   if defined (ZMQ_CURVE_SECRETKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_secretkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SECRETKEY, curve_secretkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1060,6 +1490,13 @@ zsock_curve_secretkey (void *self)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SECRETKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_secretkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 40 + 1;     //  Z85 key + terminator
     char *curve_secretkey = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_CURVE_SECRETKEY, curve_secretkey, &option_len);
@@ -1078,6 +1515,13 @@ zsock_set_curve_serverkey (void *self, const char * curve_serverkey)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SERVERKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_serverkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVERKEY, curve_serverkey, strlen (curve_serverkey));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1092,6 +1536,13 @@ void
 zsock_set_curve_serverkey_bin (void *self, const byte *curve_serverkey)
 {
 #   if defined (ZMQ_CURVE_SERVERKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_serverkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_CURVE_SERVERKEY, curve_serverkey, 32);
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1107,6 +1558,13 @@ zsock_curve_serverkey (void *self)
 {
     assert (self);
 #   if defined (ZMQ_CURVE_SERVERKEY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock curve_serverkey option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 40 + 1;     //  Z85 key + terminator
     char *curve_serverkey = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_CURVE_SERVERKEY, curve_serverkey, &option_len);
@@ -1125,6 +1583,13 @@ zsock_set_gssapi_server (void *self, int gssapi_server)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_GSSAPI_SERVER, &gssapi_server, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1140,6 +1605,13 @@ zsock_gssapi_server (void *self)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_SERVER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_server option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int gssapi_server;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_GSSAPI_SERVER, &gssapi_server, &option_len);
@@ -1158,6 +1630,13 @@ zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_PLAINTEXT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_plaintext option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_GSSAPI_PLAINTEXT, &gssapi_plaintext, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1173,6 +1652,13 @@ zsock_gssapi_plaintext (void *self)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_PLAINTEXT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_plaintext option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int gssapi_plaintext;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_GSSAPI_PLAINTEXT, &gssapi_plaintext, &option_len);
@@ -1191,6 +1677,13 @@ zsock_set_gssapi_principal (void *self, const char * gssapi_principal)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_PRINCIPAL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_principal option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_GSSAPI_PRINCIPAL, gssapi_principal, strlen (gssapi_principal));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1206,6 +1699,13 @@ zsock_gssapi_principal (void *self)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_PRINCIPAL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_principal option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *gssapi_principal = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_GSSAPI_PRINCIPAL, gssapi_principal, &option_len);
@@ -1224,6 +1724,13 @@ zsock_set_gssapi_service_principal (void *self, const char * gssapi_service_prin
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_SERVICE_PRINCIPAL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_service_principal option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_GSSAPI_SERVICE_PRINCIPAL, gssapi_service_principal, strlen (gssapi_service_principal));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1239,6 +1746,13 @@ zsock_gssapi_service_principal (void *self)
 {
     assert (self);
 #   if defined (ZMQ_GSSAPI_SERVICE_PRINCIPAL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock gssapi_service_principal option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *gssapi_service_principal = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_GSSAPI_SERVICE_PRINCIPAL, gssapi_service_principal, &option_len);
@@ -1257,6 +1771,13 @@ zsock_set_ipv6 (void *self, int ipv6)
 {
     assert (self);
 #   if defined (ZMQ_IPV6)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock ipv6 option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IPV6, &ipv6, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1272,6 +1793,13 @@ zsock_ipv6 (void *self)
 {
     assert (self);
 #   if defined (ZMQ_IPV6)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock ipv6 option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int ipv6;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_IPV6, &ipv6, &option_len);
@@ -1290,6 +1818,13 @@ zsock_set_immediate (void *self, int immediate)
 {
     assert (self);
 #   if defined (ZMQ_IMMEDIATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock immediate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IMMEDIATE, &immediate, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1305,6 +1840,13 @@ zsock_immediate (void *self)
 {
     assert (self);
 #   if defined (ZMQ_IMMEDIATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (4, 0, 0)) {
+        zsys_error ("zsock immediate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 4.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int immediate;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_IMMEDIATE, &immediate, &option_len);
@@ -1314,73 +1856,9 @@ zsock_immediate (void *self)
 #   endif
 }
 
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_ROUTER_RAW value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
+#endif
 
-void
-zsock_set_router_raw (void *self, int router_raw)
-{
-    assert (self);
-#   if defined (ZMQ_ROUTER_RAW)
-    if (zsock_type (self) != ZMQ_ROUTER) {
-        printf ("ZMQ_ROUTER_RAW is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_ROUTER_RAW, &router_raw, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_IPV4ONLY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_ipv4only (void *self, int ipv4only)
-{
-    assert (self);
-#   if defined (ZMQ_IPV4ONLY)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IPV4ONLY, &ipv4only, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_IPV4ONLY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_ipv4only (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_IPV4ONLY)
-    int ipv4only;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_IPV4ONLY, &ipv4only, &option_len);
-    return ipv4only;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_DELAY_ATTACH_ON_CONNECT value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect)
-{
-    assert (self);
-#   if defined (ZMQ_DELAY_ATTACH_ON_CONNECT)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_DELAY_ATTACH_ON_CONNECT, &delay_attach_on_connect, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
+#if (ZMQ_VERSION_MAJOR >= 3)
 //  --------------------------------------------------------------------------
 //  Return socket ZMQ_TYPE value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -1390,6 +1868,13 @@ zsock_type (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TYPE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock type option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int type;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TYPE, &type, &option_len);
@@ -1408,6 +1893,13 @@ zsock_set_sndhwm (void *self, int sndhwm)
 {
     assert (self);
 #   if defined (ZMQ_SNDHWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndhwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDHWM, &sndhwm, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1423,6 +1915,13 @@ zsock_sndhwm (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SNDHWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndhwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int sndhwm;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDHWM, &sndhwm, &option_len);
@@ -1441,6 +1940,13 @@ zsock_set_rcvhwm (void *self, int rcvhwm)
 {
     assert (self);
 #   if defined (ZMQ_RCVHWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvhwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVHWM, &rcvhwm, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1456,6 +1962,13 @@ zsock_rcvhwm (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVHWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvhwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rcvhwm;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVHWM, &rcvhwm, &option_len);
@@ -1474,6 +1987,13 @@ zsock_set_affinity (void *self, int affinity)
 {
     assert (self);
 #   if defined (ZMQ_AFFINITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = affinity;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_AFFINITY, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -1490,6 +2010,13 @@ zsock_affinity (void *self)
 {
     assert (self);
 #   if defined (ZMQ_AFFINITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t affinity;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_AFFINITY, &affinity, &option_len);
@@ -1508,6 +2035,13 @@ zsock_set_subscribe (void *self, const char * subscribe)
 {
     assert (self);
 #   if defined (ZMQ_SUBSCRIBE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock subscribe option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_SUB) {
         printf ("ZMQ_SUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -1527,6 +2061,13 @@ zsock_set_unsubscribe (void *self, const char * unsubscribe)
 {
     assert (self);
 #   if defined (ZMQ_UNSUBSCRIBE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock unsubscribe option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_SUB) {
         printf ("ZMQ_UNSUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -1546,6 +2087,13 @@ zsock_set_identity (void *self, const char * identity)
 {
     assert (self);
 #   if defined (ZMQ_IDENTITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_REQ
     &&  zsock_type (self) != ZMQ_REP
     &&  zsock_type (self) != ZMQ_DEALER
@@ -1568,6 +2116,13 @@ zsock_identity (void *self)
 {
     assert (self);
 #   if defined (ZMQ_IDENTITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *identity = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, &option_len);
@@ -1586,6 +2141,13 @@ zsock_set_rate (void *self, int rate)
 {
     assert (self);
 #   if defined (ZMQ_RATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &rate, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1601,6 +2163,13 @@ zsock_rate (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rate;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
@@ -1619,6 +2188,13 @@ zsock_set_recovery_ivl (void *self, int recovery_ivl)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1634,6 +2210,13 @@ zsock_recovery_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int recovery_ivl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
@@ -1652,6 +2235,13 @@ zsock_set_sndbuf (void *self, int sndbuf)
 {
     assert (self);
 #   if defined (ZMQ_SNDBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1667,6 +2257,13 @@ zsock_sndbuf (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SNDBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int sndbuf;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
@@ -1685,6 +2282,13 @@ zsock_set_rcvbuf (void *self, int rcvbuf)
 {
     assert (self);
 #   if defined (ZMQ_RCVBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1700,6 +2304,13 @@ zsock_rcvbuf (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rcvbuf;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
@@ -1718,6 +2329,13 @@ zsock_set_linger (void *self, int linger)
 {
     assert (self);
 #   if defined (ZMQ_LINGER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1733,6 +2351,13 @@ zsock_linger (void *self)
 {
     assert (self);
 #   if defined (ZMQ_LINGER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int linger;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, &option_len);
@@ -1751,6 +2376,13 @@ zsock_set_reconnect_ivl (void *self, int reconnect_ivl)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1766,6 +2398,13 @@ zsock_reconnect_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int reconnect_ivl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
@@ -1784,6 +2423,13 @@ zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1799,6 +2445,13 @@ zsock_reconnect_ivl_max (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int reconnect_ivl_max;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
@@ -1817,6 +2470,13 @@ zsock_set_backlog (void *self, int backlog)
 {
     assert (self);
 #   if defined (ZMQ_BACKLOG)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1832,6 +2492,13 @@ zsock_backlog (void *self)
 {
     assert (self);
 #   if defined (ZMQ_BACKLOG)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int backlog;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, &option_len);
@@ -1850,6 +2517,13 @@ zsock_set_maxmsgsize (void *self, int maxmsgsize)
 {
     assert (self);
 #   if defined (ZMQ_MAXMSGSIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock maxmsgsize option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = maxmsgsize;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MAXMSGSIZE, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -1866,6 +2540,13 @@ zsock_maxmsgsize (void *self)
 {
     assert (self);
 #   if defined (ZMQ_MAXMSGSIZE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock maxmsgsize option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t maxmsgsize;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MAXMSGSIZE, &maxmsgsize, &option_len);
@@ -1884,6 +2565,13 @@ zsock_set_multicast_hops (void *self, int multicast_hops)
 {
     assert (self);
 #   if defined (ZMQ_MULTICAST_HOPS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock multicast_hops option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MULTICAST_HOPS, &multicast_hops, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1899,6 +2587,13 @@ zsock_multicast_hops (void *self)
 {
     assert (self);
 #   if defined (ZMQ_MULTICAST_HOPS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock multicast_hops option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int multicast_hops;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MULTICAST_HOPS, &multicast_hops, &option_len);
@@ -1917,6 +2612,13 @@ zsock_set_rcvtimeo (void *self, int rcvtimeo)
 {
     assert (self);
 #   if defined (ZMQ_RCVTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1932,6 +2634,13 @@ zsock_rcvtimeo (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rcvtimeo;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, &option_len);
@@ -1950,6 +2659,13 @@ zsock_set_sndtimeo (void *self, int sndtimeo)
 {
     assert (self);
 #   if defined (ZMQ_SNDTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -1965,6 +2681,13 @@ zsock_sndtimeo (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SNDTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int sndtimeo;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, &option_len);
@@ -1983,6 +2706,13 @@ zsock_set_xpub_verbose (void *self, int xpub_verbose)
 {
     assert (self);
 #   if defined (ZMQ_XPUB_VERBOSE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock xpub_verbose option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_XPUB) {
         printf ("ZMQ_XPUB_VERBOSE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -2002,6 +2732,13 @@ zsock_set_tcp_keepalive (void *self, int tcp_keepalive)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE, &tcp_keepalive, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2017,6 +2754,13 @@ zsock_tcp_keepalive (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tcp_keepalive;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE, &tcp_keepalive, &option_len);
@@ -2035,6 +2779,13 @@ zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_IDLE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_idle option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_IDLE, &tcp_keepalive_idle, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2050,6 +2801,13 @@ zsock_tcp_keepalive_idle (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_IDLE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_idle option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tcp_keepalive_idle;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_IDLE, &tcp_keepalive_idle, &option_len);
@@ -2068,6 +2826,13 @@ zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_CNT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_cnt option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_CNT, &tcp_keepalive_cnt, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2083,6 +2848,13 @@ zsock_tcp_keepalive_cnt (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_CNT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_cnt option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tcp_keepalive_cnt;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_CNT, &tcp_keepalive_cnt, &option_len);
@@ -2101,6 +2873,13 @@ zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_INTVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_intvl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_INTVL, &tcp_keepalive_intvl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2116,6 +2895,13 @@ zsock_tcp_keepalive_intvl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_KEEPALIVE_INTVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_keepalive_intvl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int tcp_keepalive_intvl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_INTVL, &tcp_keepalive_intvl, &option_len);
@@ -2134,6 +2920,13 @@ zsock_set_tcp_accept_filter (void *self, const char * tcp_accept_filter)
 {
     assert (self);
 #   if defined (ZMQ_TCP_ACCEPT_FILTER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_accept_filter option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_ACCEPT_FILTER, tcp_accept_filter, strlen (tcp_accept_filter));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2149,6 +2942,13 @@ zsock_tcp_accept_filter (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TCP_ACCEPT_FILTER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock tcp_accept_filter option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *tcp_accept_filter = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_ACCEPT_FILTER, tcp_accept_filter, &option_len);
@@ -2167,6 +2967,13 @@ zsock_rcvmore (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVMORE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvmore option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rcvmore;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
@@ -2185,6 +2992,13 @@ zsock_fd (void *self)
 {
     assert (self);
 #   if defined (ZMQ_FD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock fd option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     SOCKET fd;
     size_t option_len = sizeof (SOCKET);
     zmq_getsockopt (zsock_resolve (self), ZMQ_FD, &fd, &option_len);
@@ -2203,6 +3017,13 @@ zsock_events (void *self)
 {
     assert (self);
 #   if defined (ZMQ_EVENTS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock events option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int events;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
@@ -2221,6 +3042,13 @@ zsock_last_endpoint (void *self)
 {
     assert (self);
 #   if defined (ZMQ_LAST_ENDPOINT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock last_endpoint option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *last_endpoint = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_LAST_ENDPOINT, last_endpoint, &option_len);
@@ -2230,9 +3058,6 @@ zsock_last_endpoint (void *self)
 #   endif
 }
 
-#endif
-
-#if (ZMQ_VERSION_MAJOR == 3)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_ROUTER_RAW value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -2242,6 +3067,13 @@ zsock_set_router_raw (void *self, int router_raw)
 {
     assert (self);
 #   if defined (ZMQ_ROUTER_RAW)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock router_raw option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_ROUTER) {
         printf ("ZMQ_ROUTER_RAW is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -2261,6 +3093,13 @@ zsock_set_ipv4only (void *self, int ipv4only)
 {
     assert (self);
 #   if defined (ZMQ_IPV4ONLY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock ipv4only option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IPV4ONLY, &ipv4only, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -2276,6 +3115,13 @@ zsock_ipv4only (void *self)
 {
     assert (self);
 #   if defined (ZMQ_IPV4ONLY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock ipv4only option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int ipv4only;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_IPV4ONLY, &ipv4only, &option_len);
@@ -2294,864 +3140,22 @@ zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect)
 {
     assert (self);
 #   if defined (ZMQ_DELAY_ATTACH_ON_CONNECT)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock delay_attach_on_connect option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_DELAY_ATTACH_ON_CONNECT, &delay_attach_on_connect, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
 }
 
 
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TYPE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_type (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TYPE)
-    int type;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TYPE, &type, &option_len);
-    return type;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDHWM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_sndhwm (void *self, int sndhwm)
-{
-    assert (self);
-#   if defined (ZMQ_SNDHWM)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDHWM, &sndhwm, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDHWM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_sndhwm (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_SNDHWM)
-    int sndhwm;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDHWM, &sndhwm, &option_len);
-    return sndhwm;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVHWM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rcvhwm (void *self, int rcvhwm)
-{
-    assert (self);
-#   if defined (ZMQ_RCVHWM)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVHWM, &rcvhwm, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVHWM value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvhwm (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVHWM)
-    int rcvhwm;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVHWM, &rcvhwm, &option_len);
-    return rcvhwm;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_AFFINITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_affinity (void *self, int affinity)
-{
-    assert (self);
-#   if defined (ZMQ_AFFINITY)
-    uint64_t value = affinity;
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_AFFINITY, &value, sizeof (uint64_t));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_AFFINITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_affinity (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_AFFINITY)
-    uint64_t affinity;
-    size_t option_len = sizeof (uint64_t);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_AFFINITY, &affinity, &option_len);
-    return (int) affinity;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SUBSCRIBE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_subscribe (void *self, const char * subscribe)
-{
-    assert (self);
-#   if defined (ZMQ_SUBSCRIBE)
-    if (zsock_type (self) != ZMQ_SUB) {
-        printf ("ZMQ_SUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_UNSUBSCRIBE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_unsubscribe (void *self, const char * unsubscribe)
-{
-    assert (self);
-#   if defined (ZMQ_UNSUBSCRIBE)
-    if (zsock_type (self) != ZMQ_SUB) {
-        printf ("ZMQ_UNSUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_IDENTITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_identity (void *self, const char * identity)
-{
-    assert (self);
-#   if defined (ZMQ_IDENTITY)
-    if (zsock_type (self) != ZMQ_REQ
-    &&  zsock_type (self) != ZMQ_REP
-    &&  zsock_type (self) != ZMQ_DEALER
-    &&  zsock_type (self) != ZMQ_ROUTER) {
-        printf ("ZMQ_IDENTITY is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, strlen (identity));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_IDENTITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char *
-zsock_identity (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_IDENTITY)
-    size_t option_len = 255;
-    char *identity = (char *) zmalloc (option_len);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, &option_len);
-    return (char *) identity;
-#   else
-    return NULL;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RATE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rate (void *self, int rate)
-{
-    assert (self);
-#   if defined (ZMQ_RATE)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &rate, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RATE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rate (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RATE)
-    int rate;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
-    return rate;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECOVERY_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_recovery_ivl (void *self, int recovery_ivl)
-{
-    assert (self);
-#   if defined (ZMQ_RECOVERY_IVL)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECOVERY_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_recovery_ivl (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECOVERY_IVL)
-    int recovery_ivl;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
-    return recovery_ivl;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_sndbuf (void *self, int sndbuf)
-{
-    assert (self);
-#   if defined (ZMQ_SNDBUF)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_sndbuf (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_SNDBUF)
-    int sndbuf;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
-    return sndbuf;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rcvbuf (void *self, int rcvbuf)
-{
-    assert (self);
-#   if defined (ZMQ_RCVBUF)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvbuf (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVBUF)
-    int rcvbuf;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
-    return rcvbuf;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_LINGER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_linger (void *self, int linger)
-{
-    assert (self);
-#   if defined (ZMQ_LINGER)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_LINGER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_linger (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_LINGER)
-    int linger;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, &option_len);
-    return linger;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_reconnect_ivl (void *self, int reconnect_ivl)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_reconnect_ivl (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL)
-    int reconnect_ivl;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
-    return reconnect_ivl;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL_MAX value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL_MAX)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL_MAX value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_reconnect_ivl_max (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL_MAX)
-    int reconnect_ivl_max;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
-    return reconnect_ivl_max;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_BACKLOG value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_backlog (void *self, int backlog)
-{
-    assert (self);
-#   if defined (ZMQ_BACKLOG)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_BACKLOG value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_backlog (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_BACKLOG)
-    int backlog;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, &option_len);
-    return backlog;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_MAXMSGSIZE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_maxmsgsize (void *self, int maxmsgsize)
-{
-    assert (self);
-#   if defined (ZMQ_MAXMSGSIZE)
-    int64_t value = maxmsgsize;
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MAXMSGSIZE, &value, sizeof (int64_t));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_MAXMSGSIZE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_maxmsgsize (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_MAXMSGSIZE)
-    int64_t maxmsgsize;
-    size_t option_len = sizeof (int64_t);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_MAXMSGSIZE, &maxmsgsize, &option_len);
-    return (int) maxmsgsize;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_MULTICAST_HOPS value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_multicast_hops (void *self, int multicast_hops)
-{
-    assert (self);
-#   if defined (ZMQ_MULTICAST_HOPS)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MULTICAST_HOPS, &multicast_hops, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_MULTICAST_HOPS value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_multicast_hops (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_MULTICAST_HOPS)
-    int multicast_hops;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_MULTICAST_HOPS, &multicast_hops, &option_len);
-    return multicast_hops;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rcvtimeo (void *self, int rcvtimeo)
-{
-    assert (self);
-#   if defined (ZMQ_RCVTIMEO)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvtimeo (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVTIMEO)
-    int rcvtimeo;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, &option_len);
-    return rcvtimeo;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_sndtimeo (void *self, int sndtimeo)
-{
-    assert (self);
-#   if defined (ZMQ_SNDTIMEO)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_sndtimeo (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_SNDTIMEO)
-    int sndtimeo;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, &option_len);
-    return sndtimeo;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_XPUB_VERBOSE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_xpub_verbose (void *self, int xpub_verbose)
-{
-    assert (self);
-#   if defined (ZMQ_XPUB_VERBOSE)
-    if (zsock_type (self) != ZMQ_XPUB) {
-        printf ("ZMQ_XPUB_VERBOSE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_XPUB_VERBOSE, &xpub_verbose, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_TCP_KEEPALIVE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_tcp_keepalive (void *self, int tcp_keepalive)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE, &tcp_keepalive, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TCP_KEEPALIVE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_tcp_keepalive (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE)
-    int tcp_keepalive;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE, &tcp_keepalive, &option_len);
-    return tcp_keepalive;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_TCP_KEEPALIVE_IDLE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_IDLE)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_IDLE, &tcp_keepalive_idle, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TCP_KEEPALIVE_IDLE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_tcp_keepalive_idle (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_IDLE)
-    int tcp_keepalive_idle;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_IDLE, &tcp_keepalive_idle, &option_len);
-    return tcp_keepalive_idle;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_TCP_KEEPALIVE_CNT value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_CNT)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_CNT, &tcp_keepalive_cnt, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TCP_KEEPALIVE_CNT value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_tcp_keepalive_cnt (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_CNT)
-    int tcp_keepalive_cnt;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_CNT, &tcp_keepalive_cnt, &option_len);
-    return tcp_keepalive_cnt;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_TCP_KEEPALIVE_INTVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_INTVL)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_INTVL, &tcp_keepalive_intvl, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TCP_KEEPALIVE_INTVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_tcp_keepalive_intvl (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_KEEPALIVE_INTVL)
-    int tcp_keepalive_intvl;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_KEEPALIVE_INTVL, &tcp_keepalive_intvl, &option_len);
-    return tcp_keepalive_intvl;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_TCP_ACCEPT_FILTER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_tcp_accept_filter (void *self, const char * tcp_accept_filter)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_ACCEPT_FILTER)
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_TCP_ACCEPT_FILTER, tcp_accept_filter, strlen (tcp_accept_filter));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TCP_ACCEPT_FILTER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char *
-zsock_tcp_accept_filter (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TCP_ACCEPT_FILTER)
-    size_t option_len = 255;
-    char *tcp_accept_filter = (char *) zmalloc (option_len);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TCP_ACCEPT_FILTER, tcp_accept_filter, &option_len);
-    return (char *) tcp_accept_filter;
-#   else
-    return NULL;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVMORE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvmore (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVMORE)
-    int rcvmore;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
-    return rcvmore;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_FD value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-SOCKET
-zsock_fd (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_FD)
-    SOCKET fd;
-    size_t option_len = sizeof (SOCKET);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_FD, &fd, &option_len);
-    return fd;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_EVENTS value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_events (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_EVENTS)
-    int events;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
-    return events;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_LAST_ENDPOINT value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char *
-zsock_last_endpoint (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_LAST_ENDPOINT)
-    size_t option_len = 255;
-    char *last_endpoint = (char *) zmalloc (option_len);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_LAST_ENDPOINT, last_endpoint, &option_len);
-    return (char *) last_endpoint;
-#   else
-    return NULL;
-#   endif
-}
-
 #endif
 
-#if (ZMQ_VERSION_MAJOR == 2)
+#if (ZMQ_VERSION_MAJOR >= 2) && (ZMQ_VERSION_MAJOR < 3)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_HWM value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -3161,6 +3165,14 @@ zsock_set_hwm (void *self, int hwm)
 {
     assert (self);
 #   if defined (ZMQ_HWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock hwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = hwm;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_HWM, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3177,6 +3189,14 @@ zsock_hwm (void *self)
 {
     assert (self);
 #   if defined (ZMQ_HWM)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock hwm option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t hwm;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_HWM, &hwm, &option_len);
@@ -3195,6 +3215,14 @@ zsock_set_swap (void *self, int swap)
 {
     assert (self);
 #   if defined (ZMQ_SWAP)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock swap option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = swap;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SWAP, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3211,6 +3239,14 @@ zsock_swap (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SWAP)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock swap option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t swap;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SWAP, &swap, &option_len);
@@ -3229,6 +3265,14 @@ zsock_set_affinity (void *self, int affinity)
 {
     assert (self);
 #   if defined (ZMQ_AFFINITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = affinity;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_AFFINITY, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3245,6 +3289,14 @@ zsock_affinity (void *self)
 {
     assert (self);
 #   if defined (ZMQ_AFFINITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t affinity;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_AFFINITY, &affinity, &option_len);
@@ -3263,6 +3315,14 @@ zsock_set_identity (void *self, const char * identity)
 {
     assert (self);
 #   if defined (ZMQ_IDENTITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, strlen (identity));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3278,6 +3338,14 @@ zsock_identity (void *self)
 {
     assert (self);
 #   if defined (ZMQ_IDENTITY)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     size_t option_len = 255;
     char *identity = (char *) zmalloc (option_len);
     zmq_getsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, &option_len);
@@ -3296,6 +3364,14 @@ zsock_set_rate (void *self, int rate)
 {
     assert (self);
 #   if defined (ZMQ_RATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = rate;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3312,6 +3388,14 @@ zsock_rate (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RATE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t rate;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
@@ -3330,6 +3414,14 @@ zsock_set_recovery_ivl (void *self, int recovery_ivl)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = recovery_ivl;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3346,6 +3438,14 @@ zsock_recovery_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t recovery_ivl;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
@@ -3364,6 +3464,14 @@ zsock_set_recovery_ivl_msec (void *self, int recovery_ivl_msec)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL_MSEC)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl_msec option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = recovery_ivl_msec;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL_MSEC, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3380,6 +3488,14 @@ zsock_recovery_ivl_msec (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECOVERY_IVL_MSEC)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock recovery_ivl_msec option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t recovery_ivl_msec;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL_MSEC, &recovery_ivl_msec, &option_len);
@@ -3398,6 +3514,14 @@ zsock_set_mcast_loop (void *self, int mcast_loop)
 {
     assert (self);
 #   if defined (ZMQ_MCAST_LOOP)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock mcast_loop option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int64_t value = mcast_loop;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_MCAST_LOOP, &value, sizeof (int64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3414,6 +3538,14 @@ zsock_mcast_loop (void *self)
 {
     assert (self);
 #   if defined (ZMQ_MCAST_LOOP)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock mcast_loop option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t mcast_loop;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MCAST_LOOP, &mcast_loop, &option_len);
@@ -3423,7 +3555,6 @@ zsock_mcast_loop (void *self)
 #   endif
 }
 
-#   if (ZMQ_VERSION_MINOR == 2)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_RCVTIMEO value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -3433,6 +3564,14 @@ zsock_set_rcvtimeo (void *self, int rcvtimeo)
 {
     assert (self);
 #   if defined (ZMQ_RCVTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3448,6 +3587,14 @@ zsock_rcvtimeo (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int rcvtimeo;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, &option_len);
@@ -3457,8 +3604,6 @@ zsock_rcvtimeo (void *self)
 #   endif
 }
 
-#   endif
-#   if (ZMQ_VERSION_MINOR == 2)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_SNDTIMEO value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -3468,6 +3613,14 @@ zsock_set_sndtimeo (void *self, int sndtimeo)
 {
     assert (self);
 #   if defined (ZMQ_SNDTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3483,6 +3636,14 @@ zsock_sndtimeo (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SNDTIMEO)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int sndtimeo;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, &option_len);
@@ -3492,7 +3653,6 @@ zsock_sndtimeo (void *self)
 #   endif
 }
 
-#   endif
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_SNDBUF value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -3502,6 +3662,14 @@ zsock_set_sndbuf (void *self, int sndbuf)
 {
     assert (self);
 #   if defined (ZMQ_SNDBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = sndbuf;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3518,6 +3686,14 @@ zsock_sndbuf (void *self)
 {
     assert (self);
 #   if defined (ZMQ_SNDBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t sndbuf;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
@@ -3536,6 +3712,14 @@ zsock_set_rcvbuf (void *self, int rcvbuf)
 {
     assert (self);
 #   if defined (ZMQ_RCVBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     uint64_t value = rcvbuf;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &value, sizeof (uint64_t));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3552,6 +3736,14 @@ zsock_rcvbuf (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVBUF)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint64_t rcvbuf;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
@@ -3570,6 +3762,14 @@ zsock_set_linger (void *self, int linger)
 {
     assert (self);
 #   if defined (ZMQ_LINGER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3585,6 +3785,14 @@ zsock_linger (void *self)
 {
     assert (self);
 #   if defined (ZMQ_LINGER)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int linger;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, &option_len);
@@ -3603,6 +3811,14 @@ zsock_set_reconnect_ivl (void *self, int reconnect_ivl)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3618,6 +3834,14 @@ zsock_reconnect_ivl (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int reconnect_ivl;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
@@ -3636,6 +3860,14 @@ zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3651,6 +3883,14 @@ zsock_reconnect_ivl_max (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int reconnect_ivl_max;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
@@ -3669,6 +3909,14 @@ zsock_set_backlog (void *self, int backlog)
 {
     assert (self);
 #   if defined (ZMQ_BACKLOG)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, sizeof (int));
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
@@ -3684,6 +3932,14 @@ zsock_backlog (void *self)
 {
     assert (self);
 #   if defined (ZMQ_BACKLOG)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int backlog;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, &option_len);
@@ -3702,6 +3958,14 @@ zsock_set_subscribe (void *self, const char * subscribe)
 {
     assert (self);
 #   if defined (ZMQ_SUBSCRIBE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock subscribe option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_SUB) {
         printf ("ZMQ_SUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -3721,6 +3985,14 @@ zsock_set_unsubscribe (void *self, const char * unsubscribe)
 {
     assert (self);
 #   if defined (ZMQ_UNSUBSCRIBE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock unsubscribe option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return;
+    }
     if (zsock_type (self) != ZMQ_SUB) {
         printf ("ZMQ_UNSUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
         assert (false);
@@ -3740,6 +4012,14 @@ zsock_type (void *self)
 {
     assert (self);
 #   if defined (ZMQ_TYPE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock type option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int type;
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_TYPE, &type, &option_len);
@@ -3758,6 +4038,14 @@ zsock_rcvmore (void *self)
 {
     assert (self);
 #   if defined (ZMQ_RCVMORE)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock rcvmore option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     int64_t rcvmore;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
@@ -3776,6 +4064,14 @@ zsock_fd (void *self)
 {
     assert (self);
 #   if defined (ZMQ_FD)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock fd option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     SOCKET fd;
     size_t option_len = sizeof (SOCKET);
     zmq_getsockopt (zsock_resolve (self), ZMQ_FD, &fd, &option_len);
@@ -3794,6 +4090,14 @@ zsock_events (void *self)
 {
     assert (self);
 #   if defined (ZMQ_EVENTS)
+    int major, minor, patch;
+    zmq_version (&major, &minor, &patch);
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
+            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+        zsys_error ("zsock events option not supported by libzmq version %d.%d.%d, "
+            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+        return 0;
+    }
     uint32_t events;
     size_t option_len = sizeof (uint32_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
@@ -3816,7 +4120,8 @@ zsock_option_test (bool verbose)
 
     //  @selftest
     zsock_t *self;
-#if (ZMQ_VERSION_MAJOR == 4)
+#if (ZMQ_VERSION_MAJOR >= 4)
+#   if (ZMQ_VERSION_MINOR >= 2)
 #     if defined (ZMQ_HEARTBEAT_IVL)
     self = zsock_new (ZMQ_DEALER);
     assert (self);
@@ -3911,6 +4216,11 @@ zsock_option_test (bool verbose)
     zsock_multicast_maxtpdu (self);
     zsock_destroy (&self);
 #     endif
+#   endif
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 4)
+#   if (ZMQ_VERSION_MINOR >= 1)
 #     if defined (ZMQ_TOS)
     self = zsock_new (ZMQ_DEALER);
     assert (self);
@@ -3954,6 +4264,10 @@ zsock_option_test (bool verbose)
     zsock_set_xpub_nodrop (self, 1);
     zsock_destroy (&self);
 #     endif
+#   endif
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 4)
 #     if defined (ZMQ_ROUTER_MANDATORY)
     self = zsock_new (ZMQ_ROUTER);
     assert (self);
@@ -4041,26 +4355,9 @@ zsock_option_test (bool verbose)
     zsock_immediate (self);
     zsock_destroy (&self);
 #     endif
-#     if defined (ZMQ_ROUTER_RAW)
-    self = zsock_new (ZMQ_ROUTER);
-    assert (self);
-    zsock_set_router_raw (self, 1);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_IPV4ONLY)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_ipv4only (self, 1);
-    assert (zsock_ipv4only (self) == 1);
-    zsock_ipv4only (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_DELAY_ATTACH_ON_CONNECT)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_delay_attach_on_connect (self, 1);
-    zsock_destroy (&self);
-#     endif
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 3)
 #     if defined (ZMQ_TYPE)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4281,9 +4578,6 @@ zsock_option_test (bool verbose)
     free (last_endpoint);
     zsock_destroy (&self);
 #     endif
-#endif
-
-#if (ZMQ_VERSION_MAJOR == 3)
 #     if defined (ZMQ_ROUTER_RAW)
     self = zsock_new (ZMQ_ROUTER);
     assert (self);
@@ -4304,229 +4598,9 @@ zsock_option_test (bool verbose)
     zsock_set_delay_attach_on_connect (self, 1);
     zsock_destroy (&self);
 #     endif
-#     if defined (ZMQ_TYPE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_type (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SNDHWM)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_sndhwm (self, 1);
-    assert (zsock_sndhwm (self) == 1);
-    zsock_sndhwm (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVHWM)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rcvhwm (self, 1);
-    assert (zsock_rcvhwm (self) == 1);
-    zsock_rcvhwm (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_AFFINITY)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_affinity (self, 1);
-    assert (zsock_affinity (self) == 1);
-    zsock_affinity (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SUBSCRIBE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_subscribe (self, "test");
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_UNSUBSCRIBE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_unsubscribe (self, "test");
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_IDENTITY)
-    self = zsock_new (ZMQ_DEALER);
-    assert (self);
-    zsock_set_identity (self, "test");
-    char *identity = zsock_identity (self);
-    assert (identity);
-    free (identity);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RATE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rate (self, 1);
-    assert (zsock_rate (self) == 1);
-    zsock_rate (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECOVERY_IVL)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_recovery_ivl (self, 1);
-    assert (zsock_recovery_ivl (self) == 1);
-    zsock_recovery_ivl (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SNDBUF)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_sndbuf (self, 1);
-    assert (zsock_sndbuf (self) == 1);
-    zsock_sndbuf (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVBUF)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rcvbuf (self, 1);
-    assert (zsock_rcvbuf (self) == 1);
-    zsock_rcvbuf (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_LINGER)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_linger (self, 1);
-    assert (zsock_linger (self) == 1);
-    zsock_linger (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECONNECT_IVL)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_reconnect_ivl (self, 1);
-    assert (zsock_reconnect_ivl (self) == 1);
-    zsock_reconnect_ivl (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECONNECT_IVL_MAX)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_reconnect_ivl_max (self, 1);
-    assert (zsock_reconnect_ivl_max (self) == 1);
-    zsock_reconnect_ivl_max (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_BACKLOG)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_backlog (self, 1);
-    assert (zsock_backlog (self) == 1);
-    zsock_backlog (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_MAXMSGSIZE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_maxmsgsize (self, 1);
-    assert (zsock_maxmsgsize (self) == 1);
-    zsock_maxmsgsize (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_MULTICAST_HOPS)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_multicast_hops (self, 1);
-    assert (zsock_multicast_hops (self) == 1);
-    zsock_multicast_hops (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVTIMEO)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rcvtimeo (self, 1);
-    assert (zsock_rcvtimeo (self) == 1);
-    zsock_rcvtimeo (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SNDTIMEO)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_sndtimeo (self, 1);
-    assert (zsock_sndtimeo (self) == 1);
-    zsock_sndtimeo (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_XPUB_VERBOSE)
-    self = zsock_new (ZMQ_XPUB);
-    assert (self);
-    zsock_set_xpub_verbose (self, 1);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_TCP_KEEPALIVE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_tcp_keepalive (self, 1);
-    assert (zsock_tcp_keepalive (self) == 1);
-    zsock_tcp_keepalive (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_TCP_KEEPALIVE_IDLE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_tcp_keepalive_idle (self, 1);
-    assert (zsock_tcp_keepalive_idle (self) == 1);
-    zsock_tcp_keepalive_idle (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_TCP_KEEPALIVE_CNT)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_tcp_keepalive_cnt (self, 1);
-    assert (zsock_tcp_keepalive_cnt (self) == 1);
-    zsock_tcp_keepalive_cnt (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_TCP_KEEPALIVE_INTVL)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_tcp_keepalive_intvl (self, 1);
-    assert (zsock_tcp_keepalive_intvl (self) == 1);
-    zsock_tcp_keepalive_intvl (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_TCP_ACCEPT_FILTER)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_tcp_accept_filter (self, "127.0.0.1");
-    char *tcp_accept_filter = zsock_tcp_accept_filter (self);
-    assert (tcp_accept_filter);
-    free (tcp_accept_filter);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVMORE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_rcvmore (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_FD)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_fd (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_EVENTS)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_events (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_LAST_ENDPOINT)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    char *last_endpoint = zsock_last_endpoint (self);
-    assert (last_endpoint);
-    free (last_endpoint);
-    zsock_destroy (&self);
-#     endif
 #endif
 
-#if (ZMQ_VERSION_MAJOR == 2)
+#if (ZMQ_VERSION_MAJOR >= 2) && (ZMQ_VERSION_MAJOR < 3)
 #     if defined (ZMQ_HWM)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4592,7 +4666,6 @@ zsock_option_test (bool verbose)
     zsock_mcast_loop (self);
     zsock_destroy (&self);
 #     endif
-#   if (ZMQ_VERSION_MINOR == 2)
 #     if defined (ZMQ_RCVTIMEO)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4601,8 +4674,6 @@ zsock_option_test (bool verbose)
     zsock_rcvtimeo (self);
     zsock_destroy (&self);
 #     endif
-#   endif
-#   if (ZMQ_VERSION_MINOR == 2)
 #     if defined (ZMQ_SNDTIMEO)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4611,7 +4682,6 @@ zsock_option_test (bool verbose)
     zsock_sndtimeo (self);
     zsock_destroy (&self);
 #     endif
-#   endif
 #     if defined (ZMQ_SNDBUF)
     self = zsock_new (ZMQ_SUB);
     assert (self);


### PR DESCRIPTION
Solution: rework the sockopts compatibility layer to generate a
runtime check together with the build time check. In case the runtime
check fails, print an error stating what the minimum required is vs
the runtime version. It could be argued that an assert should be used
instead, but this follows the same principle as the existing
implementation where options not available at buildtime are compiled
to simply return 0 and be no-ops, rather than asserting.
Rework the sockopts.xml layout to let the options of each zmq version
be grouped together in different and independent blocks to allow mix
and match. Introduce a major_removed element to indicate in which
version an option has been removed, to allow a finer granularity in
the build time and run time checks.

Fixes https://github.com/zeromq/czmq/issues/1560

The retired options cannot be exposed in the public API unfortunately, as the bindings cannot cope with missing symbols.