### PR TITLE
Problem: zsock options API does not document libzmq requirements

### DIFF
--- a/api/zsock_option.api
+++ b/api/zsock_option.api
@@ -12,146 +12,175 @@
 
 <method name = "heartbeat ivl" polymorphic = "1">
     Get socket option `heartbeat_ivl`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set heartbeat ivl" polymorphic = "1">
     Set socket option `heartbeat_ivl`.
+    Available from libzmq 4.2.0.
     <argument name = "heartbeat ivl" type = "integer" />
 </method>
 
 <method name = "heartbeat ttl" polymorphic = "1">
     Get socket option `heartbeat_ttl`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set heartbeat ttl" polymorphic = "1">
     Set socket option `heartbeat_ttl`.
+    Available from libzmq 4.2.0.
     <argument name = "heartbeat ttl" type = "integer" />
 </method>
 
 <method name = "heartbeat timeout" polymorphic = "1">
     Get socket option `heartbeat_timeout`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set heartbeat timeout" polymorphic = "1">
     Set socket option `heartbeat_timeout`.
+    Available from libzmq 4.2.0.
     <argument name = "heartbeat timeout" type = "integer" />
 </method>
 
 <method name = "use fd" polymorphic = "1">
     Get socket option `use_fd`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set use fd" polymorphic = "1">
     Set socket option `use_fd`.
+    Available from libzmq 4.2.0.
     <argument name = "use fd" type = "integer" />
 </method>
 
 <method name = "set xpub manual" polymorphic = "1">
     Set socket option `xpub_manual`.
+    Available from libzmq 4.2.0.
     <argument name = "xpub manual" type = "integer" />
 </method>
 
 <method name = "set xpub welcome msg" polymorphic = "1">
     Set socket option `xpub_welcome_msg`.
+    Available from libzmq 4.2.0.
     <argument name = "xpub welcome msg" type = "string" />
 </method>
 
 <method name = "set stream notify" polymorphic = "1">
     Set socket option `stream_notify`.
+    Available from libzmq 4.2.0.
     <argument name = "stream notify" type = "integer" />
 </method>
 
 <method name = "invert matching" polymorphic = "1">
     Get socket option `invert_matching`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set invert matching" polymorphic = "1">
     Set socket option `invert_matching`.
+    Available from libzmq 4.2.0.
     <argument name = "invert matching" type = "integer" />
 </method>
 
 <method name = "set xpub verboser" polymorphic = "1">
     Set socket option `xpub_verboser`.
+    Available from libzmq 4.2.0.
     <argument name = "xpub verboser" type = "integer" />
 </method>
 
 <method name = "connect timeout" polymorphic = "1">
     Get socket option `connect_timeout`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set connect timeout" polymorphic = "1">
     Set socket option `connect_timeout`.
+    Available from libzmq 4.2.0.
     <argument name = "connect timeout" type = "integer" />
 </method>
 
 <method name = "tcp maxrt" polymorphic = "1">
     Get socket option `tcp_maxrt`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tcp maxrt" polymorphic = "1">
     Set socket option `tcp_maxrt`.
+    Available from libzmq 4.2.0.
     <argument name = "tcp maxrt" type = "integer" />
 </method>
 
 <method name = "thread safe" polymorphic = "1">
     Get socket option `thread_safe`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "multicast maxtpdu" polymorphic = "1">
     Get socket option `multicast_maxtpdu`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set multicast maxtpdu" polymorphic = "1">
     Set socket option `multicast_maxtpdu`.
+    Available from libzmq 4.2.0.
     <argument name = "multicast maxtpdu" type = "integer" />
 </method>
 
 <method name = "vmci buffer size" polymorphic = "1">
     Get socket option `vmci_buffer_size`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set vmci buffer size" polymorphic = "1">
     Set socket option `vmci_buffer_size`.
+    Available from libzmq 4.2.0.
     <argument name = "vmci buffer size" type = "integer" />
 </method>
 
 <method name = "vmci buffer min size" polymorphic = "1">
     Get socket option `vmci_buffer_min_size`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set vmci buffer min size" polymorphic = "1">
     Set socket option `vmci_buffer_min_size`.
+    Available from libzmq 4.2.0.
     <argument name = "vmci buffer min size" type = "integer" />
 </method>
 
 <method name = "vmci buffer max size" polymorphic = "1">
     Get socket option `vmci_buffer_max_size`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set vmci buffer max size" polymorphic = "1">
     Set socket option `vmci_buffer_max_size`.
+    Available from libzmq 4.2.0.
     <argument name = "vmci buffer max size" type = "integer" />
 </method>
 
 <method name = "vmci connect timeout" polymorphic = "1">
     Get socket option `vmci_connect_timeout`.
+    Available from libzmq 4.2.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set vmci connect timeout" polymorphic = "1">
     Set socket option `vmci_connect_timeout`.
+    Available from libzmq 4.2.0.
     <argument name = "vmci connect timeout" type = "integer" />
 </method>
 
@@ -159,51 +188,61 @@
 
 <method name = "tos" polymorphic = "1">
     Get socket option `tos`.
+    Available from libzmq 4.1.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tos" polymorphic = "1">
     Set socket option `tos`.
+    Available from libzmq 4.1.0.
     <argument name = "tos" type = "integer" />
 </method>
 
 <method name = "set router handover" polymorphic = "1">
     Set socket option `router_handover`.
+    Available from libzmq 4.1.0.
     <argument name = "router handover" type = "integer" />
 </method>
 
 <method name = "set connect rid" polymorphic = "1">
     Set socket option `connect_rid`.
+    Available from libzmq 4.1.0.
     <argument name = "connect rid" type = "string" />
 </method>
 
 <method name = "set connect rid bin" polymorphic = "1">
     Set socket option `connect_rid` from 32-octet binary
+    Available from libzmq 4.1.0.
     <argument name = "connect rid" type = "buffer" />
 </method>
 
 <method name = "handshake ivl" polymorphic = "1">
     Get socket option `handshake_ivl`.
+    Available from libzmq 4.1.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set handshake ivl" polymorphic = "1">
     Set socket option `handshake_ivl`.
+    Available from libzmq 4.1.0.
     <argument name = "handshake ivl" type = "integer" />
 </method>
 
 <method name = "socks proxy" polymorphic = "1">
     Get socket option `socks_proxy`.
+    Available from libzmq 4.1.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set socks proxy" polymorphic = "1">
     Set socket option `socks_proxy`.
+    Available from libzmq 4.1.0.
     <argument name = "socks proxy" type = "string" />
 </method>
 
 <method name = "set xpub nodrop" polymorphic = "1">
     Set socket option `xpub_nodrop`.
+    Available from libzmq 4.1.0.
     <argument name = "xpub nodrop" type = "integer" />
 </method>
 
@@ -211,186 +250,223 @@
 
 <method name = "set router mandatory" polymorphic = "1">
     Set socket option `router_mandatory`.
+    Available from libzmq 4.0.0.
     <argument name = "router mandatory" type = "integer" />
 </method>
 
 <method name = "set probe router" polymorphic = "1">
     Set socket option `probe_router`.
+    Available from libzmq 4.0.0.
     <argument name = "probe router" type = "integer" />
 </method>
 
 <method name = "set req relaxed" polymorphic = "1">
     Set socket option `req_relaxed`.
+    Available from libzmq 4.0.0.
     <argument name = "req relaxed" type = "integer" />
 </method>
 
 <method name = "set req correlate" polymorphic = "1">
     Set socket option `req_correlate`.
+    Available from libzmq 4.0.0.
     <argument name = "req correlate" type = "integer" />
 </method>
 
 <method name = "set conflate" polymorphic = "1">
     Set socket option `conflate`.
+    Available from libzmq 4.0.0.
     <argument name = "conflate" type = "integer" />
 </method>
 
 <method name = "zap domain" polymorphic = "1">
     Get socket option `zap_domain`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set zap domain" polymorphic = "1">
     Set socket option `zap_domain`.
+    Available from libzmq 4.0.0.
     <argument name = "zap domain" type = "string" />
 </method>
 
 <method name = "mechanism" polymorphic = "1">
     Get socket option `mechanism`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "plain server" polymorphic = "1">
     Get socket option `plain_server`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set plain server" polymorphic = "1">
     Set socket option `plain_server`.
+    Available from libzmq 4.0.0.
     <argument name = "plain server" type = "integer" />
 </method>
 
 <method name = "plain username" polymorphic = "1">
     Get socket option `plain_username`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set plain username" polymorphic = "1">
     Set socket option `plain_username`.
+    Available from libzmq 4.0.0.
     <argument name = "plain username" type = "string" />
 </method>
 
 <method name = "plain password" polymorphic = "1">
     Get socket option `plain_password`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set plain password" polymorphic = "1">
     Set socket option `plain_password`.
+    Available from libzmq 4.0.0.
     <argument name = "plain password" type = "string" />
 </method>
 
 <method name = "curve server" polymorphic = "1">
     Get socket option `curve_server`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set curve server" polymorphic = "1">
     Set socket option `curve_server`.
+    Available from libzmq 4.0.0.
     <argument name = "curve server" type = "integer" />
 </method>
 
 <method name = "curve publickey" polymorphic = "1">
     Get socket option `curve_publickey`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set curve publickey" polymorphic = "1">
     Set socket option `curve_publickey`.
+    Available from libzmq 4.0.0.
     <argument name = "curve publickey" type = "string" />
 </method>
 
 <method name = "set curve publickey bin" polymorphic = "1">
     Set socket option `curve_publickey` from 32-octet binary
+    Available from libzmq 4.0.0.
     <argument name = "curve publickey" type = "buffer" />
 </method>
 
 <method name = "curve secretkey" polymorphic = "1">
     Get socket option `curve_secretkey`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set curve secretkey" polymorphic = "1">
     Set socket option `curve_secretkey`.
+    Available from libzmq 4.0.0.
     <argument name = "curve secretkey" type = "string" />
 </method>
 
 <method name = "set curve secretkey bin" polymorphic = "1">
     Set socket option `curve_secretkey` from 32-octet binary
+    Available from libzmq 4.0.0.
     <argument name = "curve secretkey" type = "buffer" />
 </method>
 
 <method name = "curve serverkey" polymorphic = "1">
     Get socket option `curve_serverkey`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set curve serverkey" polymorphic = "1">
     Set socket option `curve_serverkey`.
+    Available from libzmq 4.0.0.
     <argument name = "curve serverkey" type = "string" />
 </method>
 
 <method name = "set curve serverkey bin" polymorphic = "1">
     Set socket option `curve_serverkey` from 32-octet binary
+    Available from libzmq 4.0.0.
     <argument name = "curve serverkey" type = "buffer" />
 </method>
 
 <method name = "gssapi server" polymorphic = "1">
     Get socket option `gssapi_server`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set gssapi server" polymorphic = "1">
     Set socket option `gssapi_server`.
+    Available from libzmq 4.0.0.
     <argument name = "gssapi server" type = "integer" />
 </method>
 
 <method name = "gssapi plaintext" polymorphic = "1">
     Get socket option `gssapi_plaintext`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set gssapi plaintext" polymorphic = "1">
     Set socket option `gssapi_plaintext`.
+    Available from libzmq 4.0.0.
     <argument name = "gssapi plaintext" type = "integer" />
 </method>
 
 <method name = "gssapi principal" polymorphic = "1">
     Get socket option `gssapi_principal`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set gssapi principal" polymorphic = "1">
     Set socket option `gssapi_principal`.
+    Available from libzmq 4.0.0.
     <argument name = "gssapi principal" type = "string" />
 </method>
 
 <method name = "gssapi service principal" polymorphic = "1">
     Get socket option `gssapi_service_principal`.
+    Available from libzmq 4.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set gssapi service principal" polymorphic = "1">
     Set socket option `gssapi_service_principal`.
+    Available from libzmq 4.0.0.
     <argument name = "gssapi service principal" type = "string" />
 </method>
 
 <method name = "ipv6" polymorphic = "1">
     Get socket option `ipv6`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set ipv6" polymorphic = "1">
     Set socket option `ipv6`.
+    Available from libzmq 4.0.0.
     <argument name = "ipv6" type = "integer" />
 </method>
 
 <method name = "immediate" polymorphic = "1">
     Get socket option `immediate`.
+    Available from libzmq 4.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set immediate" polymorphic = "1">
     Set socket option `immediate`.
+    Available from libzmq 4.0.0.
     <argument name = "immediate" type = "integer" />
 </method>
 
@@ -398,270 +474,324 @@
 
 <method name = "type" polymorphic = "1">
     Get socket option `type`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "sndhwm" polymorphic = "1">
     Get socket option `sndhwm`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set sndhwm" polymorphic = "1">
     Set socket option `sndhwm`.
+    Available from libzmq 3.0.0.
     <argument name = "sndhwm" type = "integer" />
 </method>
 
 <method name = "rcvhwm" polymorphic = "1">
     Get socket option `rcvhwm`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set rcvhwm" polymorphic = "1">
     Set socket option `rcvhwm`.
+    Available from libzmq 3.0.0.
     <argument name = "rcvhwm" type = "integer" />
 </method>
 
 <method name = "affinity" polymorphic = "1">
     Get socket option `affinity`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set affinity" polymorphic = "1">
     Set socket option `affinity`.
+    Available from libzmq 3.0.0.
     <argument name = "affinity" type = "integer" />
 </method>
 
 <method name = "set subscribe" polymorphic = "1">
     Set socket option `subscribe`.
+    Available from libzmq 3.0.0.
     <argument name = "subscribe" type = "string" />
 </method>
 
 <method name = "set unsubscribe" polymorphic = "1">
     Set socket option `unsubscribe`.
+    Available from libzmq 3.0.0.
     <argument name = "unsubscribe" type = "string" />
 </method>
 
 <method name = "identity" polymorphic = "1">
     Get socket option `identity`.
+    Available from libzmq 3.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set identity" polymorphic = "1">
     Set socket option `identity`.
+    Available from libzmq 3.0.0.
     <argument name = "identity" type = "string" />
 </method>
 
 <method name = "rate" polymorphic = "1">
     Get socket option `rate`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set rate" polymorphic = "1">
     Set socket option `rate`.
+    Available from libzmq 3.0.0.
     <argument name = "rate" type = "integer" />
 </method>
 
 <method name = "recovery ivl" polymorphic = "1">
     Get socket option `recovery_ivl`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set recovery ivl" polymorphic = "1">
     Set socket option `recovery_ivl`.
+    Available from libzmq 3.0.0.
     <argument name = "recovery ivl" type = "integer" />
 </method>
 
 <method name = "sndbuf" polymorphic = "1">
     Get socket option `sndbuf`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set sndbuf" polymorphic = "1">
     Set socket option `sndbuf`.
+    Available from libzmq 3.0.0.
     <argument name = "sndbuf" type = "integer" />
 </method>
 
 <method name = "rcvbuf" polymorphic = "1">
     Get socket option `rcvbuf`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set rcvbuf" polymorphic = "1">
     Set socket option `rcvbuf`.
+    Available from libzmq 3.0.0.
     <argument name = "rcvbuf" type = "integer" />
 </method>
 
 <method name = "linger" polymorphic = "1">
     Get socket option `linger`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set linger" polymorphic = "1">
     Set socket option `linger`.
+    Available from libzmq 3.0.0.
     <argument name = "linger" type = "integer" />
 </method>
 
 <method name = "reconnect ivl" polymorphic = "1">
     Get socket option `reconnect_ivl`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set reconnect ivl" polymorphic = "1">
     Set socket option `reconnect_ivl`.
+    Available from libzmq 3.0.0.
     <argument name = "reconnect ivl" type = "integer" />
 </method>
 
 <method name = "reconnect ivl max" polymorphic = "1">
     Get socket option `reconnect_ivl_max`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set reconnect ivl max" polymorphic = "1">
     Set socket option `reconnect_ivl_max`.
+    Available from libzmq 3.0.0.
     <argument name = "reconnect ivl max" type = "integer" />
 </method>
 
 <method name = "backlog" polymorphic = "1">
     Get socket option `backlog`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set backlog" polymorphic = "1">
     Set socket option `backlog`.
+    Available from libzmq 3.0.0.
     <argument name = "backlog" type = "integer" />
 </method>
 
 <method name = "maxmsgsize" polymorphic = "1">
     Get socket option `maxmsgsize`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set maxmsgsize" polymorphic = "1">
     Set socket option `maxmsgsize`.
+    Available from libzmq 3.0.0.
     <argument name = "maxmsgsize" type = "integer" />
 </method>
 
 <method name = "multicast hops" polymorphic = "1">
     Get socket option `multicast_hops`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set multicast hops" polymorphic = "1">
     Set socket option `multicast_hops`.
+    Available from libzmq 3.0.0.
     <argument name = "multicast hops" type = "integer" />
 </method>
 
 <method name = "rcvtimeo" polymorphic = "1">
     Get socket option `rcvtimeo`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set rcvtimeo" polymorphic = "1">
     Set socket option `rcvtimeo`.
+    Available from libzmq 3.0.0.
     <argument name = "rcvtimeo" type = "integer" />
 </method>
 
 <method name = "sndtimeo" polymorphic = "1">
     Get socket option `sndtimeo`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set sndtimeo" polymorphic = "1">
     Set socket option `sndtimeo`.
+    Available from libzmq 3.0.0.
     <argument name = "sndtimeo" type = "integer" />
 </method>
 
 <method name = "set xpub verbose" polymorphic = "1">
     Set socket option `xpub_verbose`.
+    Available from libzmq 3.0.0.
     <argument name = "xpub verbose" type = "integer" />
 </method>
 
 <method name = "tcp keepalive" polymorphic = "1">
     Get socket option `tcp_keepalive`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tcp keepalive" polymorphic = "1">
     Set socket option `tcp_keepalive`.
+    Available from libzmq 3.0.0.
     <argument name = "tcp keepalive" type = "integer" />
 </method>
 
 <method name = "tcp keepalive idle" polymorphic = "1">
     Get socket option `tcp_keepalive_idle`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tcp keepalive idle" polymorphic = "1">
     Set socket option `tcp_keepalive_idle`.
+    Available from libzmq 3.0.0.
     <argument name = "tcp keepalive idle" type = "integer" />
 </method>
 
 <method name = "tcp keepalive cnt" polymorphic = "1">
     Get socket option `tcp_keepalive_cnt`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tcp keepalive cnt" polymorphic = "1">
     Set socket option `tcp_keepalive_cnt`.
+    Available from libzmq 3.0.0.
     <argument name = "tcp keepalive cnt" type = "integer" />
 </method>
 
 <method name = "tcp keepalive intvl" polymorphic = "1">
     Get socket option `tcp_keepalive_intvl`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set tcp keepalive intvl" polymorphic = "1">
     Set socket option `tcp_keepalive_intvl`.
+    Available from libzmq 3.0.0.
     <argument name = "tcp keepalive intvl" type = "integer" />
 </method>
 
 <method name = "tcp accept filter" polymorphic = "1">
     Get socket option `tcp_accept_filter`.
+    Available from libzmq 3.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set tcp accept filter" polymorphic = "1">
     Set socket option `tcp_accept_filter`.
+    Available from libzmq 3.0.0.
     <argument name = "tcp accept filter" type = "string" />
 </method>
 
 <method name = "rcvmore" polymorphic = "1">
     Get socket option `rcvmore`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "fd" polymorphic = "1">
     Get socket option `fd`.
+    Available from libzmq 3.0.0.
     <return type = "socket" fresh = "1" />
 </method>
 
 <method name = "events" polymorphic = "1">
     Get socket option `events`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "last endpoint" polymorphic = "1">
     Get socket option `last_endpoint`.
+    Available from libzmq 3.0.0.
     <return type = "string" fresh = "1" />
 </method>
 
 <method name = "set router raw" polymorphic = "1">
     Set socket option `router_raw`.
+    Available from libzmq 3.0.0.
     <argument name = "router raw" type = "integer" />
 </method>
 
 <method name = "ipv4only" polymorphic = "1">
     Get socket option `ipv4only`.
+    Available from libzmq 3.0.0.
     <return type = "integer" fresh = "1" />
 </method>
 
 <method name = "set ipv4only" polymorphic = "1">
     Set socket option `ipv4only`.
+    Available from libzmq 3.0.0.
     <argument name = "ipv4only" type = "integer" />
 </method>
 
 <method name = "set delay attach on connect" polymorphic = "1">
     Set socket option `delay_attach_on_connect`.
+    Available from libzmq 3.0.0.
     <argument name = "delay attach on connect" type = "integer" />
 </method>

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -446,6 +446,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `heartbeat_ivl`.
+    Available from libzmq 4.2.0.      
     */
     native static int __heartbeatIvl (long self);
     public int heartbeatIvl () {
@@ -453,6 +454,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `heartbeat_ivl`.
+    Available from libzmq 4.2.0.      
     */
     native static void __setHeartbeatIvl (long self, int heartbeatIvl);
     public void setHeartbeatIvl (int heartbeatIvl) {
@@ -460,6 +462,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `heartbeat_ttl`.
+    Available from libzmq 4.2.0.      
     */
     native static int __heartbeatTtl (long self);
     public int heartbeatTtl () {
@@ -467,6 +470,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `heartbeat_ttl`.
+    Available from libzmq 4.2.0.      
     */
     native static void __setHeartbeatTtl (long self, int heartbeatTtl);
     public void setHeartbeatTtl (int heartbeatTtl) {
@@ -474,6 +478,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `heartbeat_timeout`.
+    Available from libzmq 4.2.0.          
     */
     native static int __heartbeatTimeout (long self);
     public int heartbeatTimeout () {
@@ -481,20 +486,23 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `heartbeat_timeout`.
+    Available from libzmq 4.2.0.          
     */
     native static void __setHeartbeatTimeout (long self, int heartbeatTimeout);
     public void setHeartbeatTimeout (int heartbeatTimeout) {
         __setHeartbeatTimeout (self, heartbeatTimeout);
     }
     /*
-    Get socket option `use_fd`.
+    Get socket option `use_fd`. 
+    Available from libzmq 4.2.0.
     */
     native static int __useFd (long self);
     public int useFd () {
         return __useFd (self);
     }
     /*
-    Set socket option `use_fd`.
+    Set socket option `use_fd`. 
+    Available from libzmq 4.2.0.
     */
     native static void __setUseFd (long self, int useFd);
     public void setUseFd (int useFd) {
@@ -502,6 +510,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `xpub_manual`.
+    Available from libzmq 4.2.0.    
     */
     native static void __setXpubManual (long self, int xpubManual);
     public void setXpubManual (int xpubManual) {
@@ -509,6 +518,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `xpub_welcome_msg`.
+    Available from libzmq 4.2.0.         
     */
     native static void __setXpubWelcomeMsg (long self, String xpubWelcomeMsg);
     public void setXpubWelcomeMsg (String xpubWelcomeMsg) {
@@ -516,6 +526,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `stream_notify`.
+    Available from libzmq 4.2.0.      
     */
     native static void __setStreamNotify (long self, int streamNotify);
     public void setStreamNotify (int streamNotify) {
@@ -523,6 +534,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `invert_matching`.
+    Available from libzmq 4.2.0.        
     */
     native static int __invertMatching (long self);
     public int invertMatching () {
@@ -530,6 +542,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `invert_matching`.
+    Available from libzmq 4.2.0.        
     */
     native static void __setInvertMatching (long self, int invertMatching);
     public void setInvertMatching (int invertMatching) {
@@ -537,6 +550,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `xpub_verboser`.
+    Available from libzmq 4.2.0.      
     */
     native static void __setXpubVerboser (long self, int xpubVerboser);
     public void setXpubVerboser (int xpubVerboser) {
@@ -544,6 +558,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `connect_timeout`.
+    Available from libzmq 4.2.0.        
     */
     native static int __connectTimeout (long self);
     public int connectTimeout () {
@@ -551,6 +566,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `connect_timeout`.
+    Available from libzmq 4.2.0.        
     */
     native static void __setConnectTimeout (long self, int connectTimeout);
     public void setConnectTimeout (int connectTimeout) {
@@ -558,6 +574,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_maxrt`.
+    Available from libzmq 4.2.0.  
     */
     native static int __tcpMaxrt (long self);
     public int tcpMaxrt () {
@@ -565,6 +582,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_maxrt`.
+    Available from libzmq 4.2.0.  
     */
     native static void __setTcpMaxrt (long self, int tcpMaxrt);
     public void setTcpMaxrt (int tcpMaxrt) {
@@ -572,6 +590,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `thread_safe`.
+    Available from libzmq 4.2.0.    
     */
     native static int __threadSafe (long self);
     public int threadSafe () {
@@ -579,6 +598,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `multicast_maxtpdu`.
+    Available from libzmq 4.2.0.          
     */
     native static int __multicastMaxtpdu (long self);
     public int multicastMaxtpdu () {
@@ -586,6 +606,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `multicast_maxtpdu`.
+    Available from libzmq 4.2.0.          
     */
     native static void __setMulticastMaxtpdu (long self, int multicastMaxtpdu);
     public void setMulticastMaxtpdu (int multicastMaxtpdu) {
@@ -593,6 +614,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `vmci_buffer_size`.
+    Available from libzmq 4.2.0.         
     */
     native static int __vmciBufferSize (long self);
     public int vmciBufferSize () {
@@ -600,6 +622,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `vmci_buffer_size`.
+    Available from libzmq 4.2.0.         
     */
     native static void __setVmciBufferSize (long self, int vmciBufferSize);
     public void setVmciBufferSize (int vmciBufferSize) {
@@ -607,6 +630,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `vmci_buffer_min_size`.
+    Available from libzmq 4.2.0.             
     */
     native static int __vmciBufferMinSize (long self);
     public int vmciBufferMinSize () {
@@ -614,6 +638,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `vmci_buffer_min_size`.
+    Available from libzmq 4.2.0.             
     */
     native static void __setVmciBufferMinSize (long self, int vmciBufferMinSize);
     public void setVmciBufferMinSize (int vmciBufferMinSize) {
@@ -621,6 +646,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `vmci_buffer_max_size`.
+    Available from libzmq 4.2.0.             
     */
     native static int __vmciBufferMaxSize (long self);
     public int vmciBufferMaxSize () {
@@ -628,6 +654,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `vmci_buffer_max_size`.
+    Available from libzmq 4.2.0.             
     */
     native static void __setVmciBufferMaxSize (long self, int vmciBufferMaxSize);
     public void setVmciBufferMaxSize (int vmciBufferMaxSize) {
@@ -635,6 +662,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `vmci_connect_timeout`.
+    Available from libzmq 4.2.0.             
     */
     native static int __vmciConnectTimeout (long self);
     public int vmciConnectTimeout () {
@@ -642,20 +670,23 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `vmci_connect_timeout`.
+    Available from libzmq 4.2.0.             
     */
     native static void __setVmciConnectTimeout (long self, int vmciConnectTimeout);
     public void setVmciConnectTimeout (int vmciConnectTimeout) {
         __setVmciConnectTimeout (self, vmciConnectTimeout);
     }
     /*
-    Get socket option `tos`.
+    Get socket option `tos`.    
+    Available from libzmq 4.1.0.
     */
     native static int __tos (long self);
     public int tos () {
         return __tos (self);
     }
     /*
-    Set socket option `tos`.
+    Set socket option `tos`.    
+    Available from libzmq 4.1.0.
     */
     native static void __setTos (long self, int tos);
     public void setTos (int tos) {
@@ -663,6 +694,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `router_handover`.
+    Available from libzmq 4.1.0.        
     */
     native static void __setRouterHandover (long self, int routerHandover);
     public void setRouterHandover (int routerHandover) {
@@ -670,6 +702,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `connect_rid`.
+    Available from libzmq 4.1.0.    
     */
     native static void __setConnectRid (long self, String connectRid);
     public void setConnectRid (String connectRid) {
@@ -677,6 +710,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `connect_rid` from 32-octet binary
+    Available from libzmq 4.1.0.                        
     */
     native static void __setConnectRidBin (long self, byte [] connectRid);
     public void setConnectRidBin (byte [] connectRid) {
@@ -684,6 +718,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `handshake_ivl`.
+    Available from libzmq 4.1.0.      
     */
     native static int __handshakeIvl (long self);
     public int handshakeIvl () {
@@ -691,6 +726,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `handshake_ivl`.
+    Available from libzmq 4.1.0.      
     */
     native static void __setHandshakeIvl (long self, int handshakeIvl);
     public void setHandshakeIvl (int handshakeIvl) {
@@ -698,6 +734,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `socks_proxy`.
+    Available from libzmq 4.1.0.    
     */
     native static String __socksProxy (long self);
     public String socksProxy () {
@@ -705,6 +742,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `socks_proxy`.
+    Available from libzmq 4.1.0.    
     */
     native static void __setSocksProxy (long self, String socksProxy);
     public void setSocksProxy (String socksProxy) {
@@ -712,6 +750,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `xpub_nodrop`.
+    Available from libzmq 4.1.0.    
     */
     native static void __setXpubNodrop (long self, int xpubNodrop);
     public void setXpubNodrop (int xpubNodrop) {
@@ -719,6 +758,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `router_mandatory`.
+    Available from libzmq 4.0.0.         
     */
     native static void __setRouterMandatory (long self, int routerMandatory);
     public void setRouterMandatory (int routerMandatory) {
@@ -726,6 +766,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `probe_router`.
+    Available from libzmq 4.0.0.     
     */
     native static void __setProbeRouter (long self, int probeRouter);
     public void setProbeRouter (int probeRouter) {
@@ -733,6 +774,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `req_relaxed`.
+    Available from libzmq 4.0.0.    
     */
     native static void __setReqRelaxed (long self, int reqRelaxed);
     public void setReqRelaxed (int reqRelaxed) {
@@ -740,6 +782,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `req_correlate`.
+    Available from libzmq 4.0.0.      
     */
     native static void __setReqCorrelate (long self, int reqCorrelate);
     public void setReqCorrelate (int reqCorrelate) {
@@ -747,6 +790,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `conflate`.
+    Available from libzmq 4.0.0. 
     */
     native static void __setConflate (long self, int conflate);
     public void setConflate (int conflate) {
@@ -754,6 +798,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `zap_domain`.
+    Available from libzmq 4.0.0.   
     */
     native static String __zapDomain (long self);
     public String zapDomain () {
@@ -761,6 +806,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `zap_domain`.
+    Available from libzmq 4.0.0.   
     */
     native static void __setZapDomain (long self, String zapDomain);
     public void setZapDomain (String zapDomain) {
@@ -768,6 +814,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `mechanism`.
+    Available from libzmq 4.0.0.  
     */
     native static int __mechanism (long self);
     public int mechanism () {
@@ -775,6 +822,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `plain_server`.
+    Available from libzmq 4.0.0.     
     */
     native static int __plainServer (long self);
     public int plainServer () {
@@ -782,6 +830,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `plain_server`.
+    Available from libzmq 4.0.0.     
     */
     native static void __setPlainServer (long self, int plainServer);
     public void setPlainServer (int plainServer) {
@@ -789,6 +838,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `plain_username`.
+    Available from libzmq 4.0.0.       
     */
     native static String __plainUsername (long self);
     public String plainUsername () {
@@ -796,6 +846,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `plain_username`.
+    Available from libzmq 4.0.0.       
     */
     native static void __setPlainUsername (long self, String plainUsername);
     public void setPlainUsername (String plainUsername) {
@@ -803,6 +854,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `plain_password`.
+    Available from libzmq 4.0.0.       
     */
     native static String __plainPassword (long self);
     public String plainPassword () {
@@ -810,6 +862,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `plain_password`.
+    Available from libzmq 4.0.0.       
     */
     native static void __setPlainPassword (long self, String plainPassword);
     public void setPlainPassword (String plainPassword) {
@@ -817,6 +870,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `curve_server`.
+    Available from libzmq 4.0.0.     
     */
     native static int __curveServer (long self);
     public int curveServer () {
@@ -824,6 +878,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_server`.
+    Available from libzmq 4.0.0.     
     */
     native static void __setCurveServer (long self, int curveServer);
     public void setCurveServer (int curveServer) {
@@ -831,6 +886,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `curve_publickey`.
+    Available from libzmq 4.0.0.        
     */
     native static String __curvePublickey (long self);
     public String curvePublickey () {
@@ -838,6 +894,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_publickey`.
+    Available from libzmq 4.0.0.        
     */
     native static void __setCurvePublickey (long self, String curvePublickey);
     public void setCurvePublickey (String curvePublickey) {
@@ -845,6 +902,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_publickey` from 32-octet binary
+    Available from libzmq 4.0.0.                            
     */
     native static void __setCurvePublickeyBin (long self, byte [] curvePublickey);
     public void setCurvePublickeyBin (byte [] curvePublickey) {
@@ -852,6 +910,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `curve_secretkey`.
+    Available from libzmq 4.0.0.        
     */
     native static String __curveSecretkey (long self);
     public String curveSecretkey () {
@@ -859,6 +918,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_secretkey`.
+    Available from libzmq 4.0.0.        
     */
     native static void __setCurveSecretkey (long self, String curveSecretkey);
     public void setCurveSecretkey (String curveSecretkey) {
@@ -866,6 +926,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_secretkey` from 32-octet binary
+    Available from libzmq 4.0.0.                            
     */
     native static void __setCurveSecretkeyBin (long self, byte [] curveSecretkey);
     public void setCurveSecretkeyBin (byte [] curveSecretkey) {
@@ -873,6 +934,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `curve_serverkey`.
+    Available from libzmq 4.0.0.        
     */
     native static String __curveServerkey (long self);
     public String curveServerkey () {
@@ -880,6 +942,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_serverkey`.
+    Available from libzmq 4.0.0.        
     */
     native static void __setCurveServerkey (long self, String curveServerkey);
     public void setCurveServerkey (String curveServerkey) {
@@ -887,6 +950,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `curve_serverkey` from 32-octet binary
+    Available from libzmq 4.0.0.                            
     */
     native static void __setCurveServerkeyBin (long self, byte [] curveServerkey);
     public void setCurveServerkeyBin (byte [] curveServerkey) {
@@ -894,6 +958,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `gssapi_server`.
+    Available from libzmq 4.0.0.      
     */
     native static int __gssapiServer (long self);
     public int gssapiServer () {
@@ -901,6 +966,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `gssapi_server`.
+    Available from libzmq 4.0.0.      
     */
     native static void __setGssapiServer (long self, int gssapiServer);
     public void setGssapiServer (int gssapiServer) {
@@ -908,6 +974,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `gssapi_plaintext`.
+    Available from libzmq 4.0.0.         
     */
     native static int __gssapiPlaintext (long self);
     public int gssapiPlaintext () {
@@ -915,6 +982,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `gssapi_plaintext`.
+    Available from libzmq 4.0.0.         
     */
     native static void __setGssapiPlaintext (long self, int gssapiPlaintext);
     public void setGssapiPlaintext (int gssapiPlaintext) {
@@ -922,6 +990,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `gssapi_principal`.
+    Available from libzmq 4.0.0.         
     */
     native static String __gssapiPrincipal (long self);
     public String gssapiPrincipal () {
@@ -929,6 +998,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `gssapi_principal`.
+    Available from libzmq 4.0.0.         
     */
     native static void __setGssapiPrincipal (long self, String gssapiPrincipal);
     public void setGssapiPrincipal (String gssapiPrincipal) {
@@ -936,6 +1006,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `gssapi_service_principal`.
+    Available from libzmq 4.0.0.                 
     */
     native static String __gssapiServicePrincipal (long self);
     public String gssapiServicePrincipal () {
@@ -943,20 +1014,23 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `gssapi_service_principal`.
+    Available from libzmq 4.0.0.                 
     */
     native static void __setGssapiServicePrincipal (long self, String gssapiServicePrincipal);
     public void setGssapiServicePrincipal (String gssapiServicePrincipal) {
         __setGssapiServicePrincipal (self, gssapiServicePrincipal);
     }
     /*
-    Get socket option `ipv6`.
+    Get socket option `ipv6`.   
+    Available from libzmq 4.0.0.
     */
     native static int __ipv6 (long self);
     public int ipv6 () {
         return __ipv6 (self);
     }
     /*
-    Set socket option `ipv6`.
+    Set socket option `ipv6`.   
+    Available from libzmq 4.0.0.
     */
     native static void __setIpv6 (long self, int ipv6);
     public void setIpv6 (int ipv6) {
@@ -964,6 +1038,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `immediate`.
+    Available from libzmq 4.0.0.  
     */
     native static int __immediate (long self);
     public int immediate () {
@@ -971,41 +1046,47 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `immediate`.
+    Available from libzmq 4.0.0.  
     */
     native static void __setImmediate (long self, int immediate);
     public void setImmediate (int immediate) {
         __setImmediate (self, immediate);
     }
     /*
-    Get socket option `type`.
+    Get socket option `type`.   
+    Available from libzmq 3.0.0.
     */
     native static int __type (long self);
     public int type () {
         return __type (self);
     }
     /*
-    Get socket option `sndhwm`.
+    Get socket option `sndhwm`. 
+    Available from libzmq 3.0.0.
     */
     native static int __sndhwm (long self);
     public int sndhwm () {
         return __sndhwm (self);
     }
     /*
-    Set socket option `sndhwm`.
+    Set socket option `sndhwm`. 
+    Available from libzmq 3.0.0.
     */
     native static void __setSndhwm (long self, int sndhwm);
     public void setSndhwm (int sndhwm) {
         __setSndhwm (self, sndhwm);
     }
     /*
-    Get socket option `rcvhwm`.
+    Get socket option `rcvhwm`. 
+    Available from libzmq 3.0.0.
     */
     native static int __rcvhwm (long self);
     public int rcvhwm () {
         return __rcvhwm (self);
     }
     /*
-    Set socket option `rcvhwm`.
+    Set socket option `rcvhwm`. 
+    Available from libzmq 3.0.0.
     */
     native static void __setRcvhwm (long self, int rcvhwm);
     public void setRcvhwm (int rcvhwm) {
@@ -1013,6 +1094,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `affinity`.
+    Available from libzmq 3.0.0. 
     */
     native static int __affinity (long self);
     public int affinity () {
@@ -1020,6 +1102,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `affinity`.
+    Available from libzmq 3.0.0. 
     */
     native static void __setAffinity (long self, int affinity);
     public void setAffinity (int affinity) {
@@ -1027,6 +1110,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `subscribe`.
+    Available from libzmq 3.0.0.  
     */
     native static void __setSubscribe (long self, String subscribe);
     public void setSubscribe (String subscribe) {
@@ -1034,6 +1118,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `unsubscribe`.
+    Available from libzmq 3.0.0.    
     */
     native static void __setUnsubscribe (long self, String unsubscribe);
     public void setUnsubscribe (String unsubscribe) {
@@ -1041,6 +1126,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `identity`.
+    Available from libzmq 3.0.0. 
     */
     native static String __identity (long self);
     public String identity () {
@@ -1048,20 +1134,23 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `identity`.
+    Available from libzmq 3.0.0. 
     */
     native static void __setIdentity (long self, String identity);
     public void setIdentity (String identity) {
         __setIdentity (self, identity);
     }
     /*
-    Get socket option `rate`.
+    Get socket option `rate`.   
+    Available from libzmq 3.0.0.
     */
     native static int __rate (long self);
     public int rate () {
         return __rate (self);
     }
     /*
-    Set socket option `rate`.
+    Set socket option `rate`.   
+    Available from libzmq 3.0.0.
     */
     native static void __setRate (long self, int rate);
     public void setRate (int rate) {
@@ -1069,6 +1158,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `recovery_ivl`.
+    Available from libzmq 3.0.0.     
     */
     native static int __recoveryIvl (long self);
     public int recoveryIvl () {
@@ -1076,48 +1166,55 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `recovery_ivl`.
+    Available from libzmq 3.0.0.     
     */
     native static void __setRecoveryIvl (long self, int recoveryIvl);
     public void setRecoveryIvl (int recoveryIvl) {
         __setRecoveryIvl (self, recoveryIvl);
     }
     /*
-    Get socket option `sndbuf`.
+    Get socket option `sndbuf`. 
+    Available from libzmq 3.0.0.
     */
     native static int __sndbuf (long self);
     public int sndbuf () {
         return __sndbuf (self);
     }
     /*
-    Set socket option `sndbuf`.
+    Set socket option `sndbuf`. 
+    Available from libzmq 3.0.0.
     */
     native static void __setSndbuf (long self, int sndbuf);
     public void setSndbuf (int sndbuf) {
         __setSndbuf (self, sndbuf);
     }
     /*
-    Get socket option `rcvbuf`.
+    Get socket option `rcvbuf`. 
+    Available from libzmq 3.0.0.
     */
     native static int __rcvbuf (long self);
     public int rcvbuf () {
         return __rcvbuf (self);
     }
     /*
-    Set socket option `rcvbuf`.
+    Set socket option `rcvbuf`. 
+    Available from libzmq 3.0.0.
     */
     native static void __setRcvbuf (long self, int rcvbuf);
     public void setRcvbuf (int rcvbuf) {
         __setRcvbuf (self, rcvbuf);
     }
     /*
-    Get socket option `linger`.
+    Get socket option `linger`. 
+    Available from libzmq 3.0.0.
     */
     native static int __linger (long self);
     public int linger () {
         return __linger (self);
     }
     /*
-    Set socket option `linger`.
+    Set socket option `linger`. 
+    Available from libzmq 3.0.0.
     */
     native static void __setLinger (long self, int linger);
     public void setLinger (int linger) {
@@ -1125,6 +1222,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `reconnect_ivl`.
+    Available from libzmq 3.0.0.      
     */
     native static int __reconnectIvl (long self);
     public int reconnectIvl () {
@@ -1132,6 +1230,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `reconnect_ivl`.
+    Available from libzmq 3.0.0.      
     */
     native static void __setReconnectIvl (long self, int reconnectIvl);
     public void setReconnectIvl (int reconnectIvl) {
@@ -1139,6 +1238,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `reconnect_ivl_max`.
+    Available from libzmq 3.0.0.          
     */
     native static int __reconnectIvlMax (long self);
     public int reconnectIvlMax () {
@@ -1146,6 +1246,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `reconnect_ivl_max`.
+    Available from libzmq 3.0.0.          
     */
     native static void __setReconnectIvlMax (long self, int reconnectIvlMax);
     public void setReconnectIvlMax (int reconnectIvlMax) {
@@ -1153,6 +1254,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `backlog`.
+    Available from libzmq 3.0.0.
     */
     native static int __backlog (long self);
     public int backlog () {
@@ -1160,6 +1262,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `backlog`.
+    Available from libzmq 3.0.0.
     */
     native static void __setBacklog (long self, int backlog);
     public void setBacklog (int backlog) {
@@ -1167,6 +1270,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `maxmsgsize`.
+    Available from libzmq 3.0.0.   
     */
     native static int __maxmsgsize (long self);
     public int maxmsgsize () {
@@ -1174,6 +1278,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `maxmsgsize`.
+    Available from libzmq 3.0.0.   
     */
     native static void __setMaxmsgsize (long self, int maxmsgsize);
     public void setMaxmsgsize (int maxmsgsize) {
@@ -1181,6 +1286,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `multicast_hops`.
+    Available from libzmq 3.0.0.       
     */
     native static int __multicastHops (long self);
     public int multicastHops () {
@@ -1188,6 +1294,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `multicast_hops`.
+    Available from libzmq 3.0.0.       
     */
     native static void __setMulticastHops (long self, int multicastHops);
     public void setMulticastHops (int multicastHops) {
@@ -1195,6 +1302,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `rcvtimeo`.
+    Available from libzmq 3.0.0. 
     */
     native static int __rcvtimeo (long self);
     public int rcvtimeo () {
@@ -1202,6 +1310,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `rcvtimeo`.
+    Available from libzmq 3.0.0. 
     */
     native static void __setRcvtimeo (long self, int rcvtimeo);
     public void setRcvtimeo (int rcvtimeo) {
@@ -1209,6 +1318,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `sndtimeo`.
+    Available from libzmq 3.0.0. 
     */
     native static int __sndtimeo (long self);
     public int sndtimeo () {
@@ -1216,6 +1326,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `sndtimeo`.
+    Available from libzmq 3.0.0. 
     */
     native static void __setSndtimeo (long self, int sndtimeo);
     public void setSndtimeo (int sndtimeo) {
@@ -1223,6 +1334,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `xpub_verbose`.
+    Available from libzmq 3.0.0.     
     */
     native static void __setXpubVerbose (long self, int xpubVerbose);
     public void setXpubVerbose (int xpubVerbose) {
@@ -1230,6 +1342,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_keepalive`.
+    Available from libzmq 3.0.0.      
     */
     native static int __tcpKeepalive (long self);
     public int tcpKeepalive () {
@@ -1237,6 +1350,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_keepalive`.
+    Available from libzmq 3.0.0.      
     */
     native static void __setTcpKeepalive (long self, int tcpKeepalive);
     public void setTcpKeepalive (int tcpKeepalive) {
@@ -1244,6 +1358,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_keepalive_idle`.
+    Available from libzmq 3.0.0.           
     */
     native static int __tcpKeepaliveIdle (long self);
     public int tcpKeepaliveIdle () {
@@ -1251,6 +1366,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_keepalive_idle`.
+    Available from libzmq 3.0.0.           
     */
     native static void __setTcpKeepaliveIdle (long self, int tcpKeepaliveIdle);
     public void setTcpKeepaliveIdle (int tcpKeepaliveIdle) {
@@ -1258,6 +1374,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_keepalive_cnt`.
+    Available from libzmq 3.0.0.          
     */
     native static int __tcpKeepaliveCnt (long self);
     public int tcpKeepaliveCnt () {
@@ -1265,6 +1382,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_keepalive_cnt`.
+    Available from libzmq 3.0.0.          
     */
     native static void __setTcpKeepaliveCnt (long self, int tcpKeepaliveCnt);
     public void setTcpKeepaliveCnt (int tcpKeepaliveCnt) {
@@ -1272,6 +1390,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_keepalive_intvl`.
+    Available from libzmq 3.0.0.            
     */
     native static int __tcpKeepaliveIntvl (long self);
     public int tcpKeepaliveIntvl () {
@@ -1279,6 +1398,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_keepalive_intvl`.
+    Available from libzmq 3.0.0.            
     */
     native static void __setTcpKeepaliveIntvl (long self, int tcpKeepaliveIntvl);
     public void setTcpKeepaliveIntvl (int tcpKeepaliveIntvl) {
@@ -1286,6 +1406,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `tcp_accept_filter`.
+    Available from libzmq 3.0.0.          
     */
     native static String __tcpAcceptFilter (long self);
     public String tcpAcceptFilter () {
@@ -1293,6 +1414,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `tcp_accept_filter`.
+    Available from libzmq 3.0.0.          
     */
     native static void __setTcpAcceptFilter (long self, String tcpAcceptFilter);
     public void setTcpAcceptFilter (String tcpAcceptFilter) {
@@ -1300,13 +1422,15 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `rcvmore`.
+    Available from libzmq 3.0.0.
     */
     native static int __rcvmore (long self);
     public int rcvmore () {
         return __rcvmore (self);
     }
     /*
-    Get socket option `events`.
+    Get socket option `events`. 
+    Available from libzmq 3.0.0.
     */
     native static int __events (long self);
     public int events () {
@@ -1314,6 +1438,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `last_endpoint`.
+    Available from libzmq 3.0.0.      
     */
     native static String __lastEndpoint (long self);
     public String lastEndpoint () {
@@ -1321,6 +1446,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `router_raw`.
+    Available from libzmq 3.0.0.   
     */
     native static void __setRouterRaw (long self, int routerRaw);
     public void setRouterRaw (int routerRaw) {
@@ -1328,6 +1454,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Get socket option `ipv4only`.
+    Available from libzmq 3.0.0. 
     */
     native static int __ipv4only (long self);
     public int ipv4only () {
@@ -1335,6 +1462,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `ipv4only`.
+    Available from libzmq 3.0.0. 
     */
     native static void __setIpv4only (long self, int ipv4only);
     public void setIpv4only (int ipv4only) {
@@ -1342,6 +1470,7 @@ public class Zsock implements AutoCloseable{
     }
     /*
     Set socket option `delay_attach_on_connect`.
+    Available from libzmq 3.0.0.                
     */
     native static void __setDelayAttachOnConnect (long self, int delayAttachOnConnect);
     public void setDelayAttachOnConnect (int delayAttachOnConnect) {

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2416,774 +2416,903 @@ integer my_zsock.heartbeatIvl ()
 ```
 
 Get socket option `heartbeat_ivl`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setHeartbeatIvl (Number)
 ```
 
 Set socket option `heartbeat_ivl`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.heartbeatTtl ()
 ```
 
 Get socket option `heartbeat_ttl`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setHeartbeatTtl (Number)
 ```
 
 Set socket option `heartbeat_ttl`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.heartbeatTimeout ()
 ```
 
 Get socket option `heartbeat_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setHeartbeatTimeout (Number)
 ```
 
 Set socket option `heartbeat_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.useFd ()
 ```
 
 Get socket option `use_fd`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setUseFd (Number)
 ```
 
 Set socket option `use_fd`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setXpubManual (Number)
 ```
 
 Set socket option `xpub_manual`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setXpubWelcomeMsg (String)
 ```
 
 Set socket option `xpub_welcome_msg`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setStreamNotify (Number)
 ```
 
 Set socket option `stream_notify`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.invertMatching ()
 ```
 
 Get socket option `invert_matching`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setInvertMatching (Number)
 ```
 
 Set socket option `invert_matching`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setXpubVerboser (Number)
 ```
 
 Set socket option `xpub_verboser`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.connectTimeout ()
 ```
 
 Get socket option `connect_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setConnectTimeout (Number)
 ```
 
 Set socket option `connect_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.tcpMaxrt ()
 ```
 
 Get socket option `tcp_maxrt`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setTcpMaxrt (Number)
 ```
 
 Set socket option `tcp_maxrt`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.threadSafe ()
 ```
 
 Get socket option `thread_safe`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.multicastMaxtpdu ()
 ```
 
 Get socket option `multicast_maxtpdu`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setMulticastMaxtpdu (Number)
 ```
 
 Set socket option `multicast_maxtpdu`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.vmciBufferSize ()
 ```
 
 Get socket option `vmci_buffer_size`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setVmciBufferSize (Number)
 ```
 
 Set socket option `vmci_buffer_size`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.vmciBufferMinSize ()
 ```
 
 Get socket option `vmci_buffer_min_size`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setVmciBufferMinSize (Number)
 ```
 
 Set socket option `vmci_buffer_min_size`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.vmciBufferMaxSize ()
 ```
 
 Get socket option `vmci_buffer_max_size`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setVmciBufferMaxSize (Number)
 ```
 
 Set socket option `vmci_buffer_max_size`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.vmciConnectTimeout ()
 ```
 
 Get socket option `vmci_connect_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 nothing my_zsock.setVmciConnectTimeout (Number)
 ```
 
 Set socket option `vmci_connect_timeout`.
+Available from libzmq 4.2.0.
 
 ```
 integer my_zsock.tos ()
 ```
 
 Get socket option `tos`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setTos (Number)
 ```
 
 Set socket option `tos`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setRouterHandover (Number)
 ```
 
 Set socket option `router_handover`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setConnectRid (String)
 ```
 
 Set socket option `connect_rid`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setConnectRidBin (String)
 ```
 
 Set socket option `connect_rid` from 32-octet binary
+Available from libzmq 4.1.0.
 
 ```
 integer my_zsock.handshakeIvl ()
 ```
 
 Get socket option `handshake_ivl`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setHandshakeIvl (Number)
 ```
 
 Set socket option `handshake_ivl`.
+Available from libzmq 4.1.0.
 
 ```
 string my_zsock.socksProxy ()
 ```
 
 Get socket option `socks_proxy`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setSocksProxy (String)
 ```
 
 Set socket option `socks_proxy`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setXpubNodrop (Number)
 ```
 
 Set socket option `xpub_nodrop`.
+Available from libzmq 4.1.0.
 
 ```
 nothing my_zsock.setRouterMandatory (Number)
 ```
 
 Set socket option `router_mandatory`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setProbeRouter (Number)
 ```
 
 Set socket option `probe_router`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setReqRelaxed (Number)
 ```
 
 Set socket option `req_relaxed`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setReqCorrelate (Number)
 ```
 
 Set socket option `req_correlate`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setConflate (Number)
 ```
 
 Set socket option `conflate`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.zapDomain ()
 ```
 
 Get socket option `zap_domain`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setZapDomain (String)
 ```
 
 Set socket option `zap_domain`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.mechanism ()
 ```
 
 Get socket option `mechanism`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.plainServer ()
 ```
 
 Get socket option `plain_server`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setPlainServer (Number)
 ```
 
 Set socket option `plain_server`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.plainUsername ()
 ```
 
 Get socket option `plain_username`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setPlainUsername (String)
 ```
 
 Set socket option `plain_username`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.plainPassword ()
 ```
 
 Get socket option `plain_password`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setPlainPassword (String)
 ```
 
 Set socket option `plain_password`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.curveServer ()
 ```
 
 Get socket option `curve_server`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurveServer (Number)
 ```
 
 Set socket option `curve_server`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.curvePublickey ()
 ```
 
 Get socket option `curve_publickey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurvePublickey (String)
 ```
 
 Set socket option `curve_publickey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurvePublickeyBin (String)
 ```
 
 Set socket option `curve_publickey` from 32-octet binary
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.curveSecretkey ()
 ```
 
 Get socket option `curve_secretkey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurveSecretkey (String)
 ```
 
 Set socket option `curve_secretkey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurveSecretkeyBin (String)
 ```
 
 Set socket option `curve_secretkey` from 32-octet binary
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.curveServerkey ()
 ```
 
 Get socket option `curve_serverkey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurveServerkey (String)
 ```
 
 Set socket option `curve_serverkey`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setCurveServerkeyBin (String)
 ```
 
 Set socket option `curve_serverkey` from 32-octet binary
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.gssapiServer ()
 ```
 
 Get socket option `gssapi_server`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setGssapiServer (Number)
 ```
 
 Set socket option `gssapi_server`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.gssapiPlaintext ()
 ```
 
 Get socket option `gssapi_plaintext`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setGssapiPlaintext (Number)
 ```
 
 Set socket option `gssapi_plaintext`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.gssapiPrincipal ()
 ```
 
 Get socket option `gssapi_principal`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setGssapiPrincipal (String)
 ```
 
 Set socket option `gssapi_principal`.
+Available from libzmq 4.0.0.
 
 ```
 string my_zsock.gssapiServicePrincipal ()
 ```
 
 Get socket option `gssapi_service_principal`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setGssapiServicePrincipal (String)
 ```
 
 Set socket option `gssapi_service_principal`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.ipv6 ()
 ```
 
 Get socket option `ipv6`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setIpv6 (Number)
 ```
 
 Set socket option `ipv6`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.immediate ()
 ```
 
 Get socket option `immediate`.
+Available from libzmq 4.0.0.
 
 ```
 nothing my_zsock.setImmediate (Number)
 ```
 
 Set socket option `immediate`.
+Available from libzmq 4.0.0.
 
 ```
 integer my_zsock.type ()
 ```
 
 Get socket option `type`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.sndhwm ()
 ```
 
 Get socket option `sndhwm`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setSndhwm (Number)
 ```
 
 Set socket option `sndhwm`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.rcvhwm ()
 ```
 
 Get socket option `rcvhwm`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRcvhwm (Number)
 ```
 
 Set socket option `rcvhwm`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.affinity ()
 ```
 
 Get socket option `affinity`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setAffinity (Number)
 ```
 
 Set socket option `affinity`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setSubscribe (String)
 ```
 
 Set socket option `subscribe`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setUnsubscribe (String)
 ```
 
 Set socket option `unsubscribe`.
+Available from libzmq 3.0.0.
 
 ```
 string my_zsock.identity ()
 ```
 
 Get socket option `identity`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setIdentity (String)
 ```
 
 Set socket option `identity`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.rate ()
 ```
 
 Get socket option `rate`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRate (Number)
 ```
 
 Set socket option `rate`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.recoveryIvl ()
 ```
 
 Get socket option `recovery_ivl`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRecoveryIvl (Number)
 ```
 
 Set socket option `recovery_ivl`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.sndbuf ()
 ```
 
 Get socket option `sndbuf`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setSndbuf (Number)
 ```
 
 Set socket option `sndbuf`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.rcvbuf ()
 ```
 
 Get socket option `rcvbuf`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRcvbuf (Number)
 ```
 
 Set socket option `rcvbuf`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.linger ()
 ```
 
 Get socket option `linger`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setLinger (Number)
 ```
 
 Set socket option `linger`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.reconnectIvl ()
 ```
 
 Get socket option `reconnect_ivl`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setReconnectIvl (Number)
 ```
 
 Set socket option `reconnect_ivl`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.reconnectIvlMax ()
 ```
 
 Get socket option `reconnect_ivl_max`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setReconnectIvlMax (Number)
 ```
 
 Set socket option `reconnect_ivl_max`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.backlog ()
 ```
 
 Get socket option `backlog`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setBacklog (Number)
 ```
 
 Set socket option `backlog`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.maxmsgsize ()
 ```
 
 Get socket option `maxmsgsize`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setMaxmsgsize (Number)
 ```
 
 Set socket option `maxmsgsize`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.multicastHops ()
 ```
 
 Get socket option `multicast_hops`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setMulticastHops (Number)
 ```
 
 Set socket option `multicast_hops`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.rcvtimeo ()
 ```
 
 Get socket option `rcvtimeo`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRcvtimeo (Number)
 ```
 
 Set socket option `rcvtimeo`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.sndtimeo ()
 ```
 
 Get socket option `sndtimeo`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setSndtimeo (Number)
 ```
 
 Set socket option `sndtimeo`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setXpubVerbose (Number)
 ```
 
 Set socket option `xpub_verbose`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.tcpKeepalive ()
 ```
 
 Get socket option `tcp_keepalive`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setTcpKeepalive (Number)
 ```
 
 Set socket option `tcp_keepalive`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.tcpKeepaliveIdle ()
 ```
 
 Get socket option `tcp_keepalive_idle`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setTcpKeepaliveIdle (Number)
 ```
 
 Set socket option `tcp_keepalive_idle`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.tcpKeepaliveCnt ()
 ```
 
 Get socket option `tcp_keepalive_cnt`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setTcpKeepaliveCnt (Number)
 ```
 
 Set socket option `tcp_keepalive_cnt`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.tcpKeepaliveIntvl ()
 ```
 
 Get socket option `tcp_keepalive_intvl`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setTcpKeepaliveIntvl (Number)
 ```
 
 Set socket option `tcp_keepalive_intvl`.
+Available from libzmq 3.0.0.
 
 ```
 string my_zsock.tcpAcceptFilter ()
 ```
 
 Get socket option `tcp_accept_filter`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setTcpAcceptFilter (String)
 ```
 
 Set socket option `tcp_accept_filter`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.rcvmore ()
 ```
 
 Get socket option `rcvmore`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.events ()
 ```
 
 Get socket option `events`.
+Available from libzmq 3.0.0.
 
 ```
 string my_zsock.lastEndpoint ()
 ```
 
 Get socket option `last_endpoint`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setRouterRaw (Number)
 ```
 
 Set socket option `router_raw`.
+Available from libzmq 3.0.0.
 
 ```
 integer my_zsock.ipv4only ()
 ```
 
 Get socket option `ipv4only`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setIpv4only (Number)
 ```
 
 Set socket option `ipv4only`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.setDelayAttachOnConnect (Number)
 ```
 
 Set socket option `delay_attach_on_connect`.
+Available from libzmq 3.0.0.
 
 ```
 nothing my_zsock.test (Boolean)

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -5571,780 +5571,910 @@ return the supplied value. Takes a polymorphic socket reference.
     def heartbeat_ivl(self):
         """
         Get socket option `heartbeat_ivl`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_heartbeat_ivl(self._as_parameter_)
 
     def set_heartbeat_ivl(self, heartbeat_ivl):
         """
         Set socket option `heartbeat_ivl`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_heartbeat_ivl(self._as_parameter_, heartbeat_ivl)
 
     def heartbeat_ttl(self):
         """
         Get socket option `heartbeat_ttl`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_heartbeat_ttl(self._as_parameter_)
 
     def set_heartbeat_ttl(self, heartbeat_ttl):
         """
         Set socket option `heartbeat_ttl`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_heartbeat_ttl(self._as_parameter_, heartbeat_ttl)
 
     def heartbeat_timeout(self):
         """
         Get socket option `heartbeat_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_heartbeat_timeout(self._as_parameter_)
 
     def set_heartbeat_timeout(self, heartbeat_timeout):
         """
         Set socket option `heartbeat_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_heartbeat_timeout(self._as_parameter_, heartbeat_timeout)
 
     def use_fd(self):
         """
         Get socket option `use_fd`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_use_fd(self._as_parameter_)
 
     def set_use_fd(self, use_fd):
         """
         Set socket option `use_fd`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_use_fd(self._as_parameter_, use_fd)
 
     def set_xpub_manual(self, xpub_manual):
         """
         Set socket option `xpub_manual`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_xpub_manual(self._as_parameter_, xpub_manual)
 
     def set_xpub_welcome_msg(self, xpub_welcome_msg):
         """
         Set socket option `xpub_welcome_msg`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_xpub_welcome_msg(self._as_parameter_, xpub_welcome_msg)
 
     def set_stream_notify(self, stream_notify):
         """
         Set socket option `stream_notify`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_stream_notify(self._as_parameter_, stream_notify)
 
     def invert_matching(self):
         """
         Get socket option `invert_matching`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_invert_matching(self._as_parameter_)
 
     def set_invert_matching(self, invert_matching):
         """
         Set socket option `invert_matching`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_invert_matching(self._as_parameter_, invert_matching)
 
     def set_xpub_verboser(self, xpub_verboser):
         """
         Set socket option `xpub_verboser`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_xpub_verboser(self._as_parameter_, xpub_verboser)
 
     def connect_timeout(self):
         """
         Get socket option `connect_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_connect_timeout(self._as_parameter_)
 
     def set_connect_timeout(self, connect_timeout):
         """
         Set socket option `connect_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_connect_timeout(self._as_parameter_, connect_timeout)
 
     def tcp_maxrt(self):
         """
         Get socket option `tcp_maxrt`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_tcp_maxrt(self._as_parameter_)
 
     def set_tcp_maxrt(self, tcp_maxrt):
         """
         Set socket option `tcp_maxrt`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_tcp_maxrt(self._as_parameter_, tcp_maxrt)
 
     def thread_safe(self):
         """
         Get socket option `thread_safe`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_thread_safe(self._as_parameter_)
 
     def multicast_maxtpdu(self):
         """
         Get socket option `multicast_maxtpdu`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_multicast_maxtpdu(self._as_parameter_)
 
     def set_multicast_maxtpdu(self, multicast_maxtpdu):
         """
         Set socket option `multicast_maxtpdu`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_multicast_maxtpdu(self._as_parameter_, multicast_maxtpdu)
 
     def vmci_buffer_size(self):
         """
         Get socket option `vmci_buffer_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_vmci_buffer_size(self._as_parameter_)
 
     def set_vmci_buffer_size(self, vmci_buffer_size):
         """
         Set socket option `vmci_buffer_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_vmci_buffer_size(self._as_parameter_, vmci_buffer_size)
 
     def vmci_buffer_min_size(self):
         """
         Get socket option `vmci_buffer_min_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_vmci_buffer_min_size(self._as_parameter_)
 
     def set_vmci_buffer_min_size(self, vmci_buffer_min_size):
         """
         Set socket option `vmci_buffer_min_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_vmci_buffer_min_size(self._as_parameter_, vmci_buffer_min_size)
 
     def vmci_buffer_max_size(self):
         """
         Get socket option `vmci_buffer_max_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_vmci_buffer_max_size(self._as_parameter_)
 
     def set_vmci_buffer_max_size(self, vmci_buffer_max_size):
         """
         Set socket option `vmci_buffer_max_size`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_vmci_buffer_max_size(self._as_parameter_, vmci_buffer_max_size)
 
     def vmci_connect_timeout(self):
         """
         Get socket option `vmci_connect_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_vmci_connect_timeout(self._as_parameter_)
 
     def set_vmci_connect_timeout(self, vmci_connect_timeout):
         """
         Set socket option `vmci_connect_timeout`.
+Available from libzmq 4.2.0.
         """
         return lib.zsock_set_vmci_connect_timeout(self._as_parameter_, vmci_connect_timeout)
 
     def tos(self):
         """
         Get socket option `tos`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_tos(self._as_parameter_)
 
     def set_tos(self, tos):
         """
         Set socket option `tos`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_tos(self._as_parameter_, tos)
 
     def set_router_handover(self, router_handover):
         """
         Set socket option `router_handover`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_router_handover(self._as_parameter_, router_handover)
 
     def set_connect_rid(self, connect_rid):
         """
         Set socket option `connect_rid`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_connect_rid(self._as_parameter_, connect_rid)
 
     def set_connect_rid_bin(self, connect_rid):
         """
         Set socket option `connect_rid` from 32-octet binary
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_connect_rid_bin(self._as_parameter_, connect_rid)
 
     def handshake_ivl(self):
         """
         Get socket option `handshake_ivl`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_handshake_ivl(self._as_parameter_)
 
     def set_handshake_ivl(self, handshake_ivl):
         """
         Set socket option `handshake_ivl`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_handshake_ivl(self._as_parameter_, handshake_ivl)
 
     def socks_proxy(self):
         """
         Get socket option `socks_proxy`.
+Available from libzmq 4.1.0.
         """
         return return_fresh_string(lib.zsock_socks_proxy(self._as_parameter_))
 
     def set_socks_proxy(self, socks_proxy):
         """
         Set socket option `socks_proxy`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_socks_proxy(self._as_parameter_, socks_proxy)
 
     def set_xpub_nodrop(self, xpub_nodrop):
         """
         Set socket option `xpub_nodrop`.
+Available from libzmq 4.1.0.
         """
         return lib.zsock_set_xpub_nodrop(self._as_parameter_, xpub_nodrop)
 
     def set_router_mandatory(self, router_mandatory):
         """
         Set socket option `router_mandatory`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_router_mandatory(self._as_parameter_, router_mandatory)
 
     def set_probe_router(self, probe_router):
         """
         Set socket option `probe_router`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_probe_router(self._as_parameter_, probe_router)
 
     def set_req_relaxed(self, req_relaxed):
         """
         Set socket option `req_relaxed`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_req_relaxed(self._as_parameter_, req_relaxed)
 
     def set_req_correlate(self, req_correlate):
         """
         Set socket option `req_correlate`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_req_correlate(self._as_parameter_, req_correlate)
 
     def set_conflate(self, conflate):
         """
         Set socket option `conflate`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_conflate(self._as_parameter_, conflate)
 
     def zap_domain(self):
         """
         Get socket option `zap_domain`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_zap_domain(self._as_parameter_))
 
     def set_zap_domain(self, zap_domain):
         """
         Set socket option `zap_domain`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_zap_domain(self._as_parameter_, zap_domain)
 
     def mechanism(self):
         """
         Get socket option `mechanism`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_mechanism(self._as_parameter_)
 
     def plain_server(self):
         """
         Get socket option `plain_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_plain_server(self._as_parameter_)
 
     def set_plain_server(self, plain_server):
         """
         Set socket option `plain_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_plain_server(self._as_parameter_, plain_server)
 
     def plain_username(self):
         """
         Get socket option `plain_username`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_plain_username(self._as_parameter_))
 
     def set_plain_username(self, plain_username):
         """
         Set socket option `plain_username`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_plain_username(self._as_parameter_, plain_username)
 
     def plain_password(self):
         """
         Get socket option `plain_password`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_plain_password(self._as_parameter_))
 
     def set_plain_password(self, plain_password):
         """
         Set socket option `plain_password`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_plain_password(self._as_parameter_, plain_password)
 
     def curve_server(self):
         """
         Get socket option `curve_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_curve_server(self._as_parameter_)
 
     def set_curve_server(self, curve_server):
         """
         Set socket option `curve_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_server(self._as_parameter_, curve_server)
 
     def curve_publickey(self):
         """
         Get socket option `curve_publickey`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_curve_publickey(self._as_parameter_))
 
     def set_curve_publickey(self, curve_publickey):
         """
         Set socket option `curve_publickey`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_publickey(self._as_parameter_, curve_publickey)
 
     def set_curve_publickey_bin(self, curve_publickey):
         """
         Set socket option `curve_publickey` from 32-octet binary
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_publickey_bin(self._as_parameter_, curve_publickey)
 
     def curve_secretkey(self):
         """
         Get socket option `curve_secretkey`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_curve_secretkey(self._as_parameter_))
 
     def set_curve_secretkey(self, curve_secretkey):
         """
         Set socket option `curve_secretkey`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_secretkey(self._as_parameter_, curve_secretkey)
 
     def set_curve_secretkey_bin(self, curve_secretkey):
         """
         Set socket option `curve_secretkey` from 32-octet binary
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_secretkey_bin(self._as_parameter_, curve_secretkey)
 
     def curve_serverkey(self):
         """
         Get socket option `curve_serverkey`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_curve_serverkey(self._as_parameter_))
 
     def set_curve_serverkey(self, curve_serverkey):
         """
         Set socket option `curve_serverkey`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_serverkey(self._as_parameter_, curve_serverkey)
 
     def set_curve_serverkey_bin(self, curve_serverkey):
         """
         Set socket option `curve_serverkey` from 32-octet binary
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_curve_serverkey_bin(self._as_parameter_, curve_serverkey)
 
     def gssapi_server(self):
         """
         Get socket option `gssapi_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_gssapi_server(self._as_parameter_)
 
     def set_gssapi_server(self, gssapi_server):
         """
         Set socket option `gssapi_server`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_gssapi_server(self._as_parameter_, gssapi_server)
 
     def gssapi_plaintext(self):
         """
         Get socket option `gssapi_plaintext`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_gssapi_plaintext(self._as_parameter_)
 
     def set_gssapi_plaintext(self, gssapi_plaintext):
         """
         Set socket option `gssapi_plaintext`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_gssapi_plaintext(self._as_parameter_, gssapi_plaintext)
 
     def gssapi_principal(self):
         """
         Get socket option `gssapi_principal`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_gssapi_principal(self._as_parameter_))
 
     def set_gssapi_principal(self, gssapi_principal):
         """
         Set socket option `gssapi_principal`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_gssapi_principal(self._as_parameter_, gssapi_principal)
 
     def gssapi_service_principal(self):
         """
         Get socket option `gssapi_service_principal`.
+Available from libzmq 4.0.0.
         """
         return return_fresh_string(lib.zsock_gssapi_service_principal(self._as_parameter_))
 
     def set_gssapi_service_principal(self, gssapi_service_principal):
         """
         Set socket option `gssapi_service_principal`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_gssapi_service_principal(self._as_parameter_, gssapi_service_principal)
 
     def ipv6(self):
         """
         Get socket option `ipv6`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_ipv6(self._as_parameter_)
 
     def set_ipv6(self, ipv6):
         """
         Set socket option `ipv6`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_ipv6(self._as_parameter_, ipv6)
 
     def immediate(self):
         """
         Get socket option `immediate`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_immediate(self._as_parameter_)
 
     def set_immediate(self, immediate):
         """
         Set socket option `immediate`.
+Available from libzmq 4.0.0.
         """
         return lib.zsock_set_immediate(self._as_parameter_, immediate)
 
     def type(self):
         """
         Get socket option `type`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_type(self._as_parameter_)
 
     def sndhwm(self):
         """
         Get socket option `sndhwm`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_sndhwm(self._as_parameter_)
 
     def set_sndhwm(self, sndhwm):
         """
         Set socket option `sndhwm`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_sndhwm(self._as_parameter_, sndhwm)
 
     def rcvhwm(self):
         """
         Get socket option `rcvhwm`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_rcvhwm(self._as_parameter_)
 
     def set_rcvhwm(self, rcvhwm):
         """
         Set socket option `rcvhwm`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_rcvhwm(self._as_parameter_, rcvhwm)
 
     def affinity(self):
         """
         Get socket option `affinity`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_affinity(self._as_parameter_)
 
     def set_affinity(self, affinity):
         """
         Set socket option `affinity`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_affinity(self._as_parameter_, affinity)
 
     def set_subscribe(self, subscribe):
         """
         Set socket option `subscribe`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_subscribe(self._as_parameter_, subscribe)
 
     def set_unsubscribe(self, unsubscribe):
         """
         Set socket option `unsubscribe`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_unsubscribe(self._as_parameter_, unsubscribe)
 
     def identity(self):
         """
         Get socket option `identity`.
+Available from libzmq 3.0.0.
         """
         return return_fresh_string(lib.zsock_identity(self._as_parameter_))
 
     def set_identity(self, identity):
         """
         Set socket option `identity`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_identity(self._as_parameter_, identity)
 
     def rate(self):
         """
         Get socket option `rate`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_rate(self._as_parameter_)
 
     def set_rate(self, rate):
         """
         Set socket option `rate`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_rate(self._as_parameter_, rate)
 
     def recovery_ivl(self):
         """
         Get socket option `recovery_ivl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_recovery_ivl(self._as_parameter_)
 
     def set_recovery_ivl(self, recovery_ivl):
         """
         Set socket option `recovery_ivl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_recovery_ivl(self._as_parameter_, recovery_ivl)
 
     def sndbuf(self):
         """
         Get socket option `sndbuf`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_sndbuf(self._as_parameter_)
 
     def set_sndbuf(self, sndbuf):
         """
         Set socket option `sndbuf`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_sndbuf(self._as_parameter_, sndbuf)
 
     def rcvbuf(self):
         """
         Get socket option `rcvbuf`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_rcvbuf(self._as_parameter_)
 
     def set_rcvbuf(self, rcvbuf):
         """
         Set socket option `rcvbuf`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_rcvbuf(self._as_parameter_, rcvbuf)
 
     def linger(self):
         """
         Get socket option `linger`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_linger(self._as_parameter_)
 
     def set_linger(self, linger):
         """
         Set socket option `linger`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_linger(self._as_parameter_, linger)
 
     def reconnect_ivl(self):
         """
         Get socket option `reconnect_ivl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_reconnect_ivl(self._as_parameter_)
 
     def set_reconnect_ivl(self, reconnect_ivl):
         """
         Set socket option `reconnect_ivl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_reconnect_ivl(self._as_parameter_, reconnect_ivl)
 
     def reconnect_ivl_max(self):
         """
         Get socket option `reconnect_ivl_max`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_reconnect_ivl_max(self._as_parameter_)
 
     def set_reconnect_ivl_max(self, reconnect_ivl_max):
         """
         Set socket option `reconnect_ivl_max`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_reconnect_ivl_max(self._as_parameter_, reconnect_ivl_max)
 
     def backlog(self):
         """
         Get socket option `backlog`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_backlog(self._as_parameter_)
 
     def set_backlog(self, backlog):
         """
         Set socket option `backlog`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_backlog(self._as_parameter_, backlog)
 
     def maxmsgsize(self):
         """
         Get socket option `maxmsgsize`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_maxmsgsize(self._as_parameter_)
 
     def set_maxmsgsize(self, maxmsgsize):
         """
         Set socket option `maxmsgsize`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_maxmsgsize(self._as_parameter_, maxmsgsize)
 
     def multicast_hops(self):
         """
         Get socket option `multicast_hops`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_multicast_hops(self._as_parameter_)
 
     def set_multicast_hops(self, multicast_hops):
         """
         Set socket option `multicast_hops`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_multicast_hops(self._as_parameter_, multicast_hops)
 
     def rcvtimeo(self):
         """
         Get socket option `rcvtimeo`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_rcvtimeo(self._as_parameter_)
 
     def set_rcvtimeo(self, rcvtimeo):
         """
         Set socket option `rcvtimeo`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_rcvtimeo(self._as_parameter_, rcvtimeo)
 
     def sndtimeo(self):
         """
         Get socket option `sndtimeo`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_sndtimeo(self._as_parameter_)
 
     def set_sndtimeo(self, sndtimeo):
         """
         Set socket option `sndtimeo`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_sndtimeo(self._as_parameter_, sndtimeo)
 
     def set_xpub_verbose(self, xpub_verbose):
         """
         Set socket option `xpub_verbose`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_xpub_verbose(self._as_parameter_, xpub_verbose)
 
     def tcp_keepalive(self):
         """
         Get socket option `tcp_keepalive`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_tcp_keepalive(self._as_parameter_)
 
     def set_tcp_keepalive(self, tcp_keepalive):
         """
         Set socket option `tcp_keepalive`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_tcp_keepalive(self._as_parameter_, tcp_keepalive)
 
     def tcp_keepalive_idle(self):
         """
         Get socket option `tcp_keepalive_idle`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_tcp_keepalive_idle(self._as_parameter_)
 
     def set_tcp_keepalive_idle(self, tcp_keepalive_idle):
         """
         Set socket option `tcp_keepalive_idle`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_tcp_keepalive_idle(self._as_parameter_, tcp_keepalive_idle)
 
     def tcp_keepalive_cnt(self):
         """
         Get socket option `tcp_keepalive_cnt`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_tcp_keepalive_cnt(self._as_parameter_)
 
     def set_tcp_keepalive_cnt(self, tcp_keepalive_cnt):
         """
         Set socket option `tcp_keepalive_cnt`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_tcp_keepalive_cnt(self._as_parameter_, tcp_keepalive_cnt)
 
     def tcp_keepalive_intvl(self):
         """
         Get socket option `tcp_keepalive_intvl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_tcp_keepalive_intvl(self._as_parameter_)
 
     def set_tcp_keepalive_intvl(self, tcp_keepalive_intvl):
         """
         Set socket option `tcp_keepalive_intvl`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_tcp_keepalive_intvl(self._as_parameter_, tcp_keepalive_intvl)
 
     def tcp_accept_filter(self):
         """
         Get socket option `tcp_accept_filter`.
+Available from libzmq 3.0.0.
         """
         return return_fresh_string(lib.zsock_tcp_accept_filter(self._as_parameter_))
 
     def set_tcp_accept_filter(self, tcp_accept_filter):
         """
         Set socket option `tcp_accept_filter`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_tcp_accept_filter(self._as_parameter_, tcp_accept_filter)
 
     def rcvmore(self):
         """
         Get socket option `rcvmore`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_rcvmore(self._as_parameter_)
 
     def fd(self):
         """
         Get socket option `fd`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_fd(self._as_parameter_)
 
     def events(self):
         """
         Get socket option `events`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_events(self._as_parameter_)
 
     def last_endpoint(self):
         """
         Get socket option `last_endpoint`.
+Available from libzmq 3.0.0.
         """
         return return_fresh_string(lib.zsock_last_endpoint(self._as_parameter_))
 
     def set_router_raw(self, router_raw):
         """
         Set socket option `router_raw`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_router_raw(self._as_parameter_, router_raw)
 
     def ipv4only(self):
         """
         Get socket option `ipv4only`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_ipv4only(self._as_parameter_)
 
     def set_ipv4only(self, ipv4only):
         """
         Set socket option `ipv4only`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_ipv4only(self._as_parameter_, ipv4only)
 
     def set_delay_attach_on_connect(self, delay_attach_on_connect):
         """
         Set socket option `delay_attach_on_connect`.
+Available from libzmq 3.0.0.
         """
         return lib.zsock_set_delay_attach_on_connect(self._as_parameter_, delay_attach_on_connect)
 

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -2564,522 +2564,652 @@ void *
     zsock_resolve (void *self);
 
 // Get socket option `heartbeat_ivl`.
+// Available from libzmq 4.2.0.      
 int
     zsock_heartbeat_ivl (void *self);
 
 // Set socket option `heartbeat_ivl`.
+// Available from libzmq 4.2.0.      
 void
     zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
 
 // Get socket option `heartbeat_ttl`.
+// Available from libzmq 4.2.0.      
 int
     zsock_heartbeat_ttl (void *self);
 
 // Set socket option `heartbeat_ttl`.
+// Available from libzmq 4.2.0.      
 void
     zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
 
 // Get socket option `heartbeat_timeout`.
+// Available from libzmq 4.2.0.          
 int
     zsock_heartbeat_timeout (void *self);
 
 // Set socket option `heartbeat_timeout`.
+// Available from libzmq 4.2.0.          
 void
     zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
 
-// Get socket option `use_fd`.
+// Get socket option `use_fd`. 
+// Available from libzmq 4.2.0.
 int
     zsock_use_fd (void *self);
 
-// Set socket option `use_fd`.
+// Set socket option `use_fd`. 
+// Available from libzmq 4.2.0.
 void
     zsock_set_use_fd (void *self, int use_fd);
 
 // Set socket option `xpub_manual`.
+// Available from libzmq 4.2.0.    
 void
     zsock_set_xpub_manual (void *self, int xpub_manual);
 
 // Set socket option `xpub_welcome_msg`.
+// Available from libzmq 4.2.0.         
 void
     zsock_set_xpub_welcome_msg (void *self, const char *xpub_welcome_msg);
 
 // Set socket option `stream_notify`.
+// Available from libzmq 4.2.0.      
 void
     zsock_set_stream_notify (void *self, int stream_notify);
 
 // Get socket option `invert_matching`.
+// Available from libzmq 4.2.0.        
 int
     zsock_invert_matching (void *self);
 
 // Set socket option `invert_matching`.
+// Available from libzmq 4.2.0.        
 void
     zsock_set_invert_matching (void *self, int invert_matching);
 
 // Set socket option `xpub_verboser`.
+// Available from libzmq 4.2.0.      
 void
     zsock_set_xpub_verboser (void *self, int xpub_verboser);
 
 // Get socket option `connect_timeout`.
+// Available from libzmq 4.2.0.        
 int
     zsock_connect_timeout (void *self);
 
 // Set socket option `connect_timeout`.
+// Available from libzmq 4.2.0.        
 void
     zsock_set_connect_timeout (void *self, int connect_timeout);
 
 // Get socket option `tcp_maxrt`.
+// Available from libzmq 4.2.0.  
 int
     zsock_tcp_maxrt (void *self);
 
 // Set socket option `tcp_maxrt`.
+// Available from libzmq 4.2.0.  
 void
     zsock_set_tcp_maxrt (void *self, int tcp_maxrt);
 
 // Get socket option `thread_safe`.
+// Available from libzmq 4.2.0.    
 int
     zsock_thread_safe (void *self);
 
 // Get socket option `multicast_maxtpdu`.
+// Available from libzmq 4.2.0.          
 int
     zsock_multicast_maxtpdu (void *self);
 
 // Set socket option `multicast_maxtpdu`.
+// Available from libzmq 4.2.0.          
 void
     zsock_set_multicast_maxtpdu (void *self, int multicast_maxtpdu);
 
 // Get socket option `vmci_buffer_size`.
+// Available from libzmq 4.2.0.         
 int
     zsock_vmci_buffer_size (void *self);
 
 // Set socket option `vmci_buffer_size`.
+// Available from libzmq 4.2.0.         
 void
     zsock_set_vmci_buffer_size (void *self, int vmci_buffer_size);
 
 // Get socket option `vmci_buffer_min_size`.
+// Available from libzmq 4.2.0.             
 int
     zsock_vmci_buffer_min_size (void *self);
 
 // Set socket option `vmci_buffer_min_size`.
+// Available from libzmq 4.2.0.             
 void
     zsock_set_vmci_buffer_min_size (void *self, int vmci_buffer_min_size);
 
 // Get socket option `vmci_buffer_max_size`.
+// Available from libzmq 4.2.0.             
 int
     zsock_vmci_buffer_max_size (void *self);
 
 // Set socket option `vmci_buffer_max_size`.
+// Available from libzmq 4.2.0.             
 void
     zsock_set_vmci_buffer_max_size (void *self, int vmci_buffer_max_size);
 
 // Get socket option `vmci_connect_timeout`.
+// Available from libzmq 4.2.0.             
 int
     zsock_vmci_connect_timeout (void *self);
 
 // Set socket option `vmci_connect_timeout`.
+// Available from libzmq 4.2.0.             
 void
     zsock_set_vmci_connect_timeout (void *self, int vmci_connect_timeout);
 
-// Get socket option `tos`.
+// Get socket option `tos`.    
+// Available from libzmq 4.1.0.
 int
     zsock_tos (void *self);
 
-// Set socket option `tos`.
+// Set socket option `tos`.    
+// Available from libzmq 4.1.0.
 void
     zsock_set_tos (void *self, int tos);
 
 // Set socket option `router_handover`.
+// Available from libzmq 4.1.0.        
 void
     zsock_set_router_handover (void *self, int router_handover);
 
 // Set socket option `connect_rid`.
+// Available from libzmq 4.1.0.    
 void
     zsock_set_connect_rid (void *self, const char *connect_rid);
 
 // Set socket option `connect_rid` from 32-octet binary
+// Available from libzmq 4.1.0.                        
 void
     zsock_set_connect_rid_bin (void *self, const byte *connect_rid);
 
 // Get socket option `handshake_ivl`.
+// Available from libzmq 4.1.0.      
 int
     zsock_handshake_ivl (void *self);
 
 // Set socket option `handshake_ivl`.
+// Available from libzmq 4.1.0.      
 void
     zsock_set_handshake_ivl (void *self, int handshake_ivl);
 
 // Get socket option `socks_proxy`.
+// Available from libzmq 4.1.0.    
 char *
     zsock_socks_proxy (void *self);
 
 // Set socket option `socks_proxy`.
+// Available from libzmq 4.1.0.    
 void
     zsock_set_socks_proxy (void *self, const char *socks_proxy);
 
 // Set socket option `xpub_nodrop`.
+// Available from libzmq 4.1.0.    
 void
     zsock_set_xpub_nodrop (void *self, int xpub_nodrop);
 
 // Set socket option `router_mandatory`.
+// Available from libzmq 4.0.0.         
 void
     zsock_set_router_mandatory (void *self, int router_mandatory);
 
 // Set socket option `probe_router`.
+// Available from libzmq 4.0.0.     
 void
     zsock_set_probe_router (void *self, int probe_router);
 
 // Set socket option `req_relaxed`.
+// Available from libzmq 4.0.0.    
 void
     zsock_set_req_relaxed (void *self, int req_relaxed);
 
 // Set socket option `req_correlate`.
+// Available from libzmq 4.0.0.      
 void
     zsock_set_req_correlate (void *self, int req_correlate);
 
 // Set socket option `conflate`.
+// Available from libzmq 4.0.0. 
 void
     zsock_set_conflate (void *self, int conflate);
 
 // Get socket option `zap_domain`.
+// Available from libzmq 4.0.0.   
 char *
     zsock_zap_domain (void *self);
 
 // Set socket option `zap_domain`.
+// Available from libzmq 4.0.0.   
 void
     zsock_set_zap_domain (void *self, const char *zap_domain);
 
 // Get socket option `mechanism`.
+// Available from libzmq 4.0.0.  
 int
     zsock_mechanism (void *self);
 
 // Get socket option `plain_server`.
+// Available from libzmq 4.0.0.     
 int
     zsock_plain_server (void *self);
 
 // Set socket option `plain_server`.
+// Available from libzmq 4.0.0.     
 void
     zsock_set_plain_server (void *self, int plain_server);
 
 // Get socket option `plain_username`.
+// Available from libzmq 4.0.0.       
 char *
     zsock_plain_username (void *self);
 
 // Set socket option `plain_username`.
+// Available from libzmq 4.0.0.       
 void
     zsock_set_plain_username (void *self, const char *plain_username);
 
 // Get socket option `plain_password`.
+// Available from libzmq 4.0.0.       
 char *
     zsock_plain_password (void *self);
 
 // Set socket option `plain_password`.
+// Available from libzmq 4.0.0.       
 void
     zsock_set_plain_password (void *self, const char *plain_password);
 
 // Get socket option `curve_server`.
+// Available from libzmq 4.0.0.     
 int
     zsock_curve_server (void *self);
 
 // Set socket option `curve_server`.
+// Available from libzmq 4.0.0.     
 void
     zsock_set_curve_server (void *self, int curve_server);
 
 // Get socket option `curve_publickey`.
+// Available from libzmq 4.0.0.        
 char *
     zsock_curve_publickey (void *self);
 
 // Set socket option `curve_publickey`.
+// Available from libzmq 4.0.0.        
 void
     zsock_set_curve_publickey (void *self, const char *curve_publickey);
 
 // Set socket option `curve_publickey` from 32-octet binary
+// Available from libzmq 4.0.0.                            
 void
     zsock_set_curve_publickey_bin (void *self, const byte *curve_publickey);
 
 // Get socket option `curve_secretkey`.
+// Available from libzmq 4.0.0.        
 char *
     zsock_curve_secretkey (void *self);
 
 // Set socket option `curve_secretkey`.
+// Available from libzmq 4.0.0.        
 void
     zsock_set_curve_secretkey (void *self, const char *curve_secretkey);
 
 // Set socket option `curve_secretkey` from 32-octet binary
+// Available from libzmq 4.0.0.                            
 void
     zsock_set_curve_secretkey_bin (void *self, const byte *curve_secretkey);
 
 // Get socket option `curve_serverkey`.
+// Available from libzmq 4.0.0.        
 char *
     zsock_curve_serverkey (void *self);
 
 // Set socket option `curve_serverkey`.
+// Available from libzmq 4.0.0.        
 void
     zsock_set_curve_serverkey (void *self, const char *curve_serverkey);
 
 // Set socket option `curve_serverkey` from 32-octet binary
+// Available from libzmq 4.0.0.                            
 void
     zsock_set_curve_serverkey_bin (void *self, const byte *curve_serverkey);
 
 // Get socket option `gssapi_server`.
+// Available from libzmq 4.0.0.      
 int
     zsock_gssapi_server (void *self);
 
 // Set socket option `gssapi_server`.
+// Available from libzmq 4.0.0.      
 void
     zsock_set_gssapi_server (void *self, int gssapi_server);
 
 // Get socket option `gssapi_plaintext`.
+// Available from libzmq 4.0.0.         
 int
     zsock_gssapi_plaintext (void *self);
 
 // Set socket option `gssapi_plaintext`.
+// Available from libzmq 4.0.0.         
 void
     zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext);
 
 // Get socket option `gssapi_principal`.
+// Available from libzmq 4.0.0.         
 char *
     zsock_gssapi_principal (void *self);
 
 // Set socket option `gssapi_principal`.
+// Available from libzmq 4.0.0.         
 void
     zsock_set_gssapi_principal (void *self, const char *gssapi_principal);
 
 // Get socket option `gssapi_service_principal`.
+// Available from libzmq 4.0.0.                 
 char *
     zsock_gssapi_service_principal (void *self);
 
 // Set socket option `gssapi_service_principal`.
+// Available from libzmq 4.0.0.                 
 void
     zsock_set_gssapi_service_principal (void *self, const char *gssapi_service_principal);
 
-// Get socket option `ipv6`.
+// Get socket option `ipv6`.   
+// Available from libzmq 4.0.0.
 int
     zsock_ipv6 (void *self);
 
-// Set socket option `ipv6`.
+// Set socket option `ipv6`.   
+// Available from libzmq 4.0.0.
 void
     zsock_set_ipv6 (void *self, int ipv6);
 
 // Get socket option `immediate`.
+// Available from libzmq 4.0.0.  
 int
     zsock_immediate (void *self);
 
 // Set socket option `immediate`.
+// Available from libzmq 4.0.0.  
 void
     zsock_set_immediate (void *self, int immediate);
 
-// Get socket option `type`.
+// Get socket option `type`.   
+// Available from libzmq 3.0.0.
 int
     zsock_type (void *self);
 
-// Get socket option `sndhwm`.
+// Get socket option `sndhwm`. 
+// Available from libzmq 3.0.0.
 int
     zsock_sndhwm (void *self);
 
-// Set socket option `sndhwm`.
+// Set socket option `sndhwm`. 
+// Available from libzmq 3.0.0.
 void
     zsock_set_sndhwm (void *self, int sndhwm);
 
-// Get socket option `rcvhwm`.
+// Get socket option `rcvhwm`. 
+// Available from libzmq 3.0.0.
 int
     zsock_rcvhwm (void *self);
 
-// Set socket option `rcvhwm`.
+// Set socket option `rcvhwm`. 
+// Available from libzmq 3.0.0.
 void
     zsock_set_rcvhwm (void *self, int rcvhwm);
 
 // Get socket option `affinity`.
+// Available from libzmq 3.0.0. 
 int
     zsock_affinity (void *self);
 
 // Set socket option `affinity`.
+// Available from libzmq 3.0.0. 
 void
     zsock_set_affinity (void *self, int affinity);
 
 // Set socket option `subscribe`.
+// Available from libzmq 3.0.0.  
 void
     zsock_set_subscribe (void *self, const char *subscribe);
 
 // Set socket option `unsubscribe`.
+// Available from libzmq 3.0.0.    
 void
     zsock_set_unsubscribe (void *self, const char *unsubscribe);
 
 // Get socket option `identity`.
+// Available from libzmq 3.0.0. 
 char *
     zsock_identity (void *self);
 
 // Set socket option `identity`.
+// Available from libzmq 3.0.0. 
 void
     zsock_set_identity (void *self, const char *identity);
 
-// Get socket option `rate`.
+// Get socket option `rate`.   
+// Available from libzmq 3.0.0.
 int
     zsock_rate (void *self);
 
-// Set socket option `rate`.
+// Set socket option `rate`.   
+// Available from libzmq 3.0.0.
 void
     zsock_set_rate (void *self, int rate);
 
 // Get socket option `recovery_ivl`.
+// Available from libzmq 3.0.0.     
 int
     zsock_recovery_ivl (void *self);
 
 // Set socket option `recovery_ivl`.
+// Available from libzmq 3.0.0.     
 void
     zsock_set_recovery_ivl (void *self, int recovery_ivl);
 
-// Get socket option `sndbuf`.
+// Get socket option `sndbuf`. 
+// Available from libzmq 3.0.0.
 int
     zsock_sndbuf (void *self);
 
-// Set socket option `sndbuf`.
+// Set socket option `sndbuf`. 
+// Available from libzmq 3.0.0.
 void
     zsock_set_sndbuf (void *self, int sndbuf);
 
-// Get socket option `rcvbuf`.
+// Get socket option `rcvbuf`. 
+// Available from libzmq 3.0.0.
 int
     zsock_rcvbuf (void *self);
 
-// Set socket option `rcvbuf`.
+// Set socket option `rcvbuf`. 
+// Available from libzmq 3.0.0.
 void
     zsock_set_rcvbuf (void *self, int rcvbuf);
 
-// Get socket option `linger`.
+// Get socket option `linger`. 
+// Available from libzmq 3.0.0.
 int
     zsock_linger (void *self);
 
-// Set socket option `linger`.
+// Set socket option `linger`. 
+// Available from libzmq 3.0.0.
 void
     zsock_set_linger (void *self, int linger);
 
 // Get socket option `reconnect_ivl`.
+// Available from libzmq 3.0.0.      
 int
     zsock_reconnect_ivl (void *self);
 
 // Set socket option `reconnect_ivl`.
+// Available from libzmq 3.0.0.      
 void
     zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
 
 // Get socket option `reconnect_ivl_max`.
+// Available from libzmq 3.0.0.          
 int
     zsock_reconnect_ivl_max (void *self);
 
 // Set socket option `reconnect_ivl_max`.
+// Available from libzmq 3.0.0.          
 void
     zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
 
 // Get socket option `backlog`.
+// Available from libzmq 3.0.0.
 int
     zsock_backlog (void *self);
 
 // Set socket option `backlog`.
+// Available from libzmq 3.0.0.
 void
     zsock_set_backlog (void *self, int backlog);
 
 // Get socket option `maxmsgsize`.
+// Available from libzmq 3.0.0.   
 int
     zsock_maxmsgsize (void *self);
 
 // Set socket option `maxmsgsize`.
+// Available from libzmq 3.0.0.   
 void
     zsock_set_maxmsgsize (void *self, int maxmsgsize);
 
 // Get socket option `multicast_hops`.
+// Available from libzmq 3.0.0.       
 int
     zsock_multicast_hops (void *self);
 
 // Set socket option `multicast_hops`.
+// Available from libzmq 3.0.0.       
 void
     zsock_set_multicast_hops (void *self, int multicast_hops);
 
 // Get socket option `rcvtimeo`.
+// Available from libzmq 3.0.0. 
 int
     zsock_rcvtimeo (void *self);
 
 // Set socket option `rcvtimeo`.
+// Available from libzmq 3.0.0. 
 void
     zsock_set_rcvtimeo (void *self, int rcvtimeo);
 
 // Get socket option `sndtimeo`.
+// Available from libzmq 3.0.0. 
 int
     zsock_sndtimeo (void *self);
 
 // Set socket option `sndtimeo`.
+// Available from libzmq 3.0.0. 
 void
     zsock_set_sndtimeo (void *self, int sndtimeo);
 
 // Set socket option `xpub_verbose`.
+// Available from libzmq 3.0.0.     
 void
     zsock_set_xpub_verbose (void *self, int xpub_verbose);
 
 // Get socket option `tcp_keepalive`.
+// Available from libzmq 3.0.0.      
 int
     zsock_tcp_keepalive (void *self);
 
 // Set socket option `tcp_keepalive`.
+// Available from libzmq 3.0.0.      
 void
     zsock_set_tcp_keepalive (void *self, int tcp_keepalive);
 
 // Get socket option `tcp_keepalive_idle`.
+// Available from libzmq 3.0.0.           
 int
     zsock_tcp_keepalive_idle (void *self);
 
 // Set socket option `tcp_keepalive_idle`.
+// Available from libzmq 3.0.0.           
 void
     zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle);
 
 // Get socket option `tcp_keepalive_cnt`.
+// Available from libzmq 3.0.0.          
 int
     zsock_tcp_keepalive_cnt (void *self);
 
 // Set socket option `tcp_keepalive_cnt`.
+// Available from libzmq 3.0.0.          
 void
     zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt);
 
 // Get socket option `tcp_keepalive_intvl`.
+// Available from libzmq 3.0.0.            
 int
     zsock_tcp_keepalive_intvl (void *self);
 
 // Set socket option `tcp_keepalive_intvl`.
+// Available from libzmq 3.0.0.            
 void
     zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl);
 
 // Get socket option `tcp_accept_filter`.
+// Available from libzmq 3.0.0.          
 char *
     zsock_tcp_accept_filter (void *self);
 
 // Set socket option `tcp_accept_filter`.
+// Available from libzmq 3.0.0.          
 void
     zsock_set_tcp_accept_filter (void *self, const char *tcp_accept_filter);
 
 // Get socket option `rcvmore`.
+// Available from libzmq 3.0.0.
 int
     zsock_rcvmore (void *self);
 
-// Get socket option `fd`.
+// Get socket option `fd`.     
+// Available from libzmq 3.0.0.
 SOCKET
     zsock_fd (void *self);
 
-// Get socket option `events`.
+// Get socket option `events`. 
+// Available from libzmq 3.0.0.
 int
     zsock_events (void *self);
 
 // Get socket option `last_endpoint`.
+// Available from libzmq 3.0.0.      
 char *
     zsock_last_endpoint (void *self);
 
 // Set socket option `router_raw`.
+// Available from libzmq 3.0.0.   
 void
     zsock_set_router_raw (void *self, int router_raw);
 
 // Get socket option `ipv4only`.
+// Available from libzmq 3.0.0. 
 int
     zsock_ipv4only (void *self);
 
 // Set socket option `ipv4only`.
+// Available from libzmq 3.0.0. 
 void
     zsock_set_ipv4only (void *self, int ipv4only);
 
 // Set socket option `delay_attach_on_connect`.
+// Available from libzmq 3.0.0.                
 void
     zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 

--- a/bindings/qml/src/QmlZsock.cpp
+++ b/bindings/qml/src/QmlZsock.cpp
@@ -264,222 +264,259 @@ int QmlZsock::leave (const QString &group) {
 
 ///
 //  Get socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 int QmlZsock::heartbeatIvl () {
     return zsock_heartbeat_ivl (self);
 };
 
 ///
 //  Set socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 void QmlZsock::setHeartbeatIvl (int heartbeatIvl) {
     zsock_set_heartbeat_ivl (self, heartbeatIvl);
 };
 
 ///
 //  Get socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 int QmlZsock::heartbeatTtl () {
     return zsock_heartbeat_ttl (self);
 };
 
 ///
 //  Set socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 void QmlZsock::setHeartbeatTtl (int heartbeatTtl) {
     zsock_set_heartbeat_ttl (self, heartbeatTtl);
 };
 
 ///
 //  Get socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 int QmlZsock::heartbeatTimeout () {
     return zsock_heartbeat_timeout (self);
 };
 
 ///
 //  Set socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 void QmlZsock::setHeartbeatTimeout (int heartbeatTimeout) {
     zsock_set_heartbeat_timeout (self, heartbeatTimeout);
 };
 
 ///
-//  Get socket option `use_fd`.
+//  Get socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 int QmlZsock::useFd () {
     return zsock_use_fd (self);
 };
 
 ///
-//  Set socket option `use_fd`.
+//  Set socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 void QmlZsock::setUseFd (int useFd) {
     zsock_set_use_fd (self, useFd);
 };
 
 ///
 //  Set socket option `xpub_manual`.
+//  Available from libzmq 4.2.0.    
 void QmlZsock::setXpubManual (int xpubManual) {
     zsock_set_xpub_manual (self, xpubManual);
 };
 
 ///
 //  Set socket option `xpub_welcome_msg`.
+//  Available from libzmq 4.2.0.         
 void QmlZsock::setXpubWelcomeMsg (const QString &xpubWelcomeMsg) {
     zsock_set_xpub_welcome_msg (self, xpubWelcomeMsg.toUtf8().data());
 };
 
 ///
 //  Set socket option `stream_notify`.
+//  Available from libzmq 4.2.0.      
 void QmlZsock::setStreamNotify (int streamNotify) {
     zsock_set_stream_notify (self, streamNotify);
 };
 
 ///
 //  Get socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 int QmlZsock::invertMatching () {
     return zsock_invert_matching (self);
 };
 
 ///
 //  Set socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 void QmlZsock::setInvertMatching (int invertMatching) {
     zsock_set_invert_matching (self, invertMatching);
 };
 
 ///
 //  Set socket option `xpub_verboser`.
+//  Available from libzmq 4.2.0.      
 void QmlZsock::setXpubVerboser (int xpubVerboser) {
     zsock_set_xpub_verboser (self, xpubVerboser);
 };
 
 ///
 //  Get socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 int QmlZsock::connectTimeout () {
     return zsock_connect_timeout (self);
 };
 
 ///
 //  Set socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 void QmlZsock::setConnectTimeout (int connectTimeout) {
     zsock_set_connect_timeout (self, connectTimeout);
 };
 
 ///
 //  Get socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 int QmlZsock::tcpMaxrt () {
     return zsock_tcp_maxrt (self);
 };
 
 ///
 //  Set socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 void QmlZsock::setTcpMaxrt (int tcpMaxrt) {
     zsock_set_tcp_maxrt (self, tcpMaxrt);
 };
 
 ///
 //  Get socket option `thread_safe`.
+//  Available from libzmq 4.2.0.    
 int QmlZsock::threadSafe () {
     return zsock_thread_safe (self);
 };
 
 ///
 //  Get socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 int QmlZsock::multicastMaxtpdu () {
     return zsock_multicast_maxtpdu (self);
 };
 
 ///
 //  Set socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 void QmlZsock::setMulticastMaxtpdu (int multicastMaxtpdu) {
     zsock_set_multicast_maxtpdu (self, multicastMaxtpdu);
 };
 
 ///
 //  Get socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 int QmlZsock::vmciBufferSize () {
     return zsock_vmci_buffer_size (self);
 };
 
 ///
 //  Set socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 void QmlZsock::setVmciBufferSize (int vmciBufferSize) {
     zsock_set_vmci_buffer_size (self, vmciBufferSize);
 };
 
 ///
 //  Get socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 int QmlZsock::vmciBufferMinSize () {
     return zsock_vmci_buffer_min_size (self);
 };
 
 ///
 //  Set socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 void QmlZsock::setVmciBufferMinSize (int vmciBufferMinSize) {
     zsock_set_vmci_buffer_min_size (self, vmciBufferMinSize);
 };
 
 ///
 //  Get socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 int QmlZsock::vmciBufferMaxSize () {
     return zsock_vmci_buffer_max_size (self);
 };
 
 ///
 //  Set socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 void QmlZsock::setVmciBufferMaxSize (int vmciBufferMaxSize) {
     zsock_set_vmci_buffer_max_size (self, vmciBufferMaxSize);
 };
 
 ///
 //  Get socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 int QmlZsock::vmciConnectTimeout () {
     return zsock_vmci_connect_timeout (self);
 };
 
 ///
 //  Set socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 void QmlZsock::setVmciConnectTimeout (int vmciConnectTimeout) {
     zsock_set_vmci_connect_timeout (self, vmciConnectTimeout);
 };
 
 ///
-//  Get socket option `tos`.
+//  Get socket option `tos`.    
+//  Available from libzmq 4.1.0.
 int QmlZsock::tos () {
     return zsock_tos (self);
 };
 
 ///
-//  Set socket option `tos`.
+//  Set socket option `tos`.    
+//  Available from libzmq 4.1.0.
 void QmlZsock::setTos (int tos) {
     zsock_set_tos (self, tos);
 };
 
 ///
 //  Set socket option `router_handover`.
+//  Available from libzmq 4.1.0.        
 void QmlZsock::setRouterHandover (int routerHandover) {
     zsock_set_router_handover (self, routerHandover);
 };
 
 ///
 //  Set socket option `connect_rid`.
+//  Available from libzmq 4.1.0.    
 void QmlZsock::setConnectRid (const QString &connectRid) {
     zsock_set_connect_rid (self, connectRid.toUtf8().data());
 };
 
 ///
 //  Set socket option `connect_rid` from 32-octet binary
+//  Available from libzmq 4.1.0.                        
 void QmlZsock::setConnectRidBin (const byte *connectRid) {
     zsock_set_connect_rid_bin (self, connectRid);
 };
 
 ///
 //  Get socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 int QmlZsock::handshakeIvl () {
     return zsock_handshake_ivl (self);
 };
 
 ///
 //  Set socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 void QmlZsock::setHandshakeIvl (int handshakeIvl) {
     zsock_set_handshake_ivl (self, handshakeIvl);
 };
 
 ///
 //  Get socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 QString QmlZsock::socksProxy () {
     char *retStr_ = zsock_socks_proxy (self);
     QString retQStr_ = QString (retStr_);
@@ -489,48 +526,56 @@ QString QmlZsock::socksProxy () {
 
 ///
 //  Set socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 void QmlZsock::setSocksProxy (const QString &socksProxy) {
     zsock_set_socks_proxy (self, socksProxy.toUtf8().data());
 };
 
 ///
 //  Set socket option `xpub_nodrop`.
+//  Available from libzmq 4.1.0.    
 void QmlZsock::setXpubNodrop (int xpubNodrop) {
     zsock_set_xpub_nodrop (self, xpubNodrop);
 };
 
 ///
 //  Set socket option `router_mandatory`.
+//  Available from libzmq 4.0.0.         
 void QmlZsock::setRouterMandatory (int routerMandatory) {
     zsock_set_router_mandatory (self, routerMandatory);
 };
 
 ///
 //  Set socket option `probe_router`.
+//  Available from libzmq 4.0.0.     
 void QmlZsock::setProbeRouter (int probeRouter) {
     zsock_set_probe_router (self, probeRouter);
 };
 
 ///
 //  Set socket option `req_relaxed`.
+//  Available from libzmq 4.0.0.    
 void QmlZsock::setReqRelaxed (int reqRelaxed) {
     zsock_set_req_relaxed (self, reqRelaxed);
 };
 
 ///
 //  Set socket option `req_correlate`.
+//  Available from libzmq 4.0.0.      
 void QmlZsock::setReqCorrelate (int reqCorrelate) {
     zsock_set_req_correlate (self, reqCorrelate);
 };
 
 ///
 //  Set socket option `conflate`.
+//  Available from libzmq 4.0.0. 
 void QmlZsock::setConflate (int conflate) {
     zsock_set_conflate (self, conflate);
 };
 
 ///
 //  Get socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 QString QmlZsock::zapDomain () {
     char *retStr_ = zsock_zap_domain (self);
     QString retQStr_ = QString (retStr_);
@@ -540,30 +585,35 @@ QString QmlZsock::zapDomain () {
 
 ///
 //  Set socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 void QmlZsock::setZapDomain (const QString &zapDomain) {
     zsock_set_zap_domain (self, zapDomain.toUtf8().data());
 };
 
 ///
 //  Get socket option `mechanism`.
+//  Available from libzmq 4.0.0.  
 int QmlZsock::mechanism () {
     return zsock_mechanism (self);
 };
 
 ///
 //  Get socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 int QmlZsock::plainServer () {
     return zsock_plain_server (self);
 };
 
 ///
 //  Set socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 void QmlZsock::setPlainServer (int plainServer) {
     zsock_set_plain_server (self, plainServer);
 };
 
 ///
 //  Get socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 QString QmlZsock::plainUsername () {
     char *retStr_ = zsock_plain_username (self);
     QString retQStr_ = QString (retStr_);
@@ -573,12 +623,14 @@ QString QmlZsock::plainUsername () {
 
 ///
 //  Set socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 void QmlZsock::setPlainUsername (const QString &plainUsername) {
     zsock_set_plain_username (self, plainUsername.toUtf8().data());
 };
 
 ///
 //  Get socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 QString QmlZsock::plainPassword () {
     char *retStr_ = zsock_plain_password (self);
     QString retQStr_ = QString (retStr_);
@@ -588,24 +640,28 @@ QString QmlZsock::plainPassword () {
 
 ///
 //  Set socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 void QmlZsock::setPlainPassword (const QString &plainPassword) {
     zsock_set_plain_password (self, plainPassword.toUtf8().data());
 };
 
 ///
 //  Get socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 int QmlZsock::curveServer () {
     return zsock_curve_server (self);
 };
 
 ///
 //  Set socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 void QmlZsock::setCurveServer (int curveServer) {
     zsock_set_curve_server (self, curveServer);
 };
 
 ///
 //  Get socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 QString QmlZsock::curvePublickey () {
     char *retStr_ = zsock_curve_publickey (self);
     QString retQStr_ = QString (retStr_);
@@ -615,18 +671,21 @@ QString QmlZsock::curvePublickey () {
 
 ///
 //  Set socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 void QmlZsock::setCurvePublickey (const QString &curvePublickey) {
     zsock_set_curve_publickey (self, curvePublickey.toUtf8().data());
 };
 
 ///
 //  Set socket option `curve_publickey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QmlZsock::setCurvePublickeyBin (const byte *curvePublickey) {
     zsock_set_curve_publickey_bin (self, curvePublickey);
 };
 
 ///
 //  Get socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 QString QmlZsock::curveSecretkey () {
     char *retStr_ = zsock_curve_secretkey (self);
     QString retQStr_ = QString (retStr_);
@@ -636,18 +695,21 @@ QString QmlZsock::curveSecretkey () {
 
 ///
 //  Set socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 void QmlZsock::setCurveSecretkey (const QString &curveSecretkey) {
     zsock_set_curve_secretkey (self, curveSecretkey.toUtf8().data());
 };
 
 ///
 //  Set socket option `curve_secretkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QmlZsock::setCurveSecretkeyBin (const byte *curveSecretkey) {
     zsock_set_curve_secretkey_bin (self, curveSecretkey);
 };
 
 ///
 //  Get socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 QString QmlZsock::curveServerkey () {
     char *retStr_ = zsock_curve_serverkey (self);
     QString retQStr_ = QString (retStr_);
@@ -657,42 +719,49 @@ QString QmlZsock::curveServerkey () {
 
 ///
 //  Set socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 void QmlZsock::setCurveServerkey (const QString &curveServerkey) {
     zsock_set_curve_serverkey (self, curveServerkey.toUtf8().data());
 };
 
 ///
 //  Set socket option `curve_serverkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QmlZsock::setCurveServerkeyBin (const byte *curveServerkey) {
     zsock_set_curve_serverkey_bin (self, curveServerkey);
 };
 
 ///
 //  Get socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 int QmlZsock::gssapiServer () {
     return zsock_gssapi_server (self);
 };
 
 ///
 //  Set socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 void QmlZsock::setGssapiServer (int gssapiServer) {
     zsock_set_gssapi_server (self, gssapiServer);
 };
 
 ///
 //  Get socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 int QmlZsock::gssapiPlaintext () {
     return zsock_gssapi_plaintext (self);
 };
 
 ///
 //  Set socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 void QmlZsock::setGssapiPlaintext (int gssapiPlaintext) {
     zsock_set_gssapi_plaintext (self, gssapiPlaintext);
 };
 
 ///
 //  Get socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 QString QmlZsock::gssapiPrincipal () {
     char *retStr_ = zsock_gssapi_principal (self);
     QString retQStr_ = QString (retStr_);
@@ -702,12 +771,14 @@ QString QmlZsock::gssapiPrincipal () {
 
 ///
 //  Set socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 void QmlZsock::setGssapiPrincipal (const QString &gssapiPrincipal) {
     zsock_set_gssapi_principal (self, gssapiPrincipal.toUtf8().data());
 };
 
 ///
 //  Get socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 QString QmlZsock::gssapiServicePrincipal () {
     char *retStr_ = zsock_gssapi_service_principal (self);
     QString retQStr_ = QString (retStr_);
@@ -717,90 +788,105 @@ QString QmlZsock::gssapiServicePrincipal () {
 
 ///
 //  Set socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 void QmlZsock::setGssapiServicePrincipal (const QString &gssapiServicePrincipal) {
     zsock_set_gssapi_service_principal (self, gssapiServicePrincipal.toUtf8().data());
 };
 
 ///
-//  Get socket option `ipv6`.
+//  Get socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 int QmlZsock::ipv6 () {
     return zsock_ipv6 (self);
 };
 
 ///
-//  Set socket option `ipv6`.
+//  Set socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 void QmlZsock::setIpv6 (int ipv6) {
     zsock_set_ipv6 (self, ipv6);
 };
 
 ///
 //  Get socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 int QmlZsock::immediate () {
     return zsock_immediate (self);
 };
 
 ///
 //  Set socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 void QmlZsock::setImmediate (int immediate) {
     zsock_set_immediate (self, immediate);
 };
 
 ///
-//  Get socket option `type`.
+//  Get socket option `type`.   
+//  Available from libzmq 3.0.0.
 int QmlZsock::type () {
     return zsock_type (self);
 };
 
 ///
-//  Get socket option `sndhwm`.
+//  Get socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::sndhwm () {
     return zsock_sndhwm (self);
 };
 
 ///
-//  Set socket option `sndhwm`.
+//  Set socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 void QmlZsock::setSndhwm (int sndhwm) {
     zsock_set_sndhwm (self, sndhwm);
 };
 
 ///
-//  Get socket option `rcvhwm`.
+//  Get socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::rcvhwm () {
     return zsock_rcvhwm (self);
 };
 
 ///
-//  Set socket option `rcvhwm`.
+//  Set socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 void QmlZsock::setRcvhwm (int rcvhwm) {
     zsock_set_rcvhwm (self, rcvhwm);
 };
 
 ///
 //  Get socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 int QmlZsock::affinity () {
     return zsock_affinity (self);
 };
 
 ///
 //  Set socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 void QmlZsock::setAffinity (int affinity) {
     zsock_set_affinity (self, affinity);
 };
 
 ///
 //  Set socket option `subscribe`.
+//  Available from libzmq 3.0.0.  
 void QmlZsock::setSubscribe (const QString &subscribe) {
     zsock_set_subscribe (self, subscribe.toUtf8().data());
 };
 
 ///
 //  Set socket option `unsubscribe`.
+//  Available from libzmq 3.0.0.    
 void QmlZsock::setUnsubscribe (const QString &unsubscribe) {
     zsock_set_unsubscribe (self, unsubscribe.toUtf8().data());
 };
 
 ///
 //  Get socket option `identity`.
+//  Available from libzmq 3.0.0. 
 QString QmlZsock::identity () {
     char *retStr_ = zsock_identity (self);
     QString retQStr_ = QString (retStr_);
@@ -810,210 +896,245 @@ QString QmlZsock::identity () {
 
 ///
 //  Set socket option `identity`.
+//  Available from libzmq 3.0.0. 
 void QmlZsock::setIdentity (const QString &identity) {
     zsock_set_identity (self, identity.toUtf8().data());
 };
 
 ///
-//  Get socket option `rate`.
+//  Get socket option `rate`.   
+//  Available from libzmq 3.0.0.
 int QmlZsock::rate () {
     return zsock_rate (self);
 };
 
 ///
-//  Set socket option `rate`.
+//  Set socket option `rate`.   
+//  Available from libzmq 3.0.0.
 void QmlZsock::setRate (int rate) {
     zsock_set_rate (self, rate);
 };
 
 ///
 //  Get socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 int QmlZsock::recoveryIvl () {
     return zsock_recovery_ivl (self);
 };
 
 ///
 //  Set socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 void QmlZsock::setRecoveryIvl (int recoveryIvl) {
     zsock_set_recovery_ivl (self, recoveryIvl);
 };
 
 ///
-//  Get socket option `sndbuf`.
+//  Get socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::sndbuf () {
     return zsock_sndbuf (self);
 };
 
 ///
-//  Set socket option `sndbuf`.
+//  Set socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 void QmlZsock::setSndbuf (int sndbuf) {
     zsock_set_sndbuf (self, sndbuf);
 };
 
 ///
-//  Get socket option `rcvbuf`.
+//  Get socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::rcvbuf () {
     return zsock_rcvbuf (self);
 };
 
 ///
-//  Set socket option `rcvbuf`.
+//  Set socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 void QmlZsock::setRcvbuf (int rcvbuf) {
     zsock_set_rcvbuf (self, rcvbuf);
 };
 
 ///
-//  Get socket option `linger`.
+//  Get socket option `linger`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::linger () {
     return zsock_linger (self);
 };
 
 ///
-//  Set socket option `linger`.
+//  Set socket option `linger`. 
+//  Available from libzmq 3.0.0.
 void QmlZsock::setLinger (int linger) {
     zsock_set_linger (self, linger);
 };
 
 ///
 //  Get socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 int QmlZsock::reconnectIvl () {
     return zsock_reconnect_ivl (self);
 };
 
 ///
 //  Set socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 void QmlZsock::setReconnectIvl (int reconnectIvl) {
     zsock_set_reconnect_ivl (self, reconnectIvl);
 };
 
 ///
 //  Get socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 int QmlZsock::reconnectIvlMax () {
     return zsock_reconnect_ivl_max (self);
 };
 
 ///
 //  Set socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 void QmlZsock::setReconnectIvlMax (int reconnectIvlMax) {
     zsock_set_reconnect_ivl_max (self, reconnectIvlMax);
 };
 
 ///
 //  Get socket option `backlog`.
+//  Available from libzmq 3.0.0.
 int QmlZsock::backlog () {
     return zsock_backlog (self);
 };
 
 ///
 //  Set socket option `backlog`.
+//  Available from libzmq 3.0.0.
 void QmlZsock::setBacklog (int backlog) {
     zsock_set_backlog (self, backlog);
 };
 
 ///
 //  Get socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 int QmlZsock::maxmsgsize () {
     return zsock_maxmsgsize (self);
 };
 
 ///
 //  Set socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 void QmlZsock::setMaxmsgsize (int maxmsgsize) {
     zsock_set_maxmsgsize (self, maxmsgsize);
 };
 
 ///
 //  Get socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 int QmlZsock::multicastHops () {
     return zsock_multicast_hops (self);
 };
 
 ///
 //  Set socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 void QmlZsock::setMulticastHops (int multicastHops) {
     zsock_set_multicast_hops (self, multicastHops);
 };
 
 ///
 //  Get socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 int QmlZsock::rcvtimeo () {
     return zsock_rcvtimeo (self);
 };
 
 ///
 //  Set socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 void QmlZsock::setRcvtimeo (int rcvtimeo) {
     zsock_set_rcvtimeo (self, rcvtimeo);
 };
 
 ///
 //  Get socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 int QmlZsock::sndtimeo () {
     return zsock_sndtimeo (self);
 };
 
 ///
 //  Set socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 void QmlZsock::setSndtimeo (int sndtimeo) {
     zsock_set_sndtimeo (self, sndtimeo);
 };
 
 ///
 //  Set socket option `xpub_verbose`.
+//  Available from libzmq 3.0.0.     
 void QmlZsock::setXpubVerbose (int xpubVerbose) {
     zsock_set_xpub_verbose (self, xpubVerbose);
 };
 
 ///
 //  Get socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 int QmlZsock::tcpKeepalive () {
     return zsock_tcp_keepalive (self);
 };
 
 ///
 //  Set socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 void QmlZsock::setTcpKeepalive (int tcpKeepalive) {
     zsock_set_tcp_keepalive (self, tcpKeepalive);
 };
 
 ///
 //  Get socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 int QmlZsock::tcpKeepaliveIdle () {
     return zsock_tcp_keepalive_idle (self);
 };
 
 ///
 //  Set socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 void QmlZsock::setTcpKeepaliveIdle (int tcpKeepaliveIdle) {
     zsock_set_tcp_keepalive_idle (self, tcpKeepaliveIdle);
 };
 
 ///
 //  Get socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 int QmlZsock::tcpKeepaliveCnt () {
     return zsock_tcp_keepalive_cnt (self);
 };
 
 ///
 //  Set socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 void QmlZsock::setTcpKeepaliveCnt (int tcpKeepaliveCnt) {
     zsock_set_tcp_keepalive_cnt (self, tcpKeepaliveCnt);
 };
 
 ///
 //  Get socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 int QmlZsock::tcpKeepaliveIntvl () {
     return zsock_tcp_keepalive_intvl (self);
 };
 
 ///
 //  Set socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 void QmlZsock::setTcpKeepaliveIntvl (int tcpKeepaliveIntvl) {
     zsock_set_tcp_keepalive_intvl (self, tcpKeepaliveIntvl);
 };
 
 ///
 //  Get socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 QString QmlZsock::tcpAcceptFilter () {
     char *retStr_ = zsock_tcp_accept_filter (self);
     QString retQStr_ = QString (retStr_);
@@ -1023,30 +1144,35 @@ QString QmlZsock::tcpAcceptFilter () {
 
 ///
 //  Set socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 void QmlZsock::setTcpAcceptFilter (const QString &tcpAcceptFilter) {
     zsock_set_tcp_accept_filter (self, tcpAcceptFilter.toUtf8().data());
 };
 
 ///
 //  Get socket option `rcvmore`.
+//  Available from libzmq 3.0.0.
 int QmlZsock::rcvmore () {
     return zsock_rcvmore (self);
 };
 
 ///
-//  Get socket option `fd`.
+//  Get socket option `fd`.     
+//  Available from libzmq 3.0.0.
 SOCKET QmlZsock::fd () {
     return zsock_fd (self);
 };
 
 ///
-//  Get socket option `events`.
+//  Get socket option `events`. 
+//  Available from libzmq 3.0.0.
 int QmlZsock::events () {
     return zsock_events (self);
 };
 
 ///
 //  Get socket option `last_endpoint`.
+//  Available from libzmq 3.0.0.      
 QString QmlZsock::lastEndpoint () {
     char *retStr_ = zsock_last_endpoint (self);
     QString retQStr_ = QString (retStr_);
@@ -1056,24 +1182,28 @@ QString QmlZsock::lastEndpoint () {
 
 ///
 //  Set socket option `router_raw`.
+//  Available from libzmq 3.0.0.   
 void QmlZsock::setRouterRaw (int routerRaw) {
     zsock_set_router_raw (self, routerRaw);
 };
 
 ///
 //  Get socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 int QmlZsock::ipv4only () {
     return zsock_ipv4only (self);
 };
 
 ///
 //  Set socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 void QmlZsock::setIpv4only (int ipv4only) {
     zsock_set_ipv4only (self, ipv4only);
 };
 
 ///
 //  Set socket option `delay_attach_on_connect`.
+//  Available from libzmq 3.0.0.                
 void QmlZsock::setDelayAttachOnConnect (int delayAttachOnConnect) {
     zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);
 };

--- a/bindings/qml/src/QmlZsock.h
+++ b/bindings/qml/src/QmlZsock.h
@@ -220,393 +220,523 @@ public slots:
     int leave (const QString &group);
 
     //  Get socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     int heartbeatIvl ();
 
     //  Set socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     void setHeartbeatIvl (int heartbeatIvl);
 
     //  Get socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     int heartbeatTtl ();
 
     //  Set socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     void setHeartbeatTtl (int heartbeatTtl);
 
     //  Get socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     int heartbeatTimeout ();
 
     //  Set socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     void setHeartbeatTimeout (int heartbeatTimeout);
 
-    //  Get socket option `use_fd`.
+    //  Get socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     int useFd ();
 
-    //  Set socket option `use_fd`.
+    //  Set socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     void setUseFd (int useFd);
 
     //  Set socket option `xpub_manual`.
+    //  Available from libzmq 4.2.0.    
     void setXpubManual (int xpubManual);
 
     //  Set socket option `xpub_welcome_msg`.
+    //  Available from libzmq 4.2.0.         
     void setXpubWelcomeMsg (const QString &xpubWelcomeMsg);
 
     //  Set socket option `stream_notify`.
+    //  Available from libzmq 4.2.0.      
     void setStreamNotify (int streamNotify);
 
     //  Get socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     int invertMatching ();
 
     //  Set socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     void setInvertMatching (int invertMatching);
 
     //  Set socket option `xpub_verboser`.
+    //  Available from libzmq 4.2.0.      
     void setXpubVerboser (int xpubVerboser);
 
     //  Get socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     int connectTimeout ();
 
     //  Set socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     void setConnectTimeout (int connectTimeout);
 
     //  Get socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     int tcpMaxrt ();
 
     //  Set socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     void setTcpMaxrt (int tcpMaxrt);
 
     //  Get socket option `thread_safe`.
+    //  Available from libzmq 4.2.0.    
     int threadSafe ();
 
     //  Get socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     int multicastMaxtpdu ();
 
     //  Set socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     void setMulticastMaxtpdu (int multicastMaxtpdu);
 
     //  Get socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     int vmciBufferSize ();
 
     //  Set socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     void setVmciBufferSize (int vmciBufferSize);
 
     //  Get socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     int vmciBufferMinSize ();
 
     //  Set socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     void setVmciBufferMinSize (int vmciBufferMinSize);
 
     //  Get socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     int vmciBufferMaxSize ();
 
     //  Set socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     void setVmciBufferMaxSize (int vmciBufferMaxSize);
 
     //  Get socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     int vmciConnectTimeout ();
 
     //  Set socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     void setVmciConnectTimeout (int vmciConnectTimeout);
 
-    //  Get socket option `tos`.
+    //  Get socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     int tos ();
 
-    //  Set socket option `tos`.
+    //  Set socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     void setTos (int tos);
 
     //  Set socket option `router_handover`.
+    //  Available from libzmq 4.1.0.        
     void setRouterHandover (int routerHandover);
 
     //  Set socket option `connect_rid`.
+    //  Available from libzmq 4.1.0.    
     void setConnectRid (const QString &connectRid);
 
     //  Set socket option `connect_rid` from 32-octet binary
+    //  Available from libzmq 4.1.0.                        
     void setConnectRidBin (const byte *connectRid);
 
     //  Get socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     int handshakeIvl ();
 
     //  Set socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     void setHandshakeIvl (int handshakeIvl);
 
     //  Get socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     QString socksProxy ();
 
     //  Set socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     void setSocksProxy (const QString &socksProxy);
 
     //  Set socket option `xpub_nodrop`.
+    //  Available from libzmq 4.1.0.    
     void setXpubNodrop (int xpubNodrop);
 
     //  Set socket option `router_mandatory`.
+    //  Available from libzmq 4.0.0.         
     void setRouterMandatory (int routerMandatory);
 
     //  Set socket option `probe_router`.
+    //  Available from libzmq 4.0.0.     
     void setProbeRouter (int probeRouter);
 
     //  Set socket option `req_relaxed`.
+    //  Available from libzmq 4.0.0.    
     void setReqRelaxed (int reqRelaxed);
 
     //  Set socket option `req_correlate`.
+    //  Available from libzmq 4.0.0.      
     void setReqCorrelate (int reqCorrelate);
 
     //  Set socket option `conflate`.
+    //  Available from libzmq 4.0.0. 
     void setConflate (int conflate);
 
     //  Get socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     QString zapDomain ();
 
     //  Set socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     void setZapDomain (const QString &zapDomain);
 
     //  Get socket option `mechanism`.
+    //  Available from libzmq 4.0.0.  
     int mechanism ();
 
     //  Get socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     int plainServer ();
 
     //  Set socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     void setPlainServer (int plainServer);
 
     //  Get socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     QString plainUsername ();
 
     //  Set socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     void setPlainUsername (const QString &plainUsername);
 
     //  Get socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     QString plainPassword ();
 
     //  Set socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     void setPlainPassword (const QString &plainPassword);
 
     //  Get socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     int curveServer ();
 
     //  Set socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     void setCurveServer (int curveServer);
 
     //  Get socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     QString curvePublickey ();
 
     //  Set socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     void setCurvePublickey (const QString &curvePublickey);
 
     //  Set socket option `curve_publickey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurvePublickeyBin (const byte *curvePublickey);
 
     //  Get socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     QString curveSecretkey ();
 
     //  Set socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     void setCurveSecretkey (const QString &curveSecretkey);
 
     //  Set socket option `curve_secretkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurveSecretkeyBin (const byte *curveSecretkey);
 
     //  Get socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     QString curveServerkey ();
 
     //  Set socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     void setCurveServerkey (const QString &curveServerkey);
 
     //  Set socket option `curve_serverkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurveServerkeyBin (const byte *curveServerkey);
 
     //  Get socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     int gssapiServer ();
 
     //  Set socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     void setGssapiServer (int gssapiServer);
 
     //  Get socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     int gssapiPlaintext ();
 
     //  Set socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     void setGssapiPlaintext (int gssapiPlaintext);
 
     //  Get socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     QString gssapiPrincipal ();
 
     //  Set socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     void setGssapiPrincipal (const QString &gssapiPrincipal);
 
     //  Get socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     QString gssapiServicePrincipal ();
 
     //  Set socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     void setGssapiServicePrincipal (const QString &gssapiServicePrincipal);
 
-    //  Get socket option `ipv6`.
+    //  Get socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     int ipv6 ();
 
-    //  Set socket option `ipv6`.
+    //  Set socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     void setIpv6 (int ipv6);
 
     //  Get socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     int immediate ();
 
     //  Set socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     void setImmediate (int immediate);
 
-    //  Get socket option `type`.
+    //  Get socket option `type`.   
+    //  Available from libzmq 3.0.0.
     int type ();
 
-    //  Get socket option `sndhwm`.
+    //  Get socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     int sndhwm ();
 
-    //  Set socket option `sndhwm`.
+    //  Set socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     void setSndhwm (int sndhwm);
 
-    //  Get socket option `rcvhwm`.
+    //  Get socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     int rcvhwm ();
 
-    //  Set socket option `rcvhwm`.
+    //  Set socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     void setRcvhwm (int rcvhwm);
 
     //  Get socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     int affinity ();
 
     //  Set socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     void setAffinity (int affinity);
 
     //  Set socket option `subscribe`.
+    //  Available from libzmq 3.0.0.  
     void setSubscribe (const QString &subscribe);
 
     //  Set socket option `unsubscribe`.
+    //  Available from libzmq 3.0.0.    
     void setUnsubscribe (const QString &unsubscribe);
 
     //  Get socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     QString identity ();
 
     //  Set socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     void setIdentity (const QString &identity);
 
-    //  Get socket option `rate`.
+    //  Get socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     int rate ();
 
-    //  Set socket option `rate`.
+    //  Set socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     void setRate (int rate);
 
     //  Get socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     int recoveryIvl ();
 
     //  Set socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     void setRecoveryIvl (int recoveryIvl);
 
-    //  Get socket option `sndbuf`.
+    //  Get socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     int sndbuf ();
 
-    //  Set socket option `sndbuf`.
+    //  Set socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     void setSndbuf (int sndbuf);
 
-    //  Get socket option `rcvbuf`.
+    //  Get socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     int rcvbuf ();
 
-    //  Set socket option `rcvbuf`.
+    //  Set socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     void setRcvbuf (int rcvbuf);
 
-    //  Get socket option `linger`.
+    //  Get socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     int linger ();
 
-    //  Set socket option `linger`.
+    //  Set socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     void setLinger (int linger);
 
     //  Get socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     int reconnectIvl ();
 
     //  Set socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     void setReconnectIvl (int reconnectIvl);
 
     //  Get socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     int reconnectIvlMax ();
 
     //  Set socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     void setReconnectIvlMax (int reconnectIvlMax);
 
     //  Get socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     int backlog ();
 
     //  Set socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     void setBacklog (int backlog);
 
     //  Get socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     int maxmsgsize ();
 
     //  Set socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     void setMaxmsgsize (int maxmsgsize);
 
     //  Get socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     int multicastHops ();
 
     //  Set socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     void setMulticastHops (int multicastHops);
 
     //  Get socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     int rcvtimeo ();
 
     //  Set socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     void setRcvtimeo (int rcvtimeo);
 
     //  Get socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     int sndtimeo ();
 
     //  Set socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     void setSndtimeo (int sndtimeo);
 
     //  Set socket option `xpub_verbose`.
+    //  Available from libzmq 3.0.0.     
     void setXpubVerbose (int xpubVerbose);
 
     //  Get socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     int tcpKeepalive ();
 
     //  Set socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     void setTcpKeepalive (int tcpKeepalive);
 
     //  Get socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     int tcpKeepaliveIdle ();
 
     //  Set socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     void setTcpKeepaliveIdle (int tcpKeepaliveIdle);
 
     //  Get socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     int tcpKeepaliveCnt ();
 
     //  Set socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     void setTcpKeepaliveCnt (int tcpKeepaliveCnt);
 
     //  Get socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     int tcpKeepaliveIntvl ();
 
     //  Set socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     void setTcpKeepaliveIntvl (int tcpKeepaliveIntvl);
 
     //  Get socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     QString tcpAcceptFilter ();
 
     //  Set socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     void setTcpAcceptFilter (const QString &tcpAcceptFilter);
 
     //  Get socket option `rcvmore`.
+    //  Available from libzmq 3.0.0.
     int rcvmore ();
 
-    //  Get socket option `fd`.
+    //  Get socket option `fd`.     
+    //  Available from libzmq 3.0.0.
     SOCKET fd ();
 
-    //  Get socket option `events`.
+    //  Get socket option `events`. 
+    //  Available from libzmq 3.0.0.
     int events ();
 
     //  Get socket option `last_endpoint`.
+    //  Available from libzmq 3.0.0.      
     QString lastEndpoint ();
 
     //  Set socket option `router_raw`.
+    //  Available from libzmq 3.0.0.   
     void setRouterRaw (int routerRaw);
 
     //  Get socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
     int ipv4only ();
 
     //  Set socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
     void setIpv4only (int ipv4only);
 
     //  Set socket option `delay_attach_on_connect`.
+    //  Available from libzmq 3.0.0.                
     void setDelayAttachOnConnect (int delayAttachOnConnect);
 };
 

--- a/bindings/qt/src/qzsock.cpp
+++ b/bindings/qt/src/qzsock.cpp
@@ -440,6 +440,7 @@ void * QZsock::resolve (void *self)
 
 ///
 //  Get socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 int QZsock::heartbeatIvl ()
 {
     int rv = zsock_heartbeat_ivl (self);
@@ -448,6 +449,7 @@ int QZsock::heartbeatIvl ()
 
 ///
 //  Set socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 void QZsock::setHeartbeatIvl (int heartbeatIvl)
 {
     zsock_set_heartbeat_ivl (self, heartbeatIvl);
@@ -456,6 +458,7 @@ void QZsock::setHeartbeatIvl (int heartbeatIvl)
 
 ///
 //  Get socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 int QZsock::heartbeatTtl ()
 {
     int rv = zsock_heartbeat_ttl (self);
@@ -464,6 +467,7 @@ int QZsock::heartbeatTtl ()
 
 ///
 //  Set socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 void QZsock::setHeartbeatTtl (int heartbeatTtl)
 {
     zsock_set_heartbeat_ttl (self, heartbeatTtl);
@@ -472,6 +476,7 @@ void QZsock::setHeartbeatTtl (int heartbeatTtl)
 
 ///
 //  Get socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 int QZsock::heartbeatTimeout ()
 {
     int rv = zsock_heartbeat_timeout (self);
@@ -480,6 +485,7 @@ int QZsock::heartbeatTimeout ()
 
 ///
 //  Set socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 void QZsock::setHeartbeatTimeout (int heartbeatTimeout)
 {
     zsock_set_heartbeat_timeout (self, heartbeatTimeout);
@@ -487,7 +493,8 @@ void QZsock::setHeartbeatTimeout (int heartbeatTimeout)
 }
 
 ///
-//  Get socket option `use_fd`.
+//  Get socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 int QZsock::useFd ()
 {
     int rv = zsock_use_fd (self);
@@ -495,7 +502,8 @@ int QZsock::useFd ()
 }
 
 ///
-//  Set socket option `use_fd`.
+//  Set socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 void QZsock::setUseFd (int useFd)
 {
     zsock_set_use_fd (self, useFd);
@@ -504,6 +512,7 @@ void QZsock::setUseFd (int useFd)
 
 ///
 //  Set socket option `xpub_manual`.
+//  Available from libzmq 4.2.0.    
 void QZsock::setXpubManual (int xpubManual)
 {
     zsock_set_xpub_manual (self, xpubManual);
@@ -512,6 +521,7 @@ void QZsock::setXpubManual (int xpubManual)
 
 ///
 //  Set socket option `xpub_welcome_msg`.
+//  Available from libzmq 4.2.0.         
 void QZsock::setXpubWelcomeMsg (const QString &xpubWelcomeMsg)
 {
     zsock_set_xpub_welcome_msg (self, xpubWelcomeMsg.toUtf8().data());
@@ -520,6 +530,7 @@ void QZsock::setXpubWelcomeMsg (const QString &xpubWelcomeMsg)
 
 ///
 //  Set socket option `stream_notify`.
+//  Available from libzmq 4.2.0.      
 void QZsock::setStreamNotify (int streamNotify)
 {
     zsock_set_stream_notify (self, streamNotify);
@@ -528,6 +539,7 @@ void QZsock::setStreamNotify (int streamNotify)
 
 ///
 //  Get socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 int QZsock::invertMatching ()
 {
     int rv = zsock_invert_matching (self);
@@ -536,6 +548,7 @@ int QZsock::invertMatching ()
 
 ///
 //  Set socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 void QZsock::setInvertMatching (int invertMatching)
 {
     zsock_set_invert_matching (self, invertMatching);
@@ -544,6 +557,7 @@ void QZsock::setInvertMatching (int invertMatching)
 
 ///
 //  Set socket option `xpub_verboser`.
+//  Available from libzmq 4.2.0.      
 void QZsock::setXpubVerboser (int xpubVerboser)
 {
     zsock_set_xpub_verboser (self, xpubVerboser);
@@ -552,6 +566,7 @@ void QZsock::setXpubVerboser (int xpubVerboser)
 
 ///
 //  Get socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 int QZsock::connectTimeout ()
 {
     int rv = zsock_connect_timeout (self);
@@ -560,6 +575,7 @@ int QZsock::connectTimeout ()
 
 ///
 //  Set socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 void QZsock::setConnectTimeout (int connectTimeout)
 {
     zsock_set_connect_timeout (self, connectTimeout);
@@ -568,6 +584,7 @@ void QZsock::setConnectTimeout (int connectTimeout)
 
 ///
 //  Get socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 int QZsock::tcpMaxrt ()
 {
     int rv = zsock_tcp_maxrt (self);
@@ -576,6 +593,7 @@ int QZsock::tcpMaxrt ()
 
 ///
 //  Set socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 void QZsock::setTcpMaxrt (int tcpMaxrt)
 {
     zsock_set_tcp_maxrt (self, tcpMaxrt);
@@ -584,6 +602,7 @@ void QZsock::setTcpMaxrt (int tcpMaxrt)
 
 ///
 //  Get socket option `thread_safe`.
+//  Available from libzmq 4.2.0.    
 int QZsock::threadSafe ()
 {
     int rv = zsock_thread_safe (self);
@@ -592,6 +611,7 @@ int QZsock::threadSafe ()
 
 ///
 //  Get socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 int QZsock::multicastMaxtpdu ()
 {
     int rv = zsock_multicast_maxtpdu (self);
@@ -600,6 +620,7 @@ int QZsock::multicastMaxtpdu ()
 
 ///
 //  Set socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 void QZsock::setMulticastMaxtpdu (int multicastMaxtpdu)
 {
     zsock_set_multicast_maxtpdu (self, multicastMaxtpdu);
@@ -608,6 +629,7 @@ void QZsock::setMulticastMaxtpdu (int multicastMaxtpdu)
 
 ///
 //  Get socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 int QZsock::vmciBufferSize ()
 {
     int rv = zsock_vmci_buffer_size (self);
@@ -616,6 +638,7 @@ int QZsock::vmciBufferSize ()
 
 ///
 //  Set socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 void QZsock::setVmciBufferSize (int vmciBufferSize)
 {
     zsock_set_vmci_buffer_size (self, vmciBufferSize);
@@ -624,6 +647,7 @@ void QZsock::setVmciBufferSize (int vmciBufferSize)
 
 ///
 //  Get socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 int QZsock::vmciBufferMinSize ()
 {
     int rv = zsock_vmci_buffer_min_size (self);
@@ -632,6 +656,7 @@ int QZsock::vmciBufferMinSize ()
 
 ///
 //  Set socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 void QZsock::setVmciBufferMinSize (int vmciBufferMinSize)
 {
     zsock_set_vmci_buffer_min_size (self, vmciBufferMinSize);
@@ -640,6 +665,7 @@ void QZsock::setVmciBufferMinSize (int vmciBufferMinSize)
 
 ///
 //  Get socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 int QZsock::vmciBufferMaxSize ()
 {
     int rv = zsock_vmci_buffer_max_size (self);
@@ -648,6 +674,7 @@ int QZsock::vmciBufferMaxSize ()
 
 ///
 //  Set socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 void QZsock::setVmciBufferMaxSize (int vmciBufferMaxSize)
 {
     zsock_set_vmci_buffer_max_size (self, vmciBufferMaxSize);
@@ -656,6 +683,7 @@ void QZsock::setVmciBufferMaxSize (int vmciBufferMaxSize)
 
 ///
 //  Get socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 int QZsock::vmciConnectTimeout ()
 {
     int rv = zsock_vmci_connect_timeout (self);
@@ -664,6 +692,7 @@ int QZsock::vmciConnectTimeout ()
 
 ///
 //  Set socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 void QZsock::setVmciConnectTimeout (int vmciConnectTimeout)
 {
     zsock_set_vmci_connect_timeout (self, vmciConnectTimeout);
@@ -671,7 +700,8 @@ void QZsock::setVmciConnectTimeout (int vmciConnectTimeout)
 }
 
 ///
-//  Get socket option `tos`.
+//  Get socket option `tos`.    
+//  Available from libzmq 4.1.0.
 int QZsock::tos ()
 {
     int rv = zsock_tos (self);
@@ -679,7 +709,8 @@ int QZsock::tos ()
 }
 
 ///
-//  Set socket option `tos`.
+//  Set socket option `tos`.    
+//  Available from libzmq 4.1.0.
 void QZsock::setTos (int tos)
 {
     zsock_set_tos (self, tos);
@@ -688,6 +719,7 @@ void QZsock::setTos (int tos)
 
 ///
 //  Set socket option `router_handover`.
+//  Available from libzmq 4.1.0.        
 void QZsock::setRouterHandover (int routerHandover)
 {
     zsock_set_router_handover (self, routerHandover);
@@ -696,6 +728,7 @@ void QZsock::setRouterHandover (int routerHandover)
 
 ///
 //  Set socket option `connect_rid`.
+//  Available from libzmq 4.1.0.    
 void QZsock::setConnectRid (const QString &connectRid)
 {
     zsock_set_connect_rid (self, connectRid.toUtf8().data());
@@ -704,6 +737,7 @@ void QZsock::setConnectRid (const QString &connectRid)
 
 ///
 //  Set socket option `connect_rid` from 32-octet binary
+//  Available from libzmq 4.1.0.                        
 void QZsock::setConnectRidBin (const byte *connectRid)
 {
     zsock_set_connect_rid_bin (self, connectRid);
@@ -712,6 +746,7 @@ void QZsock::setConnectRidBin (const byte *connectRid)
 
 ///
 //  Get socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 int QZsock::handshakeIvl ()
 {
     int rv = zsock_handshake_ivl (self);
@@ -720,6 +755,7 @@ int QZsock::handshakeIvl ()
 
 ///
 //  Set socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 void QZsock::setHandshakeIvl (int handshakeIvl)
 {
     zsock_set_handshake_ivl (self, handshakeIvl);
@@ -728,6 +764,7 @@ void QZsock::setHandshakeIvl (int handshakeIvl)
 
 ///
 //  Get socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 QString QZsock::socksProxy ()
 {
     char *retStr_ = zsock_socks_proxy (self);
@@ -738,6 +775,7 @@ QString QZsock::socksProxy ()
 
 ///
 //  Set socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 void QZsock::setSocksProxy (const QString &socksProxy)
 {
     zsock_set_socks_proxy (self, socksProxy.toUtf8().data());
@@ -746,6 +784,7 @@ void QZsock::setSocksProxy (const QString &socksProxy)
 
 ///
 //  Set socket option `xpub_nodrop`.
+//  Available from libzmq 4.1.0.    
 void QZsock::setXpubNodrop (int xpubNodrop)
 {
     zsock_set_xpub_nodrop (self, xpubNodrop);
@@ -754,6 +793,7 @@ void QZsock::setXpubNodrop (int xpubNodrop)
 
 ///
 //  Set socket option `router_mandatory`.
+//  Available from libzmq 4.0.0.         
 void QZsock::setRouterMandatory (int routerMandatory)
 {
     zsock_set_router_mandatory (self, routerMandatory);
@@ -762,6 +802,7 @@ void QZsock::setRouterMandatory (int routerMandatory)
 
 ///
 //  Set socket option `probe_router`.
+//  Available from libzmq 4.0.0.     
 void QZsock::setProbeRouter (int probeRouter)
 {
     zsock_set_probe_router (self, probeRouter);
@@ -770,6 +811,7 @@ void QZsock::setProbeRouter (int probeRouter)
 
 ///
 //  Set socket option `req_relaxed`.
+//  Available from libzmq 4.0.0.    
 void QZsock::setReqRelaxed (int reqRelaxed)
 {
     zsock_set_req_relaxed (self, reqRelaxed);
@@ -778,6 +820,7 @@ void QZsock::setReqRelaxed (int reqRelaxed)
 
 ///
 //  Set socket option `req_correlate`.
+//  Available from libzmq 4.0.0.      
 void QZsock::setReqCorrelate (int reqCorrelate)
 {
     zsock_set_req_correlate (self, reqCorrelate);
@@ -786,6 +829,7 @@ void QZsock::setReqCorrelate (int reqCorrelate)
 
 ///
 //  Set socket option `conflate`.
+//  Available from libzmq 4.0.0. 
 void QZsock::setConflate (int conflate)
 {
     zsock_set_conflate (self, conflate);
@@ -794,6 +838,7 @@ void QZsock::setConflate (int conflate)
 
 ///
 //  Get socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 QString QZsock::zapDomain ()
 {
     char *retStr_ = zsock_zap_domain (self);
@@ -804,6 +849,7 @@ QString QZsock::zapDomain ()
 
 ///
 //  Set socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 void QZsock::setZapDomain (const QString &zapDomain)
 {
     zsock_set_zap_domain (self, zapDomain.toUtf8().data());
@@ -812,6 +858,7 @@ void QZsock::setZapDomain (const QString &zapDomain)
 
 ///
 //  Get socket option `mechanism`.
+//  Available from libzmq 4.0.0.  
 int QZsock::mechanism ()
 {
     int rv = zsock_mechanism (self);
@@ -820,6 +867,7 @@ int QZsock::mechanism ()
 
 ///
 //  Get socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 int QZsock::plainServer ()
 {
     int rv = zsock_plain_server (self);
@@ -828,6 +876,7 @@ int QZsock::plainServer ()
 
 ///
 //  Set socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 void QZsock::setPlainServer (int plainServer)
 {
     zsock_set_plain_server (self, plainServer);
@@ -836,6 +885,7 @@ void QZsock::setPlainServer (int plainServer)
 
 ///
 //  Get socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 QString QZsock::plainUsername ()
 {
     char *retStr_ = zsock_plain_username (self);
@@ -846,6 +896,7 @@ QString QZsock::plainUsername ()
 
 ///
 //  Set socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 void QZsock::setPlainUsername (const QString &plainUsername)
 {
     zsock_set_plain_username (self, plainUsername.toUtf8().data());
@@ -854,6 +905,7 @@ void QZsock::setPlainUsername (const QString &plainUsername)
 
 ///
 //  Get socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 QString QZsock::plainPassword ()
 {
     char *retStr_ = zsock_plain_password (self);
@@ -864,6 +916,7 @@ QString QZsock::plainPassword ()
 
 ///
 //  Set socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 void QZsock::setPlainPassword (const QString &plainPassword)
 {
     zsock_set_plain_password (self, plainPassword.toUtf8().data());
@@ -872,6 +925,7 @@ void QZsock::setPlainPassword (const QString &plainPassword)
 
 ///
 //  Get socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 int QZsock::curveServer ()
 {
     int rv = zsock_curve_server (self);
@@ -880,6 +934,7 @@ int QZsock::curveServer ()
 
 ///
 //  Set socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 void QZsock::setCurveServer (int curveServer)
 {
     zsock_set_curve_server (self, curveServer);
@@ -888,6 +943,7 @@ void QZsock::setCurveServer (int curveServer)
 
 ///
 //  Get socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 QString QZsock::curvePublickey ()
 {
     char *retStr_ = zsock_curve_publickey (self);
@@ -898,6 +954,7 @@ QString QZsock::curvePublickey ()
 
 ///
 //  Set socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 void QZsock::setCurvePublickey (const QString &curvePublickey)
 {
     zsock_set_curve_publickey (self, curvePublickey.toUtf8().data());
@@ -906,6 +963,7 @@ void QZsock::setCurvePublickey (const QString &curvePublickey)
 
 ///
 //  Set socket option `curve_publickey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QZsock::setCurvePublickeyBin (const byte *curvePublickey)
 {
     zsock_set_curve_publickey_bin (self, curvePublickey);
@@ -914,6 +972,7 @@ void QZsock::setCurvePublickeyBin (const byte *curvePublickey)
 
 ///
 //  Get socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 QString QZsock::curveSecretkey ()
 {
     char *retStr_ = zsock_curve_secretkey (self);
@@ -924,6 +983,7 @@ QString QZsock::curveSecretkey ()
 
 ///
 //  Set socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 void QZsock::setCurveSecretkey (const QString &curveSecretkey)
 {
     zsock_set_curve_secretkey (self, curveSecretkey.toUtf8().data());
@@ -932,6 +992,7 @@ void QZsock::setCurveSecretkey (const QString &curveSecretkey)
 
 ///
 //  Set socket option `curve_secretkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QZsock::setCurveSecretkeyBin (const byte *curveSecretkey)
 {
     zsock_set_curve_secretkey_bin (self, curveSecretkey);
@@ -940,6 +1001,7 @@ void QZsock::setCurveSecretkeyBin (const byte *curveSecretkey)
 
 ///
 //  Get socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 QString QZsock::curveServerkey ()
 {
     char *retStr_ = zsock_curve_serverkey (self);
@@ -950,6 +1012,7 @@ QString QZsock::curveServerkey ()
 
 ///
 //  Set socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 void QZsock::setCurveServerkey (const QString &curveServerkey)
 {
     zsock_set_curve_serverkey (self, curveServerkey.toUtf8().data());
@@ -958,6 +1021,7 @@ void QZsock::setCurveServerkey (const QString &curveServerkey)
 
 ///
 //  Set socket option `curve_serverkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 void QZsock::setCurveServerkeyBin (const byte *curveServerkey)
 {
     zsock_set_curve_serverkey_bin (self, curveServerkey);
@@ -966,6 +1030,7 @@ void QZsock::setCurveServerkeyBin (const byte *curveServerkey)
 
 ///
 //  Get socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 int QZsock::gssapiServer ()
 {
     int rv = zsock_gssapi_server (self);
@@ -974,6 +1039,7 @@ int QZsock::gssapiServer ()
 
 ///
 //  Set socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 void QZsock::setGssapiServer (int gssapiServer)
 {
     zsock_set_gssapi_server (self, gssapiServer);
@@ -982,6 +1048,7 @@ void QZsock::setGssapiServer (int gssapiServer)
 
 ///
 //  Get socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 int QZsock::gssapiPlaintext ()
 {
     int rv = zsock_gssapi_plaintext (self);
@@ -990,6 +1057,7 @@ int QZsock::gssapiPlaintext ()
 
 ///
 //  Set socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 void QZsock::setGssapiPlaintext (int gssapiPlaintext)
 {
     zsock_set_gssapi_plaintext (self, gssapiPlaintext);
@@ -998,6 +1066,7 @@ void QZsock::setGssapiPlaintext (int gssapiPlaintext)
 
 ///
 //  Get socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 QString QZsock::gssapiPrincipal ()
 {
     char *retStr_ = zsock_gssapi_principal (self);
@@ -1008,6 +1077,7 @@ QString QZsock::gssapiPrincipal ()
 
 ///
 //  Set socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 void QZsock::setGssapiPrincipal (const QString &gssapiPrincipal)
 {
     zsock_set_gssapi_principal (self, gssapiPrincipal.toUtf8().data());
@@ -1016,6 +1086,7 @@ void QZsock::setGssapiPrincipal (const QString &gssapiPrincipal)
 
 ///
 //  Get socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 QString QZsock::gssapiServicePrincipal ()
 {
     char *retStr_ = zsock_gssapi_service_principal (self);
@@ -1026,6 +1097,7 @@ QString QZsock::gssapiServicePrincipal ()
 
 ///
 //  Set socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 void QZsock::setGssapiServicePrincipal (const QString &gssapiServicePrincipal)
 {
     zsock_set_gssapi_service_principal (self, gssapiServicePrincipal.toUtf8().data());
@@ -1033,7 +1105,8 @@ void QZsock::setGssapiServicePrincipal (const QString &gssapiServicePrincipal)
 }
 
 ///
-//  Get socket option `ipv6`.
+//  Get socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 int QZsock::ipv6 ()
 {
     int rv = zsock_ipv6 (self);
@@ -1041,7 +1114,8 @@ int QZsock::ipv6 ()
 }
 
 ///
-//  Set socket option `ipv6`.
+//  Set socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 void QZsock::setIpv6 (int ipv6)
 {
     zsock_set_ipv6 (self, ipv6);
@@ -1050,6 +1124,7 @@ void QZsock::setIpv6 (int ipv6)
 
 ///
 //  Get socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 int QZsock::immediate ()
 {
     int rv = zsock_immediate (self);
@@ -1058,6 +1133,7 @@ int QZsock::immediate ()
 
 ///
 //  Set socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 void QZsock::setImmediate (int immediate)
 {
     zsock_set_immediate (self, immediate);
@@ -1065,7 +1141,8 @@ void QZsock::setImmediate (int immediate)
 }
 
 ///
-//  Get socket option `type`.
+//  Get socket option `type`.   
+//  Available from libzmq 3.0.0.
 int QZsock::type ()
 {
     int rv = zsock_type (self);
@@ -1073,7 +1150,8 @@ int QZsock::type ()
 }
 
 ///
-//  Get socket option `sndhwm`.
+//  Get socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 int QZsock::sndhwm ()
 {
     int rv = zsock_sndhwm (self);
@@ -1081,7 +1159,8 @@ int QZsock::sndhwm ()
 }
 
 ///
-//  Set socket option `sndhwm`.
+//  Set socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 void QZsock::setSndhwm (int sndhwm)
 {
     zsock_set_sndhwm (self, sndhwm);
@@ -1089,7 +1168,8 @@ void QZsock::setSndhwm (int sndhwm)
 }
 
 ///
-//  Get socket option `rcvhwm`.
+//  Get socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 int QZsock::rcvhwm ()
 {
     int rv = zsock_rcvhwm (self);
@@ -1097,7 +1177,8 @@ int QZsock::rcvhwm ()
 }
 
 ///
-//  Set socket option `rcvhwm`.
+//  Set socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 void QZsock::setRcvhwm (int rcvhwm)
 {
     zsock_set_rcvhwm (self, rcvhwm);
@@ -1106,6 +1187,7 @@ void QZsock::setRcvhwm (int rcvhwm)
 
 ///
 //  Get socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 int QZsock::affinity ()
 {
     int rv = zsock_affinity (self);
@@ -1114,6 +1196,7 @@ int QZsock::affinity ()
 
 ///
 //  Set socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 void QZsock::setAffinity (int affinity)
 {
     zsock_set_affinity (self, affinity);
@@ -1122,6 +1205,7 @@ void QZsock::setAffinity (int affinity)
 
 ///
 //  Set socket option `subscribe`.
+//  Available from libzmq 3.0.0.  
 void QZsock::setSubscribe (const QString &subscribe)
 {
     zsock_set_subscribe (self, subscribe.toUtf8().data());
@@ -1130,6 +1214,7 @@ void QZsock::setSubscribe (const QString &subscribe)
 
 ///
 //  Set socket option `unsubscribe`.
+//  Available from libzmq 3.0.0.    
 void QZsock::setUnsubscribe (const QString &unsubscribe)
 {
     zsock_set_unsubscribe (self, unsubscribe.toUtf8().data());
@@ -1138,6 +1223,7 @@ void QZsock::setUnsubscribe (const QString &unsubscribe)
 
 ///
 //  Get socket option `identity`.
+//  Available from libzmq 3.0.0. 
 QString QZsock::identity ()
 {
     char *retStr_ = zsock_identity (self);
@@ -1148,6 +1234,7 @@ QString QZsock::identity ()
 
 ///
 //  Set socket option `identity`.
+//  Available from libzmq 3.0.0. 
 void QZsock::setIdentity (const QString &identity)
 {
     zsock_set_identity (self, identity.toUtf8().data());
@@ -1155,7 +1242,8 @@ void QZsock::setIdentity (const QString &identity)
 }
 
 ///
-//  Get socket option `rate`.
+//  Get socket option `rate`.   
+//  Available from libzmq 3.0.0.
 int QZsock::rate ()
 {
     int rv = zsock_rate (self);
@@ -1163,7 +1251,8 @@ int QZsock::rate ()
 }
 
 ///
-//  Set socket option `rate`.
+//  Set socket option `rate`.   
+//  Available from libzmq 3.0.0.
 void QZsock::setRate (int rate)
 {
     zsock_set_rate (self, rate);
@@ -1172,6 +1261,7 @@ void QZsock::setRate (int rate)
 
 ///
 //  Get socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 int QZsock::recoveryIvl ()
 {
     int rv = zsock_recovery_ivl (self);
@@ -1180,6 +1270,7 @@ int QZsock::recoveryIvl ()
 
 ///
 //  Set socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 void QZsock::setRecoveryIvl (int recoveryIvl)
 {
     zsock_set_recovery_ivl (self, recoveryIvl);
@@ -1187,7 +1278,8 @@ void QZsock::setRecoveryIvl (int recoveryIvl)
 }
 
 ///
-//  Get socket option `sndbuf`.
+//  Get socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 int QZsock::sndbuf ()
 {
     int rv = zsock_sndbuf (self);
@@ -1195,7 +1287,8 @@ int QZsock::sndbuf ()
 }
 
 ///
-//  Set socket option `sndbuf`.
+//  Set socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 void QZsock::setSndbuf (int sndbuf)
 {
     zsock_set_sndbuf (self, sndbuf);
@@ -1203,7 +1296,8 @@ void QZsock::setSndbuf (int sndbuf)
 }
 
 ///
-//  Get socket option `rcvbuf`.
+//  Get socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 int QZsock::rcvbuf ()
 {
     int rv = zsock_rcvbuf (self);
@@ -1211,7 +1305,8 @@ int QZsock::rcvbuf ()
 }
 
 ///
-//  Set socket option `rcvbuf`.
+//  Set socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 void QZsock::setRcvbuf (int rcvbuf)
 {
     zsock_set_rcvbuf (self, rcvbuf);
@@ -1219,7 +1314,8 @@ void QZsock::setRcvbuf (int rcvbuf)
 }
 
 ///
-//  Get socket option `linger`.
+//  Get socket option `linger`. 
+//  Available from libzmq 3.0.0.
 int QZsock::linger ()
 {
     int rv = zsock_linger (self);
@@ -1227,7 +1323,8 @@ int QZsock::linger ()
 }
 
 ///
-//  Set socket option `linger`.
+//  Set socket option `linger`. 
+//  Available from libzmq 3.0.0.
 void QZsock::setLinger (int linger)
 {
     zsock_set_linger (self, linger);
@@ -1236,6 +1333,7 @@ void QZsock::setLinger (int linger)
 
 ///
 //  Get socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 int QZsock::reconnectIvl ()
 {
     int rv = zsock_reconnect_ivl (self);
@@ -1244,6 +1342,7 @@ int QZsock::reconnectIvl ()
 
 ///
 //  Set socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 void QZsock::setReconnectIvl (int reconnectIvl)
 {
     zsock_set_reconnect_ivl (self, reconnectIvl);
@@ -1252,6 +1351,7 @@ void QZsock::setReconnectIvl (int reconnectIvl)
 
 ///
 //  Get socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 int QZsock::reconnectIvlMax ()
 {
     int rv = zsock_reconnect_ivl_max (self);
@@ -1260,6 +1360,7 @@ int QZsock::reconnectIvlMax ()
 
 ///
 //  Set socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 void QZsock::setReconnectIvlMax (int reconnectIvlMax)
 {
     zsock_set_reconnect_ivl_max (self, reconnectIvlMax);
@@ -1268,6 +1369,7 @@ void QZsock::setReconnectIvlMax (int reconnectIvlMax)
 
 ///
 //  Get socket option `backlog`.
+//  Available from libzmq 3.0.0.
 int QZsock::backlog ()
 {
     int rv = zsock_backlog (self);
@@ -1276,6 +1378,7 @@ int QZsock::backlog ()
 
 ///
 //  Set socket option `backlog`.
+//  Available from libzmq 3.0.0.
 void QZsock::setBacklog (int backlog)
 {
     zsock_set_backlog (self, backlog);
@@ -1284,6 +1387,7 @@ void QZsock::setBacklog (int backlog)
 
 ///
 //  Get socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 int QZsock::maxmsgsize ()
 {
     int rv = zsock_maxmsgsize (self);
@@ -1292,6 +1396,7 @@ int QZsock::maxmsgsize ()
 
 ///
 //  Set socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 void QZsock::setMaxmsgsize (int maxmsgsize)
 {
     zsock_set_maxmsgsize (self, maxmsgsize);
@@ -1300,6 +1405,7 @@ void QZsock::setMaxmsgsize (int maxmsgsize)
 
 ///
 //  Get socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 int QZsock::multicastHops ()
 {
     int rv = zsock_multicast_hops (self);
@@ -1308,6 +1414,7 @@ int QZsock::multicastHops ()
 
 ///
 //  Set socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 void QZsock::setMulticastHops (int multicastHops)
 {
     zsock_set_multicast_hops (self, multicastHops);
@@ -1316,6 +1423,7 @@ void QZsock::setMulticastHops (int multicastHops)
 
 ///
 //  Get socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 int QZsock::rcvtimeo ()
 {
     int rv = zsock_rcvtimeo (self);
@@ -1324,6 +1432,7 @@ int QZsock::rcvtimeo ()
 
 ///
 //  Set socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 void QZsock::setRcvtimeo (int rcvtimeo)
 {
     zsock_set_rcvtimeo (self, rcvtimeo);
@@ -1332,6 +1441,7 @@ void QZsock::setRcvtimeo (int rcvtimeo)
 
 ///
 //  Get socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 int QZsock::sndtimeo ()
 {
     int rv = zsock_sndtimeo (self);
@@ -1340,6 +1450,7 @@ int QZsock::sndtimeo ()
 
 ///
 //  Set socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 void QZsock::setSndtimeo (int sndtimeo)
 {
     zsock_set_sndtimeo (self, sndtimeo);
@@ -1348,6 +1459,7 @@ void QZsock::setSndtimeo (int sndtimeo)
 
 ///
 //  Set socket option `xpub_verbose`.
+//  Available from libzmq 3.0.0.     
 void QZsock::setXpubVerbose (int xpubVerbose)
 {
     zsock_set_xpub_verbose (self, xpubVerbose);
@@ -1356,6 +1468,7 @@ void QZsock::setXpubVerbose (int xpubVerbose)
 
 ///
 //  Get socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 int QZsock::tcpKeepalive ()
 {
     int rv = zsock_tcp_keepalive (self);
@@ -1364,6 +1477,7 @@ int QZsock::tcpKeepalive ()
 
 ///
 //  Set socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 void QZsock::setTcpKeepalive (int tcpKeepalive)
 {
     zsock_set_tcp_keepalive (self, tcpKeepalive);
@@ -1372,6 +1486,7 @@ void QZsock::setTcpKeepalive (int tcpKeepalive)
 
 ///
 //  Get socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 int QZsock::tcpKeepaliveIdle ()
 {
     int rv = zsock_tcp_keepalive_idle (self);
@@ -1380,6 +1495,7 @@ int QZsock::tcpKeepaliveIdle ()
 
 ///
 //  Set socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 void QZsock::setTcpKeepaliveIdle (int tcpKeepaliveIdle)
 {
     zsock_set_tcp_keepalive_idle (self, tcpKeepaliveIdle);
@@ -1388,6 +1504,7 @@ void QZsock::setTcpKeepaliveIdle (int tcpKeepaliveIdle)
 
 ///
 //  Get socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 int QZsock::tcpKeepaliveCnt ()
 {
     int rv = zsock_tcp_keepalive_cnt (self);
@@ -1396,6 +1513,7 @@ int QZsock::tcpKeepaliveCnt ()
 
 ///
 //  Set socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 void QZsock::setTcpKeepaliveCnt (int tcpKeepaliveCnt)
 {
     zsock_set_tcp_keepalive_cnt (self, tcpKeepaliveCnt);
@@ -1404,6 +1522,7 @@ void QZsock::setTcpKeepaliveCnt (int tcpKeepaliveCnt)
 
 ///
 //  Get socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 int QZsock::tcpKeepaliveIntvl ()
 {
     int rv = zsock_tcp_keepalive_intvl (self);
@@ -1412,6 +1531,7 @@ int QZsock::tcpKeepaliveIntvl ()
 
 ///
 //  Set socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 void QZsock::setTcpKeepaliveIntvl (int tcpKeepaliveIntvl)
 {
     zsock_set_tcp_keepalive_intvl (self, tcpKeepaliveIntvl);
@@ -1420,6 +1540,7 @@ void QZsock::setTcpKeepaliveIntvl (int tcpKeepaliveIntvl)
 
 ///
 //  Get socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 QString QZsock::tcpAcceptFilter ()
 {
     char *retStr_ = zsock_tcp_accept_filter (self);
@@ -1430,6 +1551,7 @@ QString QZsock::tcpAcceptFilter ()
 
 ///
 //  Set socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 void QZsock::setTcpAcceptFilter (const QString &tcpAcceptFilter)
 {
     zsock_set_tcp_accept_filter (self, tcpAcceptFilter.toUtf8().data());
@@ -1438,6 +1560,7 @@ void QZsock::setTcpAcceptFilter (const QString &tcpAcceptFilter)
 
 ///
 //  Get socket option `rcvmore`.
+//  Available from libzmq 3.0.0.
 int QZsock::rcvmore ()
 {
     int rv = zsock_rcvmore (self);
@@ -1445,7 +1568,8 @@ int QZsock::rcvmore ()
 }
 
 ///
-//  Get socket option `fd`.
+//  Get socket option `fd`.     
+//  Available from libzmq 3.0.0.
 SOCKET QZsock::fd ()
 {
     SOCKET rv = zsock_fd (self);
@@ -1453,7 +1577,8 @@ SOCKET QZsock::fd ()
 }
 
 ///
-//  Get socket option `events`.
+//  Get socket option `events`. 
+//  Available from libzmq 3.0.0.
 int QZsock::events ()
 {
     int rv = zsock_events (self);
@@ -1462,6 +1587,7 @@ int QZsock::events ()
 
 ///
 //  Get socket option `last_endpoint`.
+//  Available from libzmq 3.0.0.      
 QString QZsock::lastEndpoint ()
 {
     char *retStr_ = zsock_last_endpoint (self);
@@ -1472,6 +1598,7 @@ QString QZsock::lastEndpoint ()
 
 ///
 //  Set socket option `router_raw`.
+//  Available from libzmq 3.0.0.   
 void QZsock::setRouterRaw (int routerRaw)
 {
     zsock_set_router_raw (self, routerRaw);
@@ -1480,6 +1607,7 @@ void QZsock::setRouterRaw (int routerRaw)
 
 ///
 //  Get socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 int QZsock::ipv4only ()
 {
     int rv = zsock_ipv4only (self);
@@ -1488,6 +1616,7 @@ int QZsock::ipv4only ()
 
 ///
 //  Set socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 void QZsock::setIpv4only (int ipv4only)
 {
     zsock_set_ipv4only (self, ipv4only);
@@ -1496,6 +1625,7 @@ void QZsock::setIpv4only (int ipv4only)
 
 ///
 //  Set socket option `delay_attach_on_connect`.
+//  Available from libzmq 3.0.0.                
 void QZsock::setDelayAttachOnConnect (int delayAttachOnConnect)
 {
     zsock_set_delay_attach_on_connect (self, delayAttachOnConnect);

--- a/bindings/qt/src/qzsock.h
+++ b/bindings/qt/src/qzsock.h
@@ -250,393 +250,523 @@ public:
     static void * resolve (void *self);
 
     //  Get socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     int heartbeatIvl ();
 
     //  Set socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     void setHeartbeatIvl (int heartbeatIvl);
 
     //  Get socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     int heartbeatTtl ();
 
     //  Set socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     void setHeartbeatTtl (int heartbeatTtl);
 
     //  Get socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     int heartbeatTimeout ();
 
     //  Set socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     void setHeartbeatTimeout (int heartbeatTimeout);
 
-    //  Get socket option `use_fd`.
+    //  Get socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     int useFd ();
 
-    //  Set socket option `use_fd`.
+    //  Set socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     void setUseFd (int useFd);
 
     //  Set socket option `xpub_manual`.
+    //  Available from libzmq 4.2.0.    
     void setXpubManual (int xpubManual);
 
     //  Set socket option `xpub_welcome_msg`.
+    //  Available from libzmq 4.2.0.         
     void setXpubWelcomeMsg (const QString &xpubWelcomeMsg);
 
     //  Set socket option `stream_notify`.
+    //  Available from libzmq 4.2.0.      
     void setStreamNotify (int streamNotify);
 
     //  Get socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     int invertMatching ();
 
     //  Set socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     void setInvertMatching (int invertMatching);
 
     //  Set socket option `xpub_verboser`.
+    //  Available from libzmq 4.2.0.      
     void setXpubVerboser (int xpubVerboser);
 
     //  Get socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     int connectTimeout ();
 
     //  Set socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     void setConnectTimeout (int connectTimeout);
 
     //  Get socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     int tcpMaxrt ();
 
     //  Set socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     void setTcpMaxrt (int tcpMaxrt);
 
     //  Get socket option `thread_safe`.
+    //  Available from libzmq 4.2.0.    
     int threadSafe ();
 
     //  Get socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     int multicastMaxtpdu ();
 
     //  Set socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     void setMulticastMaxtpdu (int multicastMaxtpdu);
 
     //  Get socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     int vmciBufferSize ();
 
     //  Set socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     void setVmciBufferSize (int vmciBufferSize);
 
     //  Get socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     int vmciBufferMinSize ();
 
     //  Set socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     void setVmciBufferMinSize (int vmciBufferMinSize);
 
     //  Get socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     int vmciBufferMaxSize ();
 
     //  Set socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     void setVmciBufferMaxSize (int vmciBufferMaxSize);
 
     //  Get socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     int vmciConnectTimeout ();
 
     //  Set socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     void setVmciConnectTimeout (int vmciConnectTimeout);
 
-    //  Get socket option `tos`.
+    //  Get socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     int tos ();
 
-    //  Set socket option `tos`.
+    //  Set socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     void setTos (int tos);
 
     //  Set socket option `router_handover`.
+    //  Available from libzmq 4.1.0.        
     void setRouterHandover (int routerHandover);
 
     //  Set socket option `connect_rid`.
+    //  Available from libzmq 4.1.0.    
     void setConnectRid (const QString &connectRid);
 
     //  Set socket option `connect_rid` from 32-octet binary
+    //  Available from libzmq 4.1.0.                        
     void setConnectRidBin (const byte *connectRid);
 
     //  Get socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     int handshakeIvl ();
 
     //  Set socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     void setHandshakeIvl (int handshakeIvl);
 
     //  Get socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     QString socksProxy ();
 
     //  Set socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     void setSocksProxy (const QString &socksProxy);
 
     //  Set socket option `xpub_nodrop`.
+    //  Available from libzmq 4.1.0.    
     void setXpubNodrop (int xpubNodrop);
 
     //  Set socket option `router_mandatory`.
+    //  Available from libzmq 4.0.0.         
     void setRouterMandatory (int routerMandatory);
 
     //  Set socket option `probe_router`.
+    //  Available from libzmq 4.0.0.     
     void setProbeRouter (int probeRouter);
 
     //  Set socket option `req_relaxed`.
+    //  Available from libzmq 4.0.0.    
     void setReqRelaxed (int reqRelaxed);
 
     //  Set socket option `req_correlate`.
+    //  Available from libzmq 4.0.0.      
     void setReqCorrelate (int reqCorrelate);
 
     //  Set socket option `conflate`.
+    //  Available from libzmq 4.0.0. 
     void setConflate (int conflate);
 
     //  Get socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     QString zapDomain ();
 
     //  Set socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     void setZapDomain (const QString &zapDomain);
 
     //  Get socket option `mechanism`.
+    //  Available from libzmq 4.0.0.  
     int mechanism ();
 
     //  Get socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     int plainServer ();
 
     //  Set socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     void setPlainServer (int plainServer);
 
     //  Get socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     QString plainUsername ();
 
     //  Set socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     void setPlainUsername (const QString &plainUsername);
 
     //  Get socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     QString plainPassword ();
 
     //  Set socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     void setPlainPassword (const QString &plainPassword);
 
     //  Get socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     int curveServer ();
 
     //  Set socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     void setCurveServer (int curveServer);
 
     //  Get socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     QString curvePublickey ();
 
     //  Set socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     void setCurvePublickey (const QString &curvePublickey);
 
     //  Set socket option `curve_publickey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurvePublickeyBin (const byte *curvePublickey);
 
     //  Get socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     QString curveSecretkey ();
 
     //  Set socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     void setCurveSecretkey (const QString &curveSecretkey);
 
     //  Set socket option `curve_secretkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurveSecretkeyBin (const byte *curveSecretkey);
 
     //  Get socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     QString curveServerkey ();
 
     //  Set socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     void setCurveServerkey (const QString &curveServerkey);
 
     //  Set socket option `curve_serverkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     void setCurveServerkeyBin (const byte *curveServerkey);
 
     //  Get socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     int gssapiServer ();
 
     //  Set socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     void setGssapiServer (int gssapiServer);
 
     //  Get socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     int gssapiPlaintext ();
 
     //  Set socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     void setGssapiPlaintext (int gssapiPlaintext);
 
     //  Get socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     QString gssapiPrincipal ();
 
     //  Set socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     void setGssapiPrincipal (const QString &gssapiPrincipal);
 
     //  Get socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     QString gssapiServicePrincipal ();
 
     //  Set socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     void setGssapiServicePrincipal (const QString &gssapiServicePrincipal);
 
-    //  Get socket option `ipv6`.
+    //  Get socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     int ipv6 ();
 
-    //  Set socket option `ipv6`.
+    //  Set socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     void setIpv6 (int ipv6);
 
     //  Get socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     int immediate ();
 
     //  Set socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     void setImmediate (int immediate);
 
-    //  Get socket option `type`.
+    //  Get socket option `type`.   
+    //  Available from libzmq 3.0.0.
     int type ();
 
-    //  Get socket option `sndhwm`.
+    //  Get socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     int sndhwm ();
 
-    //  Set socket option `sndhwm`.
+    //  Set socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     void setSndhwm (int sndhwm);
 
-    //  Get socket option `rcvhwm`.
+    //  Get socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     int rcvhwm ();
 
-    //  Set socket option `rcvhwm`.
+    //  Set socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     void setRcvhwm (int rcvhwm);
 
     //  Get socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     int affinity ();
 
     //  Set socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     void setAffinity (int affinity);
 
     //  Set socket option `subscribe`.
+    //  Available from libzmq 3.0.0.  
     void setSubscribe (const QString &subscribe);
 
     //  Set socket option `unsubscribe`.
+    //  Available from libzmq 3.0.0.    
     void setUnsubscribe (const QString &unsubscribe);
 
     //  Get socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     QString identity ();
 
     //  Set socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     void setIdentity (const QString &identity);
 
-    //  Get socket option `rate`.
+    //  Get socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     int rate ();
 
-    //  Set socket option `rate`.
+    //  Set socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     void setRate (int rate);
 
     //  Get socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     int recoveryIvl ();
 
     //  Set socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     void setRecoveryIvl (int recoveryIvl);
 
-    //  Get socket option `sndbuf`.
+    //  Get socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     int sndbuf ();
 
-    //  Set socket option `sndbuf`.
+    //  Set socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     void setSndbuf (int sndbuf);
 
-    //  Get socket option `rcvbuf`.
+    //  Get socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     int rcvbuf ();
 
-    //  Set socket option `rcvbuf`.
+    //  Set socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     void setRcvbuf (int rcvbuf);
 
-    //  Get socket option `linger`.
+    //  Get socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     int linger ();
 
-    //  Set socket option `linger`.
+    //  Set socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     void setLinger (int linger);
 
     //  Get socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     int reconnectIvl ();
 
     //  Set socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     void setReconnectIvl (int reconnectIvl);
 
     //  Get socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     int reconnectIvlMax ();
 
     //  Set socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     void setReconnectIvlMax (int reconnectIvlMax);
 
     //  Get socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     int backlog ();
 
     //  Set socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     void setBacklog (int backlog);
 
     //  Get socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     int maxmsgsize ();
 
     //  Set socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     void setMaxmsgsize (int maxmsgsize);
 
     //  Get socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     int multicastHops ();
 
     //  Set socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     void setMulticastHops (int multicastHops);
 
     //  Get socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     int rcvtimeo ();
 
     //  Set socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     void setRcvtimeo (int rcvtimeo);
 
     //  Get socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     int sndtimeo ();
 
     //  Set socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     void setSndtimeo (int sndtimeo);
 
     //  Set socket option `xpub_verbose`.
+    //  Available from libzmq 3.0.0.     
     void setXpubVerbose (int xpubVerbose);
 
     //  Get socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     int tcpKeepalive ();
 
     //  Set socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     void setTcpKeepalive (int tcpKeepalive);
 
     //  Get socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     int tcpKeepaliveIdle ();
 
     //  Set socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     void setTcpKeepaliveIdle (int tcpKeepaliveIdle);
 
     //  Get socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     int tcpKeepaliveCnt ();
 
     //  Set socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     void setTcpKeepaliveCnt (int tcpKeepaliveCnt);
 
     //  Get socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     int tcpKeepaliveIntvl ();
 
     //  Set socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     void setTcpKeepaliveIntvl (int tcpKeepaliveIntvl);
 
     //  Get socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     QString tcpAcceptFilter ();
 
     //  Set socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     void setTcpAcceptFilter (const QString &tcpAcceptFilter);
 
     //  Get socket option `rcvmore`.
+    //  Available from libzmq 3.0.0.
     int rcvmore ();
 
-    //  Get socket option `fd`.
+    //  Get socket option `fd`.     
+    //  Available from libzmq 3.0.0.
     SOCKET fd ();
 
-    //  Get socket option `events`.
+    //  Get socket option `events`. 
+    //  Available from libzmq 3.0.0.
     int events ();
 
     //  Get socket option `last_endpoint`.
+    //  Available from libzmq 3.0.0.      
     QString lastEndpoint ();
 
     //  Set socket option `router_raw`.
+    //  Available from libzmq 3.0.0.   
     void setRouterRaw (int routerRaw);
 
     //  Get socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
     int ipv4only ();
 
     //  Set socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
     void setIpv4only (int ipv4only);
 
     //  Set socket option `delay_attach_on_connect`.
+    //  Available from libzmq 3.0.0.                
     void setDelayAttachOnConnect (int delayAttachOnConnect);
 
     //  Self test of this class.

--- a/bindings/ruby/lib/czmq/ffi/zsock.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsock.rb
@@ -903,6 +903,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_ivl`.
+      # Available from libzmq 4.2.0.      
       #
       # @return [Integer]
       def heartbeat_ivl()
@@ -913,6 +914,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_ivl`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #heartbeat_ivl.
       #
@@ -926,6 +928,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_ivl`.
+      # Available from libzmq 4.2.0.      
       #
       # @param heartbeat_ivl [Integer, #to_int, #to_i]
       # @return [void]
@@ -938,6 +941,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_ivl`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #set_heartbeat_ivl.
       #
@@ -953,6 +957,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_ttl`.
+      # Available from libzmq 4.2.0.      
       #
       # @return [Integer]
       def heartbeat_ttl()
@@ -963,6 +968,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_ttl`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #heartbeat_ttl.
       #
@@ -976,6 +982,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_ttl`.
+      # Available from libzmq 4.2.0.      
       #
       # @param heartbeat_ttl [Integer, #to_int, #to_i]
       # @return [void]
@@ -988,6 +995,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_ttl`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #set_heartbeat_ttl.
       #
@@ -1003,6 +1011,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_timeout`.
+      # Available from libzmq 4.2.0.          
       #
       # @return [Integer]
       def heartbeat_timeout()
@@ -1013,6 +1022,7 @@ module CZMQ
       end
 
       # Get socket option `heartbeat_timeout`.
+      # Available from libzmq 4.2.0.          
       #
       # This is the polymorphic version of #heartbeat_timeout.
       #
@@ -1026,6 +1036,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_timeout`.
+      # Available from libzmq 4.2.0.          
       #
       # @param heartbeat_timeout [Integer, #to_int, #to_i]
       # @return [void]
@@ -1038,6 +1049,7 @@ module CZMQ
       end
 
       # Set socket option `heartbeat_timeout`.
+      # Available from libzmq 4.2.0.          
       #
       # This is the polymorphic version of #set_heartbeat_timeout.
       #
@@ -1052,7 +1064,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `use_fd`.
+      # Get socket option `use_fd`. 
+      # Available from libzmq 4.2.0.
       #
       # @return [Integer]
       def use_fd()
@@ -1062,7 +1075,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `use_fd`.
+      # Get socket option `use_fd`. 
+      # Available from libzmq 4.2.0.
       #
       # This is the polymorphic version of #use_fd.
       #
@@ -1075,7 +1089,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `use_fd`.
+      # Set socket option `use_fd`. 
+      # Available from libzmq 4.2.0.
       #
       # @param use_fd [Integer, #to_int, #to_i]
       # @return [void]
@@ -1087,7 +1102,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `use_fd`.
+      # Set socket option `use_fd`. 
+      # Available from libzmq 4.2.0.
       #
       # This is the polymorphic version of #set_use_fd.
       #
@@ -1103,6 +1119,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_manual`.
+      # Available from libzmq 4.2.0.    
       #
       # @param xpub_manual [Integer, #to_int, #to_i]
       # @return [void]
@@ -1115,6 +1132,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_manual`.
+      # Available from libzmq 4.2.0.    
       #
       # This is the polymorphic version of #set_xpub_manual.
       #
@@ -1130,6 +1148,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_welcome_msg`.
+      # Available from libzmq 4.2.0.         
       #
       # @param xpub_welcome_msg [String, #to_s, nil]
       # @return [void]
@@ -1141,6 +1160,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_welcome_msg`.
+      # Available from libzmq 4.2.0.         
       #
       # This is the polymorphic version of #set_xpub_welcome_msg.
       #
@@ -1155,6 +1175,7 @@ module CZMQ
       end
 
       # Set socket option `stream_notify`.
+      # Available from libzmq 4.2.0.      
       #
       # @param stream_notify [Integer, #to_int, #to_i]
       # @return [void]
@@ -1167,6 +1188,7 @@ module CZMQ
       end
 
       # Set socket option `stream_notify`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #set_stream_notify.
       #
@@ -1182,6 +1204,7 @@ module CZMQ
       end
 
       # Get socket option `invert_matching`.
+      # Available from libzmq 4.2.0.        
       #
       # @return [Integer]
       def invert_matching()
@@ -1192,6 +1215,7 @@ module CZMQ
       end
 
       # Get socket option `invert_matching`.
+      # Available from libzmq 4.2.0.        
       #
       # This is the polymorphic version of #invert_matching.
       #
@@ -1205,6 +1229,7 @@ module CZMQ
       end
 
       # Set socket option `invert_matching`.
+      # Available from libzmq 4.2.0.        
       #
       # @param invert_matching [Integer, #to_int, #to_i]
       # @return [void]
@@ -1217,6 +1242,7 @@ module CZMQ
       end
 
       # Set socket option `invert_matching`.
+      # Available from libzmq 4.2.0.        
       #
       # This is the polymorphic version of #set_invert_matching.
       #
@@ -1232,6 +1258,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_verboser`.
+      # Available from libzmq 4.2.0.      
       #
       # @param xpub_verboser [Integer, #to_int, #to_i]
       # @return [void]
@@ -1244,6 +1271,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_verboser`.
+      # Available from libzmq 4.2.0.      
       #
       # This is the polymorphic version of #set_xpub_verboser.
       #
@@ -1259,6 +1287,7 @@ module CZMQ
       end
 
       # Get socket option `connect_timeout`.
+      # Available from libzmq 4.2.0.        
       #
       # @return [Integer]
       def connect_timeout()
@@ -1269,6 +1298,7 @@ module CZMQ
       end
 
       # Get socket option `connect_timeout`.
+      # Available from libzmq 4.2.0.        
       #
       # This is the polymorphic version of #connect_timeout.
       #
@@ -1282,6 +1312,7 @@ module CZMQ
       end
 
       # Set socket option `connect_timeout`.
+      # Available from libzmq 4.2.0.        
       #
       # @param connect_timeout [Integer, #to_int, #to_i]
       # @return [void]
@@ -1294,6 +1325,7 @@ module CZMQ
       end
 
       # Set socket option `connect_timeout`.
+      # Available from libzmq 4.2.0.        
       #
       # This is the polymorphic version of #set_connect_timeout.
       #
@@ -1309,6 +1341,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_maxrt`.
+      # Available from libzmq 4.2.0.  
       #
       # @return [Integer]
       def tcp_maxrt()
@@ -1319,6 +1352,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_maxrt`.
+      # Available from libzmq 4.2.0.  
       #
       # This is the polymorphic version of #tcp_maxrt.
       #
@@ -1332,6 +1366,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_maxrt`.
+      # Available from libzmq 4.2.0.  
       #
       # @param tcp_maxrt [Integer, #to_int, #to_i]
       # @return [void]
@@ -1344,6 +1379,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_maxrt`.
+      # Available from libzmq 4.2.0.  
       #
       # This is the polymorphic version of #set_tcp_maxrt.
       #
@@ -1359,6 +1395,7 @@ module CZMQ
       end
 
       # Get socket option `thread_safe`.
+      # Available from libzmq 4.2.0.    
       #
       # @return [Integer]
       def thread_safe()
@@ -1369,6 +1406,7 @@ module CZMQ
       end
 
       # Get socket option `thread_safe`.
+      # Available from libzmq 4.2.0.    
       #
       # This is the polymorphic version of #thread_safe.
       #
@@ -1382,6 +1420,7 @@ module CZMQ
       end
 
       # Get socket option `multicast_maxtpdu`.
+      # Available from libzmq 4.2.0.          
       #
       # @return [Integer]
       def multicast_maxtpdu()
@@ -1392,6 +1431,7 @@ module CZMQ
       end
 
       # Get socket option `multicast_maxtpdu`.
+      # Available from libzmq 4.2.0.          
       #
       # This is the polymorphic version of #multicast_maxtpdu.
       #
@@ -1405,6 +1445,7 @@ module CZMQ
       end
 
       # Set socket option `multicast_maxtpdu`.
+      # Available from libzmq 4.2.0.          
       #
       # @param multicast_maxtpdu [Integer, #to_int, #to_i]
       # @return [void]
@@ -1417,6 +1458,7 @@ module CZMQ
       end
 
       # Set socket option `multicast_maxtpdu`.
+      # Available from libzmq 4.2.0.          
       #
       # This is the polymorphic version of #set_multicast_maxtpdu.
       #
@@ -1432,6 +1474,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_size`.
+      # Available from libzmq 4.2.0.         
       #
       # @return [Integer]
       def vmci_buffer_size()
@@ -1442,6 +1485,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_size`.
+      # Available from libzmq 4.2.0.         
       #
       # This is the polymorphic version of #vmci_buffer_size.
       #
@@ -1455,6 +1499,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_size`.
+      # Available from libzmq 4.2.0.         
       #
       # @param vmci_buffer_size [Integer, #to_int, #to_i]
       # @return [void]
@@ -1467,6 +1512,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_size`.
+      # Available from libzmq 4.2.0.         
       #
       # This is the polymorphic version of #set_vmci_buffer_size.
       #
@@ -1482,6 +1528,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_min_size`.
+      # Available from libzmq 4.2.0.             
       #
       # @return [Integer]
       def vmci_buffer_min_size()
@@ -1492,6 +1539,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_min_size`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #vmci_buffer_min_size.
       #
@@ -1505,6 +1553,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_min_size`.
+      # Available from libzmq 4.2.0.             
       #
       # @param vmci_buffer_min_size [Integer, #to_int, #to_i]
       # @return [void]
@@ -1517,6 +1566,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_min_size`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #set_vmci_buffer_min_size.
       #
@@ -1532,6 +1582,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_max_size`.
+      # Available from libzmq 4.2.0.             
       #
       # @return [Integer]
       def vmci_buffer_max_size()
@@ -1542,6 +1593,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_buffer_max_size`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #vmci_buffer_max_size.
       #
@@ -1555,6 +1607,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_max_size`.
+      # Available from libzmq 4.2.0.             
       #
       # @param vmci_buffer_max_size [Integer, #to_int, #to_i]
       # @return [void]
@@ -1567,6 +1620,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_buffer_max_size`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #set_vmci_buffer_max_size.
       #
@@ -1582,6 +1636,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_connect_timeout`.
+      # Available from libzmq 4.2.0.             
       #
       # @return [Integer]
       def vmci_connect_timeout()
@@ -1592,6 +1647,7 @@ module CZMQ
       end
 
       # Get socket option `vmci_connect_timeout`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #vmci_connect_timeout.
       #
@@ -1605,6 +1661,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_connect_timeout`.
+      # Available from libzmq 4.2.0.             
       #
       # @param vmci_connect_timeout [Integer, #to_int, #to_i]
       # @return [void]
@@ -1617,6 +1674,7 @@ module CZMQ
       end
 
       # Set socket option `vmci_connect_timeout`.
+      # Available from libzmq 4.2.0.             
       #
       # This is the polymorphic version of #set_vmci_connect_timeout.
       #
@@ -1631,7 +1689,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `tos`.
+      # Get socket option `tos`.    
+      # Available from libzmq 4.1.0.
       #
       # @return [Integer]
       def tos()
@@ -1641,7 +1700,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `tos`.
+      # Get socket option `tos`.    
+      # Available from libzmq 4.1.0.
       #
       # This is the polymorphic version of #tos.
       #
@@ -1654,7 +1714,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `tos`.
+      # Set socket option `tos`.    
+      # Available from libzmq 4.1.0.
       #
       # @param tos [Integer, #to_int, #to_i]
       # @return [void]
@@ -1666,7 +1727,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `tos`.
+      # Set socket option `tos`.    
+      # Available from libzmq 4.1.0.
       #
       # This is the polymorphic version of #set_tos.
       #
@@ -1682,6 +1744,7 @@ module CZMQ
       end
 
       # Set socket option `router_handover`.
+      # Available from libzmq 4.1.0.        
       #
       # @param router_handover [Integer, #to_int, #to_i]
       # @return [void]
@@ -1694,6 +1757,7 @@ module CZMQ
       end
 
       # Set socket option `router_handover`.
+      # Available from libzmq 4.1.0.        
       #
       # This is the polymorphic version of #set_router_handover.
       #
@@ -1709,6 +1773,7 @@ module CZMQ
       end
 
       # Set socket option `connect_rid`.
+      # Available from libzmq 4.1.0.    
       #
       # @param connect_rid [String, #to_s, nil]
       # @return [void]
@@ -1720,6 +1785,7 @@ module CZMQ
       end
 
       # Set socket option `connect_rid`.
+      # Available from libzmq 4.1.0.    
       #
       # This is the polymorphic version of #set_connect_rid.
       #
@@ -1734,6 +1800,7 @@ module CZMQ
       end
 
       # Set socket option `connect_rid` from 32-octet binary
+      # Available from libzmq 4.1.0.                        
       #
       # @param connect_rid [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -1745,6 +1812,7 @@ module CZMQ
       end
 
       # Set socket option `connect_rid` from 32-octet binary
+      # Available from libzmq 4.1.0.                        
       #
       # This is the polymorphic version of #set_connect_rid_bin.
       #
@@ -1759,6 +1827,7 @@ module CZMQ
       end
 
       # Get socket option `handshake_ivl`.
+      # Available from libzmq 4.1.0.      
       #
       # @return [Integer]
       def handshake_ivl()
@@ -1769,6 +1838,7 @@ module CZMQ
       end
 
       # Get socket option `handshake_ivl`.
+      # Available from libzmq 4.1.0.      
       #
       # This is the polymorphic version of #handshake_ivl.
       #
@@ -1782,6 +1852,7 @@ module CZMQ
       end
 
       # Set socket option `handshake_ivl`.
+      # Available from libzmq 4.1.0.      
       #
       # @param handshake_ivl [Integer, #to_int, #to_i]
       # @return [void]
@@ -1794,6 +1865,7 @@ module CZMQ
       end
 
       # Set socket option `handshake_ivl`.
+      # Available from libzmq 4.1.0.      
       #
       # This is the polymorphic version of #set_handshake_ivl.
       #
@@ -1809,6 +1881,7 @@ module CZMQ
       end
 
       # Get socket option `socks_proxy`.
+      # Available from libzmq 4.1.0.    
       #
       # @return [::FFI::AutoPointer]
       def socks_proxy()
@@ -1820,6 +1893,7 @@ module CZMQ
       end
 
       # Get socket option `socks_proxy`.
+      # Available from libzmq 4.1.0.    
       #
       # This is the polymorphic version of #socks_proxy.
       #
@@ -1834,6 +1908,7 @@ module CZMQ
       end
 
       # Set socket option `socks_proxy`.
+      # Available from libzmq 4.1.0.    
       #
       # @param socks_proxy [String, #to_s, nil]
       # @return [void]
@@ -1845,6 +1920,7 @@ module CZMQ
       end
 
       # Set socket option `socks_proxy`.
+      # Available from libzmq 4.1.0.    
       #
       # This is the polymorphic version of #set_socks_proxy.
       #
@@ -1859,6 +1935,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_nodrop`.
+      # Available from libzmq 4.1.0.    
       #
       # @param xpub_nodrop [Integer, #to_int, #to_i]
       # @return [void]
@@ -1871,6 +1948,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_nodrop`.
+      # Available from libzmq 4.1.0.    
       #
       # This is the polymorphic version of #set_xpub_nodrop.
       #
@@ -1886,6 +1964,7 @@ module CZMQ
       end
 
       # Set socket option `router_mandatory`.
+      # Available from libzmq 4.0.0.         
       #
       # @param router_mandatory [Integer, #to_int, #to_i]
       # @return [void]
@@ -1898,6 +1977,7 @@ module CZMQ
       end
 
       # Set socket option `router_mandatory`.
+      # Available from libzmq 4.0.0.         
       #
       # This is the polymorphic version of #set_router_mandatory.
       #
@@ -1913,6 +1993,7 @@ module CZMQ
       end
 
       # Set socket option `probe_router`.
+      # Available from libzmq 4.0.0.     
       #
       # @param probe_router [Integer, #to_int, #to_i]
       # @return [void]
@@ -1925,6 +2006,7 @@ module CZMQ
       end
 
       # Set socket option `probe_router`.
+      # Available from libzmq 4.0.0.     
       #
       # This is the polymorphic version of #set_probe_router.
       #
@@ -1940,6 +2022,7 @@ module CZMQ
       end
 
       # Set socket option `req_relaxed`.
+      # Available from libzmq 4.0.0.    
       #
       # @param req_relaxed [Integer, #to_int, #to_i]
       # @return [void]
@@ -1952,6 +2035,7 @@ module CZMQ
       end
 
       # Set socket option `req_relaxed`.
+      # Available from libzmq 4.0.0.    
       #
       # This is the polymorphic version of #set_req_relaxed.
       #
@@ -1967,6 +2051,7 @@ module CZMQ
       end
 
       # Set socket option `req_correlate`.
+      # Available from libzmq 4.0.0.      
       #
       # @param req_correlate [Integer, #to_int, #to_i]
       # @return [void]
@@ -1979,6 +2064,7 @@ module CZMQ
       end
 
       # Set socket option `req_correlate`.
+      # Available from libzmq 4.0.0.      
       #
       # This is the polymorphic version of #set_req_correlate.
       #
@@ -1994,6 +2080,7 @@ module CZMQ
       end
 
       # Set socket option `conflate`.
+      # Available from libzmq 4.0.0. 
       #
       # @param conflate [Integer, #to_int, #to_i]
       # @return [void]
@@ -2006,6 +2093,7 @@ module CZMQ
       end
 
       # Set socket option `conflate`.
+      # Available from libzmq 4.0.0. 
       #
       # This is the polymorphic version of #set_conflate.
       #
@@ -2021,6 +2109,7 @@ module CZMQ
       end
 
       # Get socket option `zap_domain`.
+      # Available from libzmq 4.0.0.   
       #
       # @return [::FFI::AutoPointer]
       def zap_domain()
@@ -2032,6 +2121,7 @@ module CZMQ
       end
 
       # Get socket option `zap_domain`.
+      # Available from libzmq 4.0.0.   
       #
       # This is the polymorphic version of #zap_domain.
       #
@@ -2046,6 +2136,7 @@ module CZMQ
       end
 
       # Set socket option `zap_domain`.
+      # Available from libzmq 4.0.0.   
       #
       # @param zap_domain [String, #to_s, nil]
       # @return [void]
@@ -2057,6 +2148,7 @@ module CZMQ
       end
 
       # Set socket option `zap_domain`.
+      # Available from libzmq 4.0.0.   
       #
       # This is the polymorphic version of #set_zap_domain.
       #
@@ -2071,6 +2163,7 @@ module CZMQ
       end
 
       # Get socket option `mechanism`.
+      # Available from libzmq 4.0.0.  
       #
       # @return [Integer]
       def mechanism()
@@ -2081,6 +2174,7 @@ module CZMQ
       end
 
       # Get socket option `mechanism`.
+      # Available from libzmq 4.0.0.  
       #
       # This is the polymorphic version of #mechanism.
       #
@@ -2094,6 +2188,7 @@ module CZMQ
       end
 
       # Get socket option `plain_server`.
+      # Available from libzmq 4.0.0.     
       #
       # @return [Integer]
       def plain_server()
@@ -2104,6 +2199,7 @@ module CZMQ
       end
 
       # Get socket option `plain_server`.
+      # Available from libzmq 4.0.0.     
       #
       # This is the polymorphic version of #plain_server.
       #
@@ -2117,6 +2213,7 @@ module CZMQ
       end
 
       # Set socket option `plain_server`.
+      # Available from libzmq 4.0.0.     
       #
       # @param plain_server [Integer, #to_int, #to_i]
       # @return [void]
@@ -2129,6 +2226,7 @@ module CZMQ
       end
 
       # Set socket option `plain_server`.
+      # Available from libzmq 4.0.0.     
       #
       # This is the polymorphic version of #set_plain_server.
       #
@@ -2144,6 +2242,7 @@ module CZMQ
       end
 
       # Get socket option `plain_username`.
+      # Available from libzmq 4.0.0.       
       #
       # @return [::FFI::AutoPointer]
       def plain_username()
@@ -2155,6 +2254,7 @@ module CZMQ
       end
 
       # Get socket option `plain_username`.
+      # Available from libzmq 4.0.0.       
       #
       # This is the polymorphic version of #plain_username.
       #
@@ -2169,6 +2269,7 @@ module CZMQ
       end
 
       # Set socket option `plain_username`.
+      # Available from libzmq 4.0.0.       
       #
       # @param plain_username [String, #to_s, nil]
       # @return [void]
@@ -2180,6 +2281,7 @@ module CZMQ
       end
 
       # Set socket option `plain_username`.
+      # Available from libzmq 4.0.0.       
       #
       # This is the polymorphic version of #set_plain_username.
       #
@@ -2194,6 +2296,7 @@ module CZMQ
       end
 
       # Get socket option `plain_password`.
+      # Available from libzmq 4.0.0.       
       #
       # @return [::FFI::AutoPointer]
       def plain_password()
@@ -2205,6 +2308,7 @@ module CZMQ
       end
 
       # Get socket option `plain_password`.
+      # Available from libzmq 4.0.0.       
       #
       # This is the polymorphic version of #plain_password.
       #
@@ -2219,6 +2323,7 @@ module CZMQ
       end
 
       # Set socket option `plain_password`.
+      # Available from libzmq 4.0.0.       
       #
       # @param plain_password [String, #to_s, nil]
       # @return [void]
@@ -2230,6 +2335,7 @@ module CZMQ
       end
 
       # Set socket option `plain_password`.
+      # Available from libzmq 4.0.0.       
       #
       # This is the polymorphic version of #set_plain_password.
       #
@@ -2244,6 +2350,7 @@ module CZMQ
       end
 
       # Get socket option `curve_server`.
+      # Available from libzmq 4.0.0.     
       #
       # @return [Integer]
       def curve_server()
@@ -2254,6 +2361,7 @@ module CZMQ
       end
 
       # Get socket option `curve_server`.
+      # Available from libzmq 4.0.0.     
       #
       # This is the polymorphic version of #curve_server.
       #
@@ -2267,6 +2375,7 @@ module CZMQ
       end
 
       # Set socket option `curve_server`.
+      # Available from libzmq 4.0.0.     
       #
       # @param curve_server [Integer, #to_int, #to_i]
       # @return [void]
@@ -2279,6 +2388,7 @@ module CZMQ
       end
 
       # Set socket option `curve_server`.
+      # Available from libzmq 4.0.0.     
       #
       # This is the polymorphic version of #set_curve_server.
       #
@@ -2294,6 +2404,7 @@ module CZMQ
       end
 
       # Get socket option `curve_publickey`.
+      # Available from libzmq 4.0.0.        
       #
       # @return [::FFI::AutoPointer]
       def curve_publickey()
@@ -2305,6 +2416,7 @@ module CZMQ
       end
 
       # Get socket option `curve_publickey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #curve_publickey.
       #
@@ -2319,6 +2431,7 @@ module CZMQ
       end
 
       # Set socket option `curve_publickey`.
+      # Available from libzmq 4.0.0.        
       #
       # @param curve_publickey [String, #to_s, nil]
       # @return [void]
@@ -2330,6 +2443,7 @@ module CZMQ
       end
 
       # Set socket option `curve_publickey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #set_curve_publickey.
       #
@@ -2344,6 +2458,7 @@ module CZMQ
       end
 
       # Set socket option `curve_publickey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # @param curve_publickey [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -2355,6 +2470,7 @@ module CZMQ
       end
 
       # Set socket option `curve_publickey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # This is the polymorphic version of #set_curve_publickey_bin.
       #
@@ -2369,6 +2485,7 @@ module CZMQ
       end
 
       # Get socket option `curve_secretkey`.
+      # Available from libzmq 4.0.0.        
       #
       # @return [::FFI::AutoPointer]
       def curve_secretkey()
@@ -2380,6 +2497,7 @@ module CZMQ
       end
 
       # Get socket option `curve_secretkey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #curve_secretkey.
       #
@@ -2394,6 +2512,7 @@ module CZMQ
       end
 
       # Set socket option `curve_secretkey`.
+      # Available from libzmq 4.0.0.        
       #
       # @param curve_secretkey [String, #to_s, nil]
       # @return [void]
@@ -2405,6 +2524,7 @@ module CZMQ
       end
 
       # Set socket option `curve_secretkey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #set_curve_secretkey.
       #
@@ -2419,6 +2539,7 @@ module CZMQ
       end
 
       # Set socket option `curve_secretkey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # @param curve_secretkey [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -2430,6 +2551,7 @@ module CZMQ
       end
 
       # Set socket option `curve_secretkey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # This is the polymorphic version of #set_curve_secretkey_bin.
       #
@@ -2444,6 +2566,7 @@ module CZMQ
       end
 
       # Get socket option `curve_serverkey`.
+      # Available from libzmq 4.0.0.        
       #
       # @return [::FFI::AutoPointer]
       def curve_serverkey()
@@ -2455,6 +2578,7 @@ module CZMQ
       end
 
       # Get socket option `curve_serverkey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #curve_serverkey.
       #
@@ -2469,6 +2593,7 @@ module CZMQ
       end
 
       # Set socket option `curve_serverkey`.
+      # Available from libzmq 4.0.0.        
       #
       # @param curve_serverkey [String, #to_s, nil]
       # @return [void]
@@ -2480,6 +2605,7 @@ module CZMQ
       end
 
       # Set socket option `curve_serverkey`.
+      # Available from libzmq 4.0.0.        
       #
       # This is the polymorphic version of #set_curve_serverkey.
       #
@@ -2494,6 +2620,7 @@ module CZMQ
       end
 
       # Set socket option `curve_serverkey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # @param curve_serverkey [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -2505,6 +2632,7 @@ module CZMQ
       end
 
       # Set socket option `curve_serverkey` from 32-octet binary
+      # Available from libzmq 4.0.0.                            
       #
       # This is the polymorphic version of #set_curve_serverkey_bin.
       #
@@ -2519,6 +2647,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_server`.
+      # Available from libzmq 4.0.0.      
       #
       # @return [Integer]
       def gssapi_server()
@@ -2529,6 +2658,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_server`.
+      # Available from libzmq 4.0.0.      
       #
       # This is the polymorphic version of #gssapi_server.
       #
@@ -2542,6 +2672,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_server`.
+      # Available from libzmq 4.0.0.      
       #
       # @param gssapi_server [Integer, #to_int, #to_i]
       # @return [void]
@@ -2554,6 +2685,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_server`.
+      # Available from libzmq 4.0.0.      
       #
       # This is the polymorphic version of #set_gssapi_server.
       #
@@ -2569,6 +2701,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_plaintext`.
+      # Available from libzmq 4.0.0.         
       #
       # @return [Integer]
       def gssapi_plaintext()
@@ -2579,6 +2712,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_plaintext`.
+      # Available from libzmq 4.0.0.         
       #
       # This is the polymorphic version of #gssapi_plaintext.
       #
@@ -2592,6 +2726,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_plaintext`.
+      # Available from libzmq 4.0.0.         
       #
       # @param gssapi_plaintext [Integer, #to_int, #to_i]
       # @return [void]
@@ -2604,6 +2739,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_plaintext`.
+      # Available from libzmq 4.0.0.         
       #
       # This is the polymorphic version of #set_gssapi_plaintext.
       #
@@ -2619,6 +2755,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_principal`.
+      # Available from libzmq 4.0.0.         
       #
       # @return [::FFI::AutoPointer]
       def gssapi_principal()
@@ -2630,6 +2767,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_principal`.
+      # Available from libzmq 4.0.0.         
       #
       # This is the polymorphic version of #gssapi_principal.
       #
@@ -2644,6 +2782,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_principal`.
+      # Available from libzmq 4.0.0.         
       #
       # @param gssapi_principal [String, #to_s, nil]
       # @return [void]
@@ -2655,6 +2794,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_principal`.
+      # Available from libzmq 4.0.0.         
       #
       # This is the polymorphic version of #set_gssapi_principal.
       #
@@ -2669,6 +2809,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_service_principal`.
+      # Available from libzmq 4.0.0.                 
       #
       # @return [::FFI::AutoPointer]
       def gssapi_service_principal()
@@ -2680,6 +2821,7 @@ module CZMQ
       end
 
       # Get socket option `gssapi_service_principal`.
+      # Available from libzmq 4.0.0.                 
       #
       # This is the polymorphic version of #gssapi_service_principal.
       #
@@ -2694,6 +2836,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_service_principal`.
+      # Available from libzmq 4.0.0.                 
       #
       # @param gssapi_service_principal [String, #to_s, nil]
       # @return [void]
@@ -2705,6 +2848,7 @@ module CZMQ
       end
 
       # Set socket option `gssapi_service_principal`.
+      # Available from libzmq 4.0.0.                 
       #
       # This is the polymorphic version of #set_gssapi_service_principal.
       #
@@ -2718,7 +2862,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `ipv6`.
+      # Get socket option `ipv6`.   
+      # Available from libzmq 4.0.0.
       #
       # @return [Integer]
       def ipv6()
@@ -2728,7 +2873,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `ipv6`.
+      # Get socket option `ipv6`.   
+      # Available from libzmq 4.0.0.
       #
       # This is the polymorphic version of #ipv6.
       #
@@ -2741,7 +2887,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `ipv6`.
+      # Set socket option `ipv6`.   
+      # Available from libzmq 4.0.0.
       #
       # @param ipv6 [Integer, #to_int, #to_i]
       # @return [void]
@@ -2753,7 +2900,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `ipv6`.
+      # Set socket option `ipv6`.   
+      # Available from libzmq 4.0.0.
       #
       # This is the polymorphic version of #set_ipv6.
       #
@@ -2769,6 +2917,7 @@ module CZMQ
       end
 
       # Get socket option `immediate`.
+      # Available from libzmq 4.0.0.  
       #
       # @return [Integer]
       def immediate()
@@ -2779,6 +2928,7 @@ module CZMQ
       end
 
       # Get socket option `immediate`.
+      # Available from libzmq 4.0.0.  
       #
       # This is the polymorphic version of #immediate.
       #
@@ -2792,6 +2942,7 @@ module CZMQ
       end
 
       # Set socket option `immediate`.
+      # Available from libzmq 4.0.0.  
       #
       # @param immediate [Integer, #to_int, #to_i]
       # @return [void]
@@ -2804,6 +2955,7 @@ module CZMQ
       end
 
       # Set socket option `immediate`.
+      # Available from libzmq 4.0.0.  
       #
       # This is the polymorphic version of #set_immediate.
       #
@@ -2818,7 +2970,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `type`.
+      # Get socket option `type`.   
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def type()
@@ -2828,7 +2981,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `type`.
+      # Get socket option `type`.   
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #type.
       #
@@ -2841,7 +2995,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `sndhwm`.
+      # Get socket option `sndhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def sndhwm()
@@ -2851,7 +3006,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `sndhwm`.
+      # Get socket option `sndhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #sndhwm.
       #
@@ -2864,7 +3020,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `sndhwm`.
+      # Set socket option `sndhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # @param sndhwm [Integer, #to_int, #to_i]
       # @return [void]
@@ -2876,7 +3033,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `sndhwm`.
+      # Set socket option `sndhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_sndhwm.
       #
@@ -2891,7 +3049,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rcvhwm`.
+      # Get socket option `rcvhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def rcvhwm()
@@ -2901,7 +3060,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rcvhwm`.
+      # Get socket option `rcvhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #rcvhwm.
       #
@@ -2914,7 +3074,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rcvhwm`.
+      # Set socket option `rcvhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # @param rcvhwm [Integer, #to_int, #to_i]
       # @return [void]
@@ -2926,7 +3087,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rcvhwm`.
+      # Set socket option `rcvhwm`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_rcvhwm.
       #
@@ -2942,6 +3104,7 @@ module CZMQ
       end
 
       # Get socket option `affinity`.
+      # Available from libzmq 3.0.0. 
       #
       # @return [Integer]
       def affinity()
@@ -2952,6 +3115,7 @@ module CZMQ
       end
 
       # Get socket option `affinity`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #affinity.
       #
@@ -2965,6 +3129,7 @@ module CZMQ
       end
 
       # Set socket option `affinity`.
+      # Available from libzmq 3.0.0. 
       #
       # @param affinity [Integer, #to_int, #to_i]
       # @return [void]
@@ -2977,6 +3142,7 @@ module CZMQ
       end
 
       # Set socket option `affinity`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #set_affinity.
       #
@@ -2992,6 +3158,7 @@ module CZMQ
       end
 
       # Set socket option `subscribe`.
+      # Available from libzmq 3.0.0.  
       #
       # @param subscribe [String, #to_s, nil]
       # @return [void]
@@ -3003,6 +3170,7 @@ module CZMQ
       end
 
       # Set socket option `subscribe`.
+      # Available from libzmq 3.0.0.  
       #
       # This is the polymorphic version of #set_subscribe.
       #
@@ -3017,6 +3185,7 @@ module CZMQ
       end
 
       # Set socket option `unsubscribe`.
+      # Available from libzmq 3.0.0.    
       #
       # @param unsubscribe [String, #to_s, nil]
       # @return [void]
@@ -3028,6 +3197,7 @@ module CZMQ
       end
 
       # Set socket option `unsubscribe`.
+      # Available from libzmq 3.0.0.    
       #
       # This is the polymorphic version of #set_unsubscribe.
       #
@@ -3042,6 +3212,7 @@ module CZMQ
       end
 
       # Get socket option `identity`.
+      # Available from libzmq 3.0.0. 
       #
       # @return [::FFI::AutoPointer]
       def identity()
@@ -3053,6 +3224,7 @@ module CZMQ
       end
 
       # Get socket option `identity`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #identity.
       #
@@ -3067,6 +3239,7 @@ module CZMQ
       end
 
       # Set socket option `identity`.
+      # Available from libzmq 3.0.0. 
       #
       # @param identity [String, #to_s, nil]
       # @return [void]
@@ -3078,6 +3251,7 @@ module CZMQ
       end
 
       # Set socket option `identity`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #set_identity.
       #
@@ -3091,7 +3265,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rate`.
+      # Get socket option `rate`.   
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def rate()
@@ -3101,7 +3276,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rate`.
+      # Get socket option `rate`.   
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #rate.
       #
@@ -3114,7 +3290,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rate`.
+      # Set socket option `rate`.   
+      # Available from libzmq 3.0.0.
       #
       # @param rate [Integer, #to_int, #to_i]
       # @return [void]
@@ -3126,7 +3303,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rate`.
+      # Set socket option `rate`.   
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_rate.
       #
@@ -3142,6 +3320,7 @@ module CZMQ
       end
 
       # Get socket option `recovery_ivl`.
+      # Available from libzmq 3.0.0.     
       #
       # @return [Integer]
       def recovery_ivl()
@@ -3152,6 +3331,7 @@ module CZMQ
       end
 
       # Get socket option `recovery_ivl`.
+      # Available from libzmq 3.0.0.     
       #
       # This is the polymorphic version of #recovery_ivl.
       #
@@ -3165,6 +3345,7 @@ module CZMQ
       end
 
       # Set socket option `recovery_ivl`.
+      # Available from libzmq 3.0.0.     
       #
       # @param recovery_ivl [Integer, #to_int, #to_i]
       # @return [void]
@@ -3177,6 +3358,7 @@ module CZMQ
       end
 
       # Set socket option `recovery_ivl`.
+      # Available from libzmq 3.0.0.     
       #
       # This is the polymorphic version of #set_recovery_ivl.
       #
@@ -3191,7 +3373,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `sndbuf`.
+      # Get socket option `sndbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def sndbuf()
@@ -3201,7 +3384,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `sndbuf`.
+      # Get socket option `sndbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #sndbuf.
       #
@@ -3214,7 +3398,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `sndbuf`.
+      # Set socket option `sndbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # @param sndbuf [Integer, #to_int, #to_i]
       # @return [void]
@@ -3226,7 +3411,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `sndbuf`.
+      # Set socket option `sndbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_sndbuf.
       #
@@ -3241,7 +3427,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rcvbuf`.
+      # Get socket option `rcvbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def rcvbuf()
@@ -3251,7 +3438,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `rcvbuf`.
+      # Get socket option `rcvbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #rcvbuf.
       #
@@ -3264,7 +3452,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rcvbuf`.
+      # Set socket option `rcvbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # @param rcvbuf [Integer, #to_int, #to_i]
       # @return [void]
@@ -3276,7 +3465,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `rcvbuf`.
+      # Set socket option `rcvbuf`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_rcvbuf.
       #
@@ -3291,7 +3481,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `linger`.
+      # Get socket option `linger`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def linger()
@@ -3301,7 +3492,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `linger`.
+      # Get socket option `linger`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #linger.
       #
@@ -3314,7 +3506,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `linger`.
+      # Set socket option `linger`. 
+      # Available from libzmq 3.0.0.
       #
       # @param linger [Integer, #to_int, #to_i]
       # @return [void]
@@ -3326,7 +3519,8 @@ module CZMQ
         result
       end
 
-      # Set socket option `linger`.
+      # Set socket option `linger`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_linger.
       #
@@ -3342,6 +3536,7 @@ module CZMQ
       end
 
       # Get socket option `reconnect_ivl`.
+      # Available from libzmq 3.0.0.      
       #
       # @return [Integer]
       def reconnect_ivl()
@@ -3352,6 +3547,7 @@ module CZMQ
       end
 
       # Get socket option `reconnect_ivl`.
+      # Available from libzmq 3.0.0.      
       #
       # This is the polymorphic version of #reconnect_ivl.
       #
@@ -3365,6 +3561,7 @@ module CZMQ
       end
 
       # Set socket option `reconnect_ivl`.
+      # Available from libzmq 3.0.0.      
       #
       # @param reconnect_ivl [Integer, #to_int, #to_i]
       # @return [void]
@@ -3377,6 +3574,7 @@ module CZMQ
       end
 
       # Set socket option `reconnect_ivl`.
+      # Available from libzmq 3.0.0.      
       #
       # This is the polymorphic version of #set_reconnect_ivl.
       #
@@ -3392,6 +3590,7 @@ module CZMQ
       end
 
       # Get socket option `reconnect_ivl_max`.
+      # Available from libzmq 3.0.0.          
       #
       # @return [Integer]
       def reconnect_ivl_max()
@@ -3402,6 +3601,7 @@ module CZMQ
       end
 
       # Get socket option `reconnect_ivl_max`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #reconnect_ivl_max.
       #
@@ -3415,6 +3615,7 @@ module CZMQ
       end
 
       # Set socket option `reconnect_ivl_max`.
+      # Available from libzmq 3.0.0.          
       #
       # @param reconnect_ivl_max [Integer, #to_int, #to_i]
       # @return [void]
@@ -3427,6 +3628,7 @@ module CZMQ
       end
 
       # Set socket option `reconnect_ivl_max`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #set_reconnect_ivl_max.
       #
@@ -3442,6 +3644,7 @@ module CZMQ
       end
 
       # Get socket option `backlog`.
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def backlog()
@@ -3452,6 +3655,7 @@ module CZMQ
       end
 
       # Get socket option `backlog`.
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #backlog.
       #
@@ -3465,6 +3669,7 @@ module CZMQ
       end
 
       # Set socket option `backlog`.
+      # Available from libzmq 3.0.0.
       #
       # @param backlog [Integer, #to_int, #to_i]
       # @return [void]
@@ -3477,6 +3682,7 @@ module CZMQ
       end
 
       # Set socket option `backlog`.
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #set_backlog.
       #
@@ -3492,6 +3698,7 @@ module CZMQ
       end
 
       # Get socket option `maxmsgsize`.
+      # Available from libzmq 3.0.0.   
       #
       # @return [Integer]
       def maxmsgsize()
@@ -3502,6 +3709,7 @@ module CZMQ
       end
 
       # Get socket option `maxmsgsize`.
+      # Available from libzmq 3.0.0.   
       #
       # This is the polymorphic version of #maxmsgsize.
       #
@@ -3515,6 +3723,7 @@ module CZMQ
       end
 
       # Set socket option `maxmsgsize`.
+      # Available from libzmq 3.0.0.   
       #
       # @param maxmsgsize [Integer, #to_int, #to_i]
       # @return [void]
@@ -3527,6 +3736,7 @@ module CZMQ
       end
 
       # Set socket option `maxmsgsize`.
+      # Available from libzmq 3.0.0.   
       #
       # This is the polymorphic version of #set_maxmsgsize.
       #
@@ -3542,6 +3752,7 @@ module CZMQ
       end
 
       # Get socket option `multicast_hops`.
+      # Available from libzmq 3.0.0.       
       #
       # @return [Integer]
       def multicast_hops()
@@ -3552,6 +3763,7 @@ module CZMQ
       end
 
       # Get socket option `multicast_hops`.
+      # Available from libzmq 3.0.0.       
       #
       # This is the polymorphic version of #multicast_hops.
       #
@@ -3565,6 +3777,7 @@ module CZMQ
       end
 
       # Set socket option `multicast_hops`.
+      # Available from libzmq 3.0.0.       
       #
       # @param multicast_hops [Integer, #to_int, #to_i]
       # @return [void]
@@ -3577,6 +3790,7 @@ module CZMQ
       end
 
       # Set socket option `multicast_hops`.
+      # Available from libzmq 3.0.0.       
       #
       # This is the polymorphic version of #set_multicast_hops.
       #
@@ -3592,6 +3806,7 @@ module CZMQ
       end
 
       # Get socket option `rcvtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # @return [Integer]
       def rcvtimeo()
@@ -3602,6 +3817,7 @@ module CZMQ
       end
 
       # Get socket option `rcvtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #rcvtimeo.
       #
@@ -3615,6 +3831,7 @@ module CZMQ
       end
 
       # Set socket option `rcvtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # @param rcvtimeo [Integer, #to_int, #to_i]
       # @return [void]
@@ -3627,6 +3844,7 @@ module CZMQ
       end
 
       # Set socket option `rcvtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #set_rcvtimeo.
       #
@@ -3642,6 +3860,7 @@ module CZMQ
       end
 
       # Get socket option `sndtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # @return [Integer]
       def sndtimeo()
@@ -3652,6 +3871,7 @@ module CZMQ
       end
 
       # Get socket option `sndtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #sndtimeo.
       #
@@ -3665,6 +3885,7 @@ module CZMQ
       end
 
       # Set socket option `sndtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # @param sndtimeo [Integer, #to_int, #to_i]
       # @return [void]
@@ -3677,6 +3898,7 @@ module CZMQ
       end
 
       # Set socket option `sndtimeo`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #set_sndtimeo.
       #
@@ -3692,6 +3914,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_verbose`.
+      # Available from libzmq 3.0.0.     
       #
       # @param xpub_verbose [Integer, #to_int, #to_i]
       # @return [void]
@@ -3704,6 +3927,7 @@ module CZMQ
       end
 
       # Set socket option `xpub_verbose`.
+      # Available from libzmq 3.0.0.     
       #
       # This is the polymorphic version of #set_xpub_verbose.
       #
@@ -3719,6 +3943,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive`.
+      # Available from libzmq 3.0.0.      
       #
       # @return [Integer]
       def tcp_keepalive()
@@ -3729,6 +3954,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive`.
+      # Available from libzmq 3.0.0.      
       #
       # This is the polymorphic version of #tcp_keepalive.
       #
@@ -3742,6 +3968,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive`.
+      # Available from libzmq 3.0.0.      
       #
       # @param tcp_keepalive [Integer, #to_int, #to_i]
       # @return [void]
@@ -3754,6 +3981,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive`.
+      # Available from libzmq 3.0.0.      
       #
       # This is the polymorphic version of #set_tcp_keepalive.
       #
@@ -3769,6 +3997,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_idle`.
+      # Available from libzmq 3.0.0.           
       #
       # @return [Integer]
       def tcp_keepalive_idle()
@@ -3779,6 +4008,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_idle`.
+      # Available from libzmq 3.0.0.           
       #
       # This is the polymorphic version of #tcp_keepalive_idle.
       #
@@ -3792,6 +4022,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_idle`.
+      # Available from libzmq 3.0.0.           
       #
       # @param tcp_keepalive_idle [Integer, #to_int, #to_i]
       # @return [void]
@@ -3804,6 +4035,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_idle`.
+      # Available from libzmq 3.0.0.           
       #
       # This is the polymorphic version of #set_tcp_keepalive_idle.
       #
@@ -3819,6 +4051,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_cnt`.
+      # Available from libzmq 3.0.0.          
       #
       # @return [Integer]
       def tcp_keepalive_cnt()
@@ -3829,6 +4062,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_cnt`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #tcp_keepalive_cnt.
       #
@@ -3842,6 +4076,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_cnt`.
+      # Available from libzmq 3.0.0.          
       #
       # @param tcp_keepalive_cnt [Integer, #to_int, #to_i]
       # @return [void]
@@ -3854,6 +4089,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_cnt`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #set_tcp_keepalive_cnt.
       #
@@ -3869,6 +4105,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_intvl`.
+      # Available from libzmq 3.0.0.            
       #
       # @return [Integer]
       def tcp_keepalive_intvl()
@@ -3879,6 +4116,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_keepalive_intvl`.
+      # Available from libzmq 3.0.0.            
       #
       # This is the polymorphic version of #tcp_keepalive_intvl.
       #
@@ -3892,6 +4130,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_intvl`.
+      # Available from libzmq 3.0.0.            
       #
       # @param tcp_keepalive_intvl [Integer, #to_int, #to_i]
       # @return [void]
@@ -3904,6 +4143,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_keepalive_intvl`.
+      # Available from libzmq 3.0.0.            
       #
       # This is the polymorphic version of #set_tcp_keepalive_intvl.
       #
@@ -3919,6 +4159,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_accept_filter`.
+      # Available from libzmq 3.0.0.          
       #
       # @return [::FFI::AutoPointer]
       def tcp_accept_filter()
@@ -3930,6 +4171,7 @@ module CZMQ
       end
 
       # Get socket option `tcp_accept_filter`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #tcp_accept_filter.
       #
@@ -3944,6 +4186,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_accept_filter`.
+      # Available from libzmq 3.0.0.          
       #
       # @param tcp_accept_filter [String, #to_s, nil]
       # @return [void]
@@ -3955,6 +4198,7 @@ module CZMQ
       end
 
       # Set socket option `tcp_accept_filter`.
+      # Available from libzmq 3.0.0.          
       #
       # This is the polymorphic version of #set_tcp_accept_filter.
       #
@@ -3969,6 +4213,7 @@ module CZMQ
       end
 
       # Get socket option `rcvmore`.
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def rcvmore()
@@ -3979,6 +4224,7 @@ module CZMQ
       end
 
       # Get socket option `rcvmore`.
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #rcvmore.
       #
@@ -3991,7 +4237,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `fd`.
+      # Get socket option `fd`.     
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer or FFI::Pointer]
       def fd()
@@ -4001,7 +4248,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `fd`.
+      # Get socket option `fd`.     
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #fd.
       #
@@ -4014,7 +4262,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `events`.
+      # Get socket option `events`. 
+      # Available from libzmq 3.0.0.
       #
       # @return [Integer]
       def events()
@@ -4024,7 +4273,8 @@ module CZMQ
         result
       end
 
-      # Get socket option `events`.
+      # Get socket option `events`. 
+      # Available from libzmq 3.0.0.
       #
       # This is the polymorphic version of #events.
       #
@@ -4038,6 +4288,7 @@ module CZMQ
       end
 
       # Get socket option `last_endpoint`.
+      # Available from libzmq 3.0.0.      
       #
       # @return [::FFI::AutoPointer]
       def last_endpoint()
@@ -4049,6 +4300,7 @@ module CZMQ
       end
 
       # Get socket option `last_endpoint`.
+      # Available from libzmq 3.0.0.      
       #
       # This is the polymorphic version of #last_endpoint.
       #
@@ -4063,6 +4315,7 @@ module CZMQ
       end
 
       # Set socket option `router_raw`.
+      # Available from libzmq 3.0.0.   
       #
       # @param router_raw [Integer, #to_int, #to_i]
       # @return [void]
@@ -4075,6 +4328,7 @@ module CZMQ
       end
 
       # Set socket option `router_raw`.
+      # Available from libzmq 3.0.0.   
       #
       # This is the polymorphic version of #set_router_raw.
       #
@@ -4090,6 +4344,7 @@ module CZMQ
       end
 
       # Get socket option `ipv4only`.
+      # Available from libzmq 3.0.0. 
       #
       # @return [Integer]
       def ipv4only()
@@ -4100,6 +4355,7 @@ module CZMQ
       end
 
       # Get socket option `ipv4only`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #ipv4only.
       #
@@ -4113,6 +4369,7 @@ module CZMQ
       end
 
       # Set socket option `ipv4only`.
+      # Available from libzmq 3.0.0. 
       #
       # @param ipv4only [Integer, #to_int, #to_i]
       # @return [void]
@@ -4125,6 +4382,7 @@ module CZMQ
       end
 
       # Set socket option `ipv4only`.
+      # Available from libzmq 3.0.0. 
       #
       # This is the polymorphic version of #set_ipv4only.
       #
@@ -4140,6 +4398,7 @@ module CZMQ
       end
 
       # Set socket option `delay_attach_on_connect`.
+      # Available from libzmq 3.0.0.                
       #
       # @param delay_attach_on_connect [Integer, #to_int, #to_i]
       # @return [void]
@@ -4152,6 +4411,7 @@ module CZMQ
       end
 
       # Set socket option `delay_attach_on_connect`.
+      # Available from libzmq 3.0.0.                
       #
       # This is the polymorphic version of #set_delay_attach_on_connect.
       #

--- a/builds/msvc/vs2010/libczmq/libczmq.props
+++ b/builds/msvc/vs2010/libczmq/libczmq.props
@@ -16,7 +16,7 @@
   <!-- Configuration -->
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)platform.h $(RepoRoot)include\</Command>
+      <Command>copy "$(BuildRoot)platform.h" "$(RepoRoot)include\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/msvc/vs2012/libczmq/libczmq.props
+++ b/builds/msvc/vs2012/libczmq/libczmq.props
@@ -16,7 +16,7 @@
   <!-- Configuration -->
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)platform.h $(RepoRoot)include\</Command>
+      <Command>copy "$(BuildRoot)platform.h" "$(RepoRoot)include\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/msvc/vs2013/libczmq/libczmq.props
+++ b/builds/msvc/vs2013/libczmq/libczmq.props
@@ -16,7 +16,7 @@
   <!-- Configuration -->
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)platform.h $(RepoRoot)include\</Command>
+      <Command>copy "$(BuildRoot)platform.h" "$(RepoRoot)include\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/msvc/vs2015/libczmq/libczmq.props
+++ b/builds/msvc/vs2015/libczmq/libczmq.props
@@ -16,7 +16,7 @@
   <!-- Configuration -->
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)platform.h $(RepoRoot)include\</Command>
+      <Command>copy "$(BuildRoot)platform.h" "$(RepoRoot)include\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -104,6 +104,7 @@ zmakecert.txt:
 	./mkman zmakecert $@
 clean:
 	rm -f *.1 *.3 *.7
+doc:
 	./mkman zactor
 	./mkman zarmour
 	./mkman zcert

--- a/doc/zloop.doc
+++ b/doc/zloop.doc
@@ -12,8 +12,6 @@ This is the class interface:
 ```h
     //  This is a stable class, and may not change except for emergencies. It
     //  is provided in stable builds.
-    //  This class has draft methods, which may change over time. They are not
-    //  in stable releases, by default. Use --enable-drafts to enable.
     // Callback function for reactor socket activity
     typedef int (zloop_reader_fn) (
         zloop_t *loop, zsock_t *reader, void *arg);
@@ -123,6 +121,13 @@ This is the class interface:
     CZMQ_EXPORT void
         zloop_set_verbose (zloop_t *self, bool verbose);
     
+    //  By default the reactor stops if the process receives a SIGINT or SIGTERM 
+    //  signal. This makes it impossible to shut-down message based architectures
+    //  like zactors. This method lets you switch off break handling. The default
+    //  nonstop setting is off (false).                                          
+    CZMQ_EXPORT void
+        zloop_set_nonstop (zloop_t *self, bool nonstop);
+    
     //  Start the reactor. Takes control of the thread and returns when the 0MQ  
     //  context is terminated or the process is interrupted, or any event handler
     //  returns -1. Event handlers may register new sockets and timers, and      
@@ -134,16 +139,6 @@ This is the class interface:
     CZMQ_EXPORT void
         zloop_test (bool verbose);
     
-    #ifdef CZMQ_BUILD_DRAFT_API
-    //  *** Draft method, for development use, may change without warning ***
-    //  By default the reactor stops if the process receives a SIGINT or SIGTERM 
-    //  signal. This makes it impossible to shut-down message based architectures
-    //  like zactors. This method lets you switch off break handling. The default
-    //  nonstop setting is off (false).                                          
-    CZMQ_EXPORT void
-        zloop_set_nonstop (zloop_t *self, bool nonstop);
-    
-    #endif // CZMQ_BUILD_DRAFT_API
 ```
 
 This is the class self test code:

--- a/doc/zloop.txt
+++ b/doc/zloop.txt
@@ -10,8 +10,6 @@ SYNOPSIS
 ----
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
-//  This class has draft methods, which may change over time. They are not
-//  in stable releases, by default. Use --enable-drafts to enable.
 // Callback function for reactor socket activity
 typedef int (zloop_reader_fn) (
     zloop_t *loop, zsock_t *reader, void *arg);
@@ -121,6 +119,13 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zloop_set_verbose (zloop_t *self, bool verbose);
 
+//  By default the reactor stops if the process receives a SIGINT or SIGTERM 
+//  signal. This makes it impossible to shut-down message based architectures
+//  like zactors. This method lets you switch off break handling. The default
+//  nonstop setting is off (false).                                          
+CZMQ_EXPORT void
+    zloop_set_nonstop (zloop_t *self, bool nonstop);
+
 //  Start the reactor. Takes control of the thread and returns when the 0MQ  
 //  context is terminated or the process is interrupted, or any event handler
 //  returns -1. Event handlers may register new sockets and timers, and      
@@ -132,16 +137,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zloop_test (bool verbose);
 
-#ifdef CZMQ_BUILD_DRAFT_API
-//  *** Draft method, for development use, may change without warning ***
-//  By default the reactor stops if the process receives a SIGINT or SIGTERM 
-//  signal. This makes it impossible to shut-down message based architectures
-//  like zactors. This method lets you switch off break handling. The default
-//  nonstop setting is off (false).                                          
-CZMQ_EXPORT void
-    zloop_set_nonstop (zloop_t *self, bool nonstop);
-
-#endif // CZMQ_BUILD_DRAFT_API
 ----
 
 DESCRIPTION

--- a/doc/zpoller.doc
+++ b/doc/zpoller.doc
@@ -13,8 +13,6 @@ This is the class interface:
 ```h
     //  This is a stable class, and may not change except for emergencies. It
     //  is provided in stable builds.
-    //  This class has draft methods, which may change over time. They are not
-    //  in stable releases, by default. Use --enable-drafts to enable.
     //  Create new poller, specifying zero or more readers. The list of 
     //  readers ends in a NULL. Each reader can be a zsock_t instance, a
     //  zactor_t instance, a libzmq socket (void *), or a file handle.  
@@ -34,6 +32,13 @@ This is the class interface:
     //  must have been passed during construction, or in an zpoller_add () call.   
     CZMQ_EXPORT int
         zpoller_remove (zpoller_t *self, void *reader);
+    
+    //  By default the poller stops if the process receives a SIGINT or SIGTERM  
+    //  signal. This makes it impossible to shut-down message based architectures
+    //  like zactors. This method lets you switch off break handling. The default
+    //  nonstop setting is off (false).                                          
+    CZMQ_EXPORT void
+        zpoller_set_nonstop (zpoller_t *self, bool nonstop);
     
     //  Poll the registered readers for I/O, return first reader that has input.  
     //  The reader will be a libzmq void * socket, or a zsock_t or zactor_t       
@@ -61,16 +66,6 @@ This is the class interface:
     CZMQ_EXPORT void
         zpoller_test (bool verbose);
     
-    #ifdef CZMQ_BUILD_DRAFT_API
-    //  *** Draft method, for development use, may change without warning ***
-    //  By default the poller stops if the process receives a SIGINT or SIGTERM  
-    //  signal. This makes it impossible to shut-down message based architectures
-    //  like zactors. This method lets you switch off break handling. The default
-    //  nonstop setting is off (false).                                          
-    CZMQ_EXPORT void
-        zpoller_set_nonstop (zpoller_t *self, bool nonstop);
-    
-    #endif // CZMQ_BUILD_DRAFT_API
 ```
 
 This is the class self test code:

--- a/doc/zpoller.txt
+++ b/doc/zpoller.txt
@@ -10,8 +10,6 @@ SYNOPSIS
 ----
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
-//  This class has draft methods, which may change over time. They are not
-//  in stable releases, by default. Use --enable-drafts to enable.
 //  Create new poller, specifying zero or more readers. The list of 
 //  readers ends in a NULL. Each reader can be a zsock_t instance, a
 //  zactor_t instance, a libzmq socket (void *), or a file handle.  
@@ -31,6 +29,13 @@ CZMQ_EXPORT int
 //  must have been passed during construction, or in an zpoller_add () call.   
 CZMQ_EXPORT int
     zpoller_remove (zpoller_t *self, void *reader);
+
+//  By default the poller stops if the process receives a SIGINT or SIGTERM  
+//  signal. This makes it impossible to shut-down message based architectures
+//  like zactors. This method lets you switch off break handling. The default
+//  nonstop setting is off (false).                                          
+CZMQ_EXPORT void
+    zpoller_set_nonstop (zpoller_t *self, bool nonstop);
 
 //  Poll the registered readers for I/O, return first reader that has input.  
 //  The reader will be a libzmq void * socket, or a zsock_t or zactor_t       
@@ -58,16 +63,6 @@ CZMQ_EXPORT bool
 CZMQ_EXPORT void
     zpoller_test (bool verbose);
 
-#ifdef CZMQ_BUILD_DRAFT_API
-//  *** Draft method, for development use, may change without warning ***
-//  By default the poller stops if the process receives a SIGINT or SIGTERM  
-//  signal. This makes it impossible to shut-down message based architectures
-//  like zactors. This method lets you switch off break handling. The default
-//  nonstop setting is off (false).                                          
-CZMQ_EXPORT void
-    zpoller_set_nonstop (zpoller_t *self, bool nonstop);
-
-#endif // CZMQ_BUILD_DRAFT_API
 ----
 
 DESCRIPTION

--- a/doc/zsock.doc
+++ b/doc/zsock.doc
@@ -282,582 +282,712 @@ This is the class interface:
         zsock_resolve (void *self);
     
     //  Get socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_heartbeat_ivl (void *self);
     
     //  Set socket option `heartbeat_ivl`.
+    //  Available from libzmq 4.2.0.      
     CZMQ_EXPORT void
         zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
     
     //  Get socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_heartbeat_ttl (void *self);
     
     //  Set socket option `heartbeat_ttl`.
+    //  Available from libzmq 4.2.0.      
     CZMQ_EXPORT void
         zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
     
     //  Get socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_heartbeat_timeout (void *self);
     
     //  Set socket option `heartbeat_timeout`.
+    //  Available from libzmq 4.2.0.          
     CZMQ_EXPORT void
         zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
     
-    //  Get socket option `use_fd`.
+    //  Get socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_use_fd (void *self);
     
-    //  Set socket option `use_fd`.
+    //  Set socket option `use_fd`. 
+    //  Available from libzmq 4.2.0.
     CZMQ_EXPORT void
         zsock_set_use_fd (void *self, int use_fd);
     
     //  Set socket option `xpub_manual`.
+    //  Available from libzmq 4.2.0.    
     CZMQ_EXPORT void
         zsock_set_xpub_manual (void *self, int xpub_manual);
     
     //  Set socket option `xpub_welcome_msg`.
+    //  Available from libzmq 4.2.0.         
     CZMQ_EXPORT void
         zsock_set_xpub_welcome_msg (void *self, const char *xpub_welcome_msg);
     
     //  Set socket option `stream_notify`.
+    //  Available from libzmq 4.2.0.      
     CZMQ_EXPORT void
         zsock_set_stream_notify (void *self, int stream_notify);
     
     //  Get socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_invert_matching (void *self);
     
     //  Set socket option `invert_matching`.
+    //  Available from libzmq 4.2.0.        
     CZMQ_EXPORT void
         zsock_set_invert_matching (void *self, int invert_matching);
     
     //  Set socket option `xpub_verboser`.
+    //  Available from libzmq 4.2.0.      
     CZMQ_EXPORT void
         zsock_set_xpub_verboser (void *self, int xpub_verboser);
     
     //  Get socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_connect_timeout (void *self);
     
     //  Set socket option `connect_timeout`.
+    //  Available from libzmq 4.2.0.        
     CZMQ_EXPORT void
         zsock_set_connect_timeout (void *self, int connect_timeout);
     
     //  Get socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tcp_maxrt (void *self);
     
     //  Set socket option `tcp_maxrt`.
+    //  Available from libzmq 4.2.0.  
     CZMQ_EXPORT void
         zsock_set_tcp_maxrt (void *self, int tcp_maxrt);
     
     //  Get socket option `thread_safe`.
+    //  Available from libzmq 4.2.0.    
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_thread_safe (void *self);
     
     //  Get socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_multicast_maxtpdu (void *self);
     
     //  Set socket option `multicast_maxtpdu`.
+    //  Available from libzmq 4.2.0.          
     CZMQ_EXPORT void
         zsock_set_multicast_maxtpdu (void *self, int multicast_maxtpdu);
     
     //  Get socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_vmci_buffer_size (void *self);
     
     //  Set socket option `vmci_buffer_size`.
+    //  Available from libzmq 4.2.0.         
     CZMQ_EXPORT void
         zsock_set_vmci_buffer_size (void *self, int vmci_buffer_size);
     
     //  Get socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_vmci_buffer_min_size (void *self);
     
     //  Set socket option `vmci_buffer_min_size`.
+    //  Available from libzmq 4.2.0.             
     CZMQ_EXPORT void
         zsock_set_vmci_buffer_min_size (void *self, int vmci_buffer_min_size);
     
     //  Get socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_vmci_buffer_max_size (void *self);
     
     //  Set socket option `vmci_buffer_max_size`.
+    //  Available from libzmq 4.2.0.             
     CZMQ_EXPORT void
         zsock_set_vmci_buffer_max_size (void *self, int vmci_buffer_max_size);
     
     //  Get socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_vmci_connect_timeout (void *self);
     
     //  Set socket option `vmci_connect_timeout`.
+    //  Available from libzmq 4.2.0.             
     CZMQ_EXPORT void
         zsock_set_vmci_connect_timeout (void *self, int vmci_connect_timeout);
     
-    //  Get socket option `tos`.
+    //  Get socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tos (void *self);
     
-    //  Set socket option `tos`.
+    //  Set socket option `tos`.    
+    //  Available from libzmq 4.1.0.
     CZMQ_EXPORT void
         zsock_set_tos (void *self, int tos);
     
     //  Set socket option `router_handover`.
+    //  Available from libzmq 4.1.0.        
     CZMQ_EXPORT void
         zsock_set_router_handover (void *self, int router_handover);
     
     //  Set socket option `connect_rid`.
+    //  Available from libzmq 4.1.0.    
     CZMQ_EXPORT void
         zsock_set_connect_rid (void *self, const char *connect_rid);
     
     //  Set socket option `connect_rid` from 32-octet binary
+    //  Available from libzmq 4.1.0.                        
     CZMQ_EXPORT void
         zsock_set_connect_rid_bin (void *self, const byte *connect_rid);
     
     //  Get socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_handshake_ivl (void *self);
     
     //  Set socket option `handshake_ivl`.
+    //  Available from libzmq 4.1.0.      
     CZMQ_EXPORT void
         zsock_set_handshake_ivl (void *self, int handshake_ivl);
     
     //  Get socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_socks_proxy (void *self);
     
     //  Set socket option `socks_proxy`.
+    //  Available from libzmq 4.1.0.    
     CZMQ_EXPORT void
         zsock_set_socks_proxy (void *self, const char *socks_proxy);
     
     //  Set socket option `xpub_nodrop`.
+    //  Available from libzmq 4.1.0.    
     CZMQ_EXPORT void
         zsock_set_xpub_nodrop (void *self, int xpub_nodrop);
     
     //  Set socket option `router_mandatory`.
+    //  Available from libzmq 4.0.0.         
     CZMQ_EXPORT void
         zsock_set_router_mandatory (void *self, int router_mandatory);
     
     //  Set socket option `probe_router`.
+    //  Available from libzmq 4.0.0.     
     CZMQ_EXPORT void
         zsock_set_probe_router (void *self, int probe_router);
     
     //  Set socket option `req_relaxed`.
+    //  Available from libzmq 4.0.0.    
     CZMQ_EXPORT void
         zsock_set_req_relaxed (void *self, int req_relaxed);
     
     //  Set socket option `req_correlate`.
+    //  Available from libzmq 4.0.0.      
     CZMQ_EXPORT void
         zsock_set_req_correlate (void *self, int req_correlate);
     
     //  Set socket option `conflate`.
+    //  Available from libzmq 4.0.0. 
     CZMQ_EXPORT void
         zsock_set_conflate (void *self, int conflate);
     
     //  Get socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_zap_domain (void *self);
     
     //  Set socket option `zap_domain`.
+    //  Available from libzmq 4.0.0.   
     CZMQ_EXPORT void
         zsock_set_zap_domain (void *self, const char *zap_domain);
     
     //  Get socket option `mechanism`.
+    //  Available from libzmq 4.0.0.  
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_mechanism (void *self);
     
     //  Get socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_plain_server (void *self);
     
     //  Set socket option `plain_server`.
+    //  Available from libzmq 4.0.0.     
     CZMQ_EXPORT void
         zsock_set_plain_server (void *self, int plain_server);
     
     //  Get socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_plain_username (void *self);
     
     //  Set socket option `plain_username`.
+    //  Available from libzmq 4.0.0.       
     CZMQ_EXPORT void
         zsock_set_plain_username (void *self, const char *plain_username);
     
     //  Get socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_plain_password (void *self);
     
     //  Set socket option `plain_password`.
+    //  Available from libzmq 4.0.0.       
     CZMQ_EXPORT void
         zsock_set_plain_password (void *self, const char *plain_password);
     
     //  Get socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_curve_server (void *self);
     
     //  Set socket option `curve_server`.
+    //  Available from libzmq 4.0.0.     
     CZMQ_EXPORT void
         zsock_set_curve_server (void *self, int curve_server);
     
     //  Get socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_curve_publickey (void *self);
     
     //  Set socket option `curve_publickey`.
+    //  Available from libzmq 4.0.0.        
     CZMQ_EXPORT void
         zsock_set_curve_publickey (void *self, const char *curve_publickey);
     
     //  Set socket option `curve_publickey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     CZMQ_EXPORT void
         zsock_set_curve_publickey_bin (void *self, const byte *curve_publickey);
     
     //  Get socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_curve_secretkey (void *self);
     
     //  Set socket option `curve_secretkey`.
+    //  Available from libzmq 4.0.0.        
     CZMQ_EXPORT void
         zsock_set_curve_secretkey (void *self, const char *curve_secretkey);
     
     //  Set socket option `curve_secretkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     CZMQ_EXPORT void
         zsock_set_curve_secretkey_bin (void *self, const byte *curve_secretkey);
     
     //  Get socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_curve_serverkey (void *self);
     
     //  Set socket option `curve_serverkey`.
+    //  Available from libzmq 4.0.0.        
     CZMQ_EXPORT void
         zsock_set_curve_serverkey (void *self, const char *curve_serverkey);
     
     //  Set socket option `curve_serverkey` from 32-octet binary
+    //  Available from libzmq 4.0.0.                            
     CZMQ_EXPORT void
         zsock_set_curve_serverkey_bin (void *self, const byte *curve_serverkey);
     
     //  Get socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_gssapi_server (void *self);
     
     //  Set socket option `gssapi_server`.
+    //  Available from libzmq 4.0.0.      
     CZMQ_EXPORT void
         zsock_set_gssapi_server (void *self, int gssapi_server);
     
     //  Get socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_gssapi_plaintext (void *self);
     
     //  Set socket option `gssapi_plaintext`.
+    //  Available from libzmq 4.0.0.         
     CZMQ_EXPORT void
         zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext);
     
     //  Get socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_gssapi_principal (void *self);
     
     //  Set socket option `gssapi_principal`.
+    //  Available from libzmq 4.0.0.         
     CZMQ_EXPORT void
         zsock_set_gssapi_principal (void *self, const char *gssapi_principal);
     
     //  Get socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_gssapi_service_principal (void *self);
     
     //  Set socket option `gssapi_service_principal`.
+    //  Available from libzmq 4.0.0.                 
     CZMQ_EXPORT void
         zsock_set_gssapi_service_principal (void *self, const char *gssapi_service_principal);
     
-    //  Get socket option `ipv6`.
+    //  Get socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_ipv6 (void *self);
     
-    //  Set socket option `ipv6`.
+    //  Set socket option `ipv6`.   
+    //  Available from libzmq 4.0.0.
     CZMQ_EXPORT void
         zsock_set_ipv6 (void *self, int ipv6);
     
     //  Get socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_immediate (void *self);
     
     //  Set socket option `immediate`.
+    //  Available from libzmq 4.0.0.  
     CZMQ_EXPORT void
         zsock_set_immediate (void *self, int immediate);
     
-    //  Set socket option `router_raw`.
-    CZMQ_EXPORT void
-        zsock_set_router_raw (void *self, int router_raw);
-    
-    //  Get socket option `ipv4only`.
-    //  Caller owns return value and must destroy it when done.
-    CZMQ_EXPORT int
-        zsock_ipv4only (void *self);
-    
-    //  Set socket option `ipv4only`.
-    CZMQ_EXPORT void
-        zsock_set_ipv4only (void *self, int ipv4only);
-    
-    //  Set socket option `delay_attach_on_connect`.
-    CZMQ_EXPORT void
-        zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
-    
-    //  Get socket option `type`.
+    //  Get socket option `type`.   
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_type (void *self);
     
-    //  Get socket option `sndhwm`.
+    //  Get socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_sndhwm (void *self);
     
-    //  Set socket option `sndhwm`.
+    //  Set socket option `sndhwm`. 
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_sndhwm (void *self, int sndhwm);
     
-    //  Get socket option `rcvhwm`.
+    //  Get socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_rcvhwm (void *self);
     
-    //  Set socket option `rcvhwm`.
+    //  Set socket option `rcvhwm`. 
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_rcvhwm (void *self, int rcvhwm);
     
     //  Get socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_affinity (void *self);
     
     //  Set socket option `affinity`.
+    //  Available from libzmq 3.0.0. 
     CZMQ_EXPORT void
         zsock_set_affinity (void *self, int affinity);
     
     //  Set socket option `subscribe`.
+    //  Available from libzmq 3.0.0.  
     CZMQ_EXPORT void
         zsock_set_subscribe (void *self, const char *subscribe);
     
     //  Set socket option `unsubscribe`.
+    //  Available from libzmq 3.0.0.    
     CZMQ_EXPORT void
         zsock_set_unsubscribe (void *self, const char *unsubscribe);
     
     //  Get socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_identity (void *self);
     
     //  Set socket option `identity`.
+    //  Available from libzmq 3.0.0. 
     CZMQ_EXPORT void
         zsock_set_identity (void *self, const char *identity);
     
-    //  Get socket option `rate`.
+    //  Get socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_rate (void *self);
     
-    //  Set socket option `rate`.
+    //  Set socket option `rate`.   
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_rate (void *self, int rate);
     
     //  Get socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_recovery_ivl (void *self);
     
     //  Set socket option `recovery_ivl`.
+    //  Available from libzmq 3.0.0.     
     CZMQ_EXPORT void
         zsock_set_recovery_ivl (void *self, int recovery_ivl);
     
-    //  Get socket option `sndbuf`.
+    //  Get socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_sndbuf (void *self);
     
-    //  Set socket option `sndbuf`.
+    //  Set socket option `sndbuf`. 
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_sndbuf (void *self, int sndbuf);
     
-    //  Get socket option `rcvbuf`.
+    //  Get socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_rcvbuf (void *self);
     
-    //  Set socket option `rcvbuf`.
+    //  Set socket option `rcvbuf`. 
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_rcvbuf (void *self, int rcvbuf);
     
-    //  Get socket option `linger`.
+    //  Get socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_linger (void *self);
     
-    //  Set socket option `linger`.
+    //  Set socket option `linger`. 
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_linger (void *self, int linger);
     
     //  Get socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_reconnect_ivl (void *self);
     
     //  Set socket option `reconnect_ivl`.
+    //  Available from libzmq 3.0.0.      
     CZMQ_EXPORT void
         zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
     
     //  Get socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_reconnect_ivl_max (void *self);
     
     //  Set socket option `reconnect_ivl_max`.
+    //  Available from libzmq 3.0.0.          
     CZMQ_EXPORT void
         zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
     
     //  Get socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_backlog (void *self);
     
     //  Set socket option `backlog`.
+    //  Available from libzmq 3.0.0.
     CZMQ_EXPORT void
         zsock_set_backlog (void *self, int backlog);
     
     //  Get socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_maxmsgsize (void *self);
     
     //  Set socket option `maxmsgsize`.
+    //  Available from libzmq 3.0.0.   
     CZMQ_EXPORT void
         zsock_set_maxmsgsize (void *self, int maxmsgsize);
     
     //  Get socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_multicast_hops (void *self);
     
     //  Set socket option `multicast_hops`.
+    //  Available from libzmq 3.0.0.       
     CZMQ_EXPORT void
         zsock_set_multicast_hops (void *self, int multicast_hops);
     
     //  Get socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_rcvtimeo (void *self);
     
     //  Set socket option `rcvtimeo`.
+    //  Available from libzmq 3.0.0. 
     CZMQ_EXPORT void
         zsock_set_rcvtimeo (void *self, int rcvtimeo);
     
     //  Get socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_sndtimeo (void *self);
     
     //  Set socket option `sndtimeo`.
+    //  Available from libzmq 3.0.0. 
     CZMQ_EXPORT void
         zsock_set_sndtimeo (void *self, int sndtimeo);
     
     //  Set socket option `xpub_verbose`.
+    //  Available from libzmq 3.0.0.     
     CZMQ_EXPORT void
         zsock_set_xpub_verbose (void *self, int xpub_verbose);
     
     //  Get socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tcp_keepalive (void *self);
     
     //  Set socket option `tcp_keepalive`.
+    //  Available from libzmq 3.0.0.      
     CZMQ_EXPORT void
         zsock_set_tcp_keepalive (void *self, int tcp_keepalive);
     
     //  Get socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tcp_keepalive_idle (void *self);
     
     //  Set socket option `tcp_keepalive_idle`.
+    //  Available from libzmq 3.0.0.           
     CZMQ_EXPORT void
         zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle);
     
     //  Get socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tcp_keepalive_cnt (void *self);
     
     //  Set socket option `tcp_keepalive_cnt`.
+    //  Available from libzmq 3.0.0.          
     CZMQ_EXPORT void
         zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt);
     
     //  Get socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_tcp_keepalive_intvl (void *self);
     
     //  Set socket option `tcp_keepalive_intvl`.
+    //  Available from libzmq 3.0.0.            
     CZMQ_EXPORT void
         zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl);
     
     //  Get socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_tcp_accept_filter (void *self);
     
     //  Set socket option `tcp_accept_filter`.
+    //  Available from libzmq 3.0.0.          
     CZMQ_EXPORT void
         zsock_set_tcp_accept_filter (void *self, const char *tcp_accept_filter);
     
     //  Get socket option `rcvmore`.
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_rcvmore (void *self);
     
-    //  Get socket option `fd`.
+    //  Get socket option `fd`.     
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT SOCKET
         zsock_fd (void *self);
     
-    //  Get socket option `events`.
+    //  Get socket option `events`. 
+    //  Available from libzmq 3.0.0.
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT int
         zsock_events (void *self);
     
     //  Get socket option `last_endpoint`.
+    //  Available from libzmq 3.0.0.      
     //  Caller owns return value and must destroy it when done.
     CZMQ_EXPORT char *
         zsock_last_endpoint (void *self);
+    
+    //  Set socket option `router_raw`.
+    //  Available from libzmq 3.0.0.   
+    CZMQ_EXPORT void
+        zsock_set_router_raw (void *self, int router_raw);
+    
+    //  Get socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
+    //  Caller owns return value and must destroy it when done.
+    CZMQ_EXPORT int
+        zsock_ipv4only (void *self);
+    
+    //  Set socket option `ipv4only`.
+    //  Available from libzmq 3.0.0. 
+    CZMQ_EXPORT void
+        zsock_set_ipv4only (void *self, int ipv4only);
+    
+    //  Set socket option `delay_attach_on_connect`.
+    //  Available from libzmq 3.0.0.                
+    CZMQ_EXPORT void
+        zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
     
     //  Self test of this class.
     CZMQ_EXPORT void

--- a/doc/zsock.txt
+++ b/doc/zsock.txt
@@ -280,582 +280,712 @@ CZMQ_EXPORT void *
     zsock_resolve (void *self);
 
 //  Get socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_ivl (void *self);
 
 //  Set socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
 
 //  Get socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_ttl (void *self);
 
 //  Set socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
 
 //  Get socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_timeout (void *self);
 
 //  Set socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 CZMQ_EXPORT void
     zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
 
-//  Get socket option `use_fd`.
+//  Get socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_use_fd (void *self);
 
-//  Set socket option `use_fd`.
+//  Set socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 CZMQ_EXPORT void
     zsock_set_use_fd (void *self, int use_fd);
 
 //  Set socket option `xpub_manual`.
+//  Available from libzmq 4.2.0.    
 CZMQ_EXPORT void
     zsock_set_xpub_manual (void *self, int xpub_manual);
 
 //  Set socket option `xpub_welcome_msg`.
+//  Available from libzmq 4.2.0.         
 CZMQ_EXPORT void
     zsock_set_xpub_welcome_msg (void *self, const char *xpub_welcome_msg);
 
 //  Set socket option `stream_notify`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_stream_notify (void *self, int stream_notify);
 
 //  Get socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_invert_matching (void *self);
 
 //  Set socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 CZMQ_EXPORT void
     zsock_set_invert_matching (void *self, int invert_matching);
 
 //  Set socket option `xpub_verboser`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_xpub_verboser (void *self, int xpub_verboser);
 
 //  Get socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_connect_timeout (void *self);
 
 //  Set socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 CZMQ_EXPORT void
     zsock_set_connect_timeout (void *self, int connect_timeout);
 
 //  Get socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_maxrt (void *self);
 
 //  Set socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 CZMQ_EXPORT void
     zsock_set_tcp_maxrt (void *self, int tcp_maxrt);
 
 //  Get socket option `thread_safe`.
+//  Available from libzmq 4.2.0.    
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_thread_safe (void *self);
 
 //  Get socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_multicast_maxtpdu (void *self);
 
 //  Set socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 CZMQ_EXPORT void
     zsock_set_multicast_maxtpdu (void *self, int multicast_maxtpdu);
 
 //  Get socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_size (void *self);
 
 //  Set socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_size (void *self, int vmci_buffer_size);
 
 //  Get socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_min_size (void *self);
 
 //  Set socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_min_size (void *self, int vmci_buffer_min_size);
 
 //  Get socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_max_size (void *self);
 
 //  Set socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_max_size (void *self, int vmci_buffer_max_size);
 
 //  Get socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_connect_timeout (void *self);
 
 //  Set socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_connect_timeout (void *self, int vmci_connect_timeout);
 
-//  Get socket option `tos`.
+//  Get socket option `tos`.    
+//  Available from libzmq 4.1.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tos (void *self);
 
-//  Set socket option `tos`.
+//  Set socket option `tos`.    
+//  Available from libzmq 4.1.0.
 CZMQ_EXPORT void
     zsock_set_tos (void *self, int tos);
 
 //  Set socket option `router_handover`.
+//  Available from libzmq 4.1.0.        
 CZMQ_EXPORT void
     zsock_set_router_handover (void *self, int router_handover);
 
 //  Set socket option `connect_rid`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_connect_rid (void *self, const char *connect_rid);
 
 //  Set socket option `connect_rid` from 32-octet binary
+//  Available from libzmq 4.1.0.                        
 CZMQ_EXPORT void
     zsock_set_connect_rid_bin (void *self, const byte *connect_rid);
 
 //  Get socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_handshake_ivl (void *self);
 
 //  Set socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 CZMQ_EXPORT void
     zsock_set_handshake_ivl (void *self, int handshake_ivl);
 
 //  Get socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_socks_proxy (void *self);
 
 //  Set socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_socks_proxy (void *self, const char *socks_proxy);
 
 //  Set socket option `xpub_nodrop`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_xpub_nodrop (void *self, int xpub_nodrop);
 
 //  Set socket option `router_mandatory`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_router_mandatory (void *self, int router_mandatory);
 
 //  Set socket option `probe_router`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_probe_router (void *self, int probe_router);
 
 //  Set socket option `req_relaxed`.
+//  Available from libzmq 4.0.0.    
 CZMQ_EXPORT void
     zsock_set_req_relaxed (void *self, int req_relaxed);
 
 //  Set socket option `req_correlate`.
+//  Available from libzmq 4.0.0.      
 CZMQ_EXPORT void
     zsock_set_req_correlate (void *self, int req_correlate);
 
 //  Set socket option `conflate`.
+//  Available from libzmq 4.0.0. 
 CZMQ_EXPORT void
     zsock_set_conflate (void *self, int conflate);
 
 //  Get socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_zap_domain (void *self);
 
 //  Set socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 CZMQ_EXPORT void
     zsock_set_zap_domain (void *self, const char *zap_domain);
 
 //  Get socket option `mechanism`.
+//  Available from libzmq 4.0.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_mechanism (void *self);
 
 //  Get socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_plain_server (void *self);
 
 //  Set socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_plain_server (void *self, int plain_server);
 
 //  Get socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_plain_username (void *self);
 
 //  Set socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 CZMQ_EXPORT void
     zsock_set_plain_username (void *self, const char *plain_username);
 
 //  Get socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_plain_password (void *self);
 
 //  Set socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 CZMQ_EXPORT void
     zsock_set_plain_password (void *self, const char *plain_password);
 
 //  Get socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_curve_server (void *self);
 
 //  Set socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_curve_server (void *self, int curve_server);
 
 //  Get socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_publickey (void *self);
 
 //  Set socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_publickey (void *self, const char *curve_publickey);
 
 //  Set socket option `curve_publickey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_publickey_bin (void *self, const byte *curve_publickey);
 
 //  Get socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_secretkey (void *self);
 
 //  Set socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_secretkey (void *self, const char *curve_secretkey);
 
 //  Set socket option `curve_secretkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_secretkey_bin (void *self, const byte *curve_secretkey);
 
 //  Get socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_serverkey (void *self);
 
 //  Set socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_serverkey (void *self, const char *curve_serverkey);
 
 //  Set socket option `curve_serverkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_serverkey_bin (void *self, const byte *curve_serverkey);
 
 //  Get socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_gssapi_server (void *self);
 
 //  Set socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 CZMQ_EXPORT void
     zsock_set_gssapi_server (void *self, int gssapi_server);
 
 //  Get socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_gssapi_plaintext (void *self);
 
 //  Set socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext);
 
 //  Get socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_gssapi_principal (void *self);
 
 //  Set socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_gssapi_principal (void *self, const char *gssapi_principal);
 
 //  Get socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_gssapi_service_principal (void *self);
 
 //  Set socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 CZMQ_EXPORT void
     zsock_set_gssapi_service_principal (void *self, const char *gssapi_service_principal);
 
-//  Get socket option `ipv6`.
+//  Get socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_ipv6 (void *self);
 
-//  Set socket option `ipv6`.
+//  Set socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 CZMQ_EXPORT void
     zsock_set_ipv6 (void *self, int ipv6);
 
 //  Get socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_immediate (void *self);
 
 //  Set socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 CZMQ_EXPORT void
     zsock_set_immediate (void *self, int immediate);
 
-//  Set socket option `router_raw`.
-CZMQ_EXPORT void
-    zsock_set_router_raw (void *self, int router_raw);
-
-//  Get socket option `ipv4only`.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_ipv4only (void *self);
-
-//  Set socket option `ipv4only`.
-CZMQ_EXPORT void
-    zsock_set_ipv4only (void *self, int ipv4only);
-
-//  Set socket option `delay_attach_on_connect`.
-CZMQ_EXPORT void
-    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
-
-//  Get socket option `type`.
+//  Get socket option `type`.   
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_type (void *self);
 
-//  Get socket option `sndhwm`.
+//  Get socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndhwm (void *self);
 
-//  Set socket option `sndhwm`.
+//  Set socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_sndhwm (void *self, int sndhwm);
 
-//  Get socket option `rcvhwm`.
+//  Get socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvhwm (void *self);
 
-//  Set socket option `rcvhwm`.
+//  Set socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rcvhwm (void *self, int rcvhwm);
 
 //  Get socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_affinity (void *self);
 
 //  Set socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_affinity (void *self, int affinity);
 
 //  Set socket option `subscribe`.
+//  Available from libzmq 3.0.0.  
 CZMQ_EXPORT void
     zsock_set_subscribe (void *self, const char *subscribe);
 
 //  Set socket option `unsubscribe`.
+//  Available from libzmq 3.0.0.    
 CZMQ_EXPORT void
     zsock_set_unsubscribe (void *self, const char *unsubscribe);
 
 //  Get socket option `identity`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_identity (void *self);
 
 //  Set socket option `identity`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_identity (void *self, const char *identity);
 
-//  Get socket option `rate`.
+//  Get socket option `rate`.   
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rate (void *self);
 
-//  Set socket option `rate`.
+//  Set socket option `rate`.   
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rate (void *self, int rate);
 
 //  Get socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_recovery_ivl (void *self);
 
 //  Set socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 CZMQ_EXPORT void
     zsock_set_recovery_ivl (void *self, int recovery_ivl);
 
-//  Get socket option `sndbuf`.
+//  Get socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndbuf (void *self);
 
-//  Set socket option `sndbuf`.
+//  Set socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_sndbuf (void *self, int sndbuf);
 
-//  Get socket option `rcvbuf`.
+//  Get socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvbuf (void *self);
 
-//  Set socket option `rcvbuf`.
+//  Set socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rcvbuf (void *self, int rcvbuf);
 
-//  Get socket option `linger`.
+//  Get socket option `linger`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_linger (void *self);
 
-//  Set socket option `linger`.
+//  Set socket option `linger`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_linger (void *self, int linger);
 
 //  Get socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_reconnect_ivl (void *self);
 
 //  Set socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 CZMQ_EXPORT void
     zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
 
 //  Get socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_reconnect_ivl_max (void *self);
 
 //  Set socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
 
 //  Get socket option `backlog`.
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_backlog (void *self);
 
 //  Set socket option `backlog`.
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_backlog (void *self, int backlog);
 
 //  Get socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_maxmsgsize (void *self);
 
 //  Set socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 CZMQ_EXPORT void
     zsock_set_maxmsgsize (void *self, int maxmsgsize);
 
 //  Get socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_multicast_hops (void *self);
 
 //  Set socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 CZMQ_EXPORT void
     zsock_set_multicast_hops (void *self, int multicast_hops);
 
 //  Get socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvtimeo (void *self);
 
 //  Set socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_rcvtimeo (void *self, int rcvtimeo);
 
 //  Get socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndtimeo (void *self);
 
 //  Set socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_sndtimeo (void *self, int sndtimeo);
 
 //  Set socket option `xpub_verbose`.
+//  Available from libzmq 3.0.0.     
 CZMQ_EXPORT void
     zsock_set_xpub_verbose (void *self, int xpub_verbose);
 
 //  Get socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive (void *self);
 
 //  Set socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive (void *self, int tcp_keepalive);
 
 //  Get socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_idle (void *self);
 
 //  Set socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle);
 
 //  Get socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_cnt (void *self);
 
 //  Set socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt);
 
 //  Get socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_intvl (void *self);
 
 //  Set socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl);
 
 //  Get socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_tcp_accept_filter (void *self);
 
 //  Set socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_tcp_accept_filter (void *self, const char *tcp_accept_filter);
 
 //  Get socket option `rcvmore`.
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvmore (void *self);
 
-//  Get socket option `fd`.
+//  Get socket option `fd`.     
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT SOCKET
     zsock_fd (void *self);
 
-//  Get socket option `events`.
+//  Get socket option `events`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_events (void *self);
 
 //  Get socket option `last_endpoint`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_last_endpoint (void *self);
+
+//  Set socket option `router_raw`.
+//  Available from libzmq 3.0.0.   
+CZMQ_EXPORT void
+    zsock_set_router_raw (void *self, int router_raw);
+
+//  Get socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_ipv4only (void *self);
+
+//  Set socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
+CZMQ_EXPORT void
+    zsock_set_ipv4only (void *self, int ipv4only);
+
+//  Set socket option `delay_attach_on_connect`.
+//  Available from libzmq 3.0.0.                
+CZMQ_EXPORT void
+    zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 
 //  Self test of this class.
 CZMQ_EXPORT void

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -299,580 +299,710 @@ CZMQ_EXPORT void *
     zsock_resolve (void *self);
 
 //  Get socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_ivl (void *self);
 
 //  Set socket option `heartbeat_ivl`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_heartbeat_ivl (void *self, int heartbeat_ivl);
 
 //  Get socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_ttl (void *self);
 
 //  Set socket option `heartbeat_ttl`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_heartbeat_ttl (void *self, int heartbeat_ttl);
 
 //  Get socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_heartbeat_timeout (void *self);
 
 //  Set socket option `heartbeat_timeout`.
+//  Available from libzmq 4.2.0.          
 CZMQ_EXPORT void
     zsock_set_heartbeat_timeout (void *self, int heartbeat_timeout);
 
-//  Get socket option `use_fd`.
+//  Get socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_use_fd (void *self);
 
-//  Set socket option `use_fd`.
+//  Set socket option `use_fd`. 
+//  Available from libzmq 4.2.0.
 CZMQ_EXPORT void
     zsock_set_use_fd (void *self, int use_fd);
 
 //  Set socket option `xpub_manual`.
+//  Available from libzmq 4.2.0.    
 CZMQ_EXPORT void
     zsock_set_xpub_manual (void *self, int xpub_manual);
 
 //  Set socket option `xpub_welcome_msg`.
+//  Available from libzmq 4.2.0.         
 CZMQ_EXPORT void
     zsock_set_xpub_welcome_msg (void *self, const char *xpub_welcome_msg);
 
 //  Set socket option `stream_notify`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_stream_notify (void *self, int stream_notify);
 
 //  Get socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_invert_matching (void *self);
 
 //  Set socket option `invert_matching`.
+//  Available from libzmq 4.2.0.        
 CZMQ_EXPORT void
     zsock_set_invert_matching (void *self, int invert_matching);
 
 //  Set socket option `xpub_verboser`.
+//  Available from libzmq 4.2.0.      
 CZMQ_EXPORT void
     zsock_set_xpub_verboser (void *self, int xpub_verboser);
 
 //  Get socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_connect_timeout (void *self);
 
 //  Set socket option `connect_timeout`.
+//  Available from libzmq 4.2.0.        
 CZMQ_EXPORT void
     zsock_set_connect_timeout (void *self, int connect_timeout);
 
 //  Get socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_maxrt (void *self);
 
 //  Set socket option `tcp_maxrt`.
+//  Available from libzmq 4.2.0.  
 CZMQ_EXPORT void
     zsock_set_tcp_maxrt (void *self, int tcp_maxrt);
 
 //  Get socket option `thread_safe`.
+//  Available from libzmq 4.2.0.    
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_thread_safe (void *self);
 
 //  Get socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_multicast_maxtpdu (void *self);
 
 //  Set socket option `multicast_maxtpdu`.
+//  Available from libzmq 4.2.0.          
 CZMQ_EXPORT void
     zsock_set_multicast_maxtpdu (void *self, int multicast_maxtpdu);
 
 //  Get socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_size (void *self);
 
 //  Set socket option `vmci_buffer_size`.
+//  Available from libzmq 4.2.0.         
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_size (void *self, int vmci_buffer_size);
 
 //  Get socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_min_size (void *self);
 
 //  Set socket option `vmci_buffer_min_size`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_min_size (void *self, int vmci_buffer_min_size);
 
 //  Get socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_buffer_max_size (void *self);
 
 //  Set socket option `vmci_buffer_max_size`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_buffer_max_size (void *self, int vmci_buffer_max_size);
 
 //  Get socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_vmci_connect_timeout (void *self);
 
 //  Set socket option `vmci_connect_timeout`.
+//  Available from libzmq 4.2.0.             
 CZMQ_EXPORT void
     zsock_set_vmci_connect_timeout (void *self, int vmci_connect_timeout);
 
-//  Get socket option `tos`.
+//  Get socket option `tos`.    
+//  Available from libzmq 4.1.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tos (void *self);
 
-//  Set socket option `tos`.
+//  Set socket option `tos`.    
+//  Available from libzmq 4.1.0.
 CZMQ_EXPORT void
     zsock_set_tos (void *self, int tos);
 
 //  Set socket option `router_handover`.
+//  Available from libzmq 4.1.0.        
 CZMQ_EXPORT void
     zsock_set_router_handover (void *self, int router_handover);
 
 //  Set socket option `connect_rid`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_connect_rid (void *self, const char *connect_rid);
 
 //  Set socket option `connect_rid` from 32-octet binary
+//  Available from libzmq 4.1.0.                        
 CZMQ_EXPORT void
     zsock_set_connect_rid_bin (void *self, const byte *connect_rid);
 
 //  Get socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_handshake_ivl (void *self);
 
 //  Set socket option `handshake_ivl`.
+//  Available from libzmq 4.1.0.      
 CZMQ_EXPORT void
     zsock_set_handshake_ivl (void *self, int handshake_ivl);
 
 //  Get socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_socks_proxy (void *self);
 
 //  Set socket option `socks_proxy`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_socks_proxy (void *self, const char *socks_proxy);
 
 //  Set socket option `xpub_nodrop`.
+//  Available from libzmq 4.1.0.    
 CZMQ_EXPORT void
     zsock_set_xpub_nodrop (void *self, int xpub_nodrop);
 
 //  Set socket option `router_mandatory`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_router_mandatory (void *self, int router_mandatory);
 
 //  Set socket option `probe_router`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_probe_router (void *self, int probe_router);
 
 //  Set socket option `req_relaxed`.
+//  Available from libzmq 4.0.0.    
 CZMQ_EXPORT void
     zsock_set_req_relaxed (void *self, int req_relaxed);
 
 //  Set socket option `req_correlate`.
+//  Available from libzmq 4.0.0.      
 CZMQ_EXPORT void
     zsock_set_req_correlate (void *self, int req_correlate);
 
 //  Set socket option `conflate`.
+//  Available from libzmq 4.0.0. 
 CZMQ_EXPORT void
     zsock_set_conflate (void *self, int conflate);
 
 //  Get socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_zap_domain (void *self);
 
 //  Set socket option `zap_domain`.
+//  Available from libzmq 4.0.0.   
 CZMQ_EXPORT void
     zsock_set_zap_domain (void *self, const char *zap_domain);
 
 //  Get socket option `mechanism`.
+//  Available from libzmq 4.0.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_mechanism (void *self);
 
 //  Get socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_plain_server (void *self);
 
 //  Set socket option `plain_server`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_plain_server (void *self, int plain_server);
 
 //  Get socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_plain_username (void *self);
 
 //  Set socket option `plain_username`.
+//  Available from libzmq 4.0.0.       
 CZMQ_EXPORT void
     zsock_set_plain_username (void *self, const char *plain_username);
 
 //  Get socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_plain_password (void *self);
 
 //  Set socket option `plain_password`.
+//  Available from libzmq 4.0.0.       
 CZMQ_EXPORT void
     zsock_set_plain_password (void *self, const char *plain_password);
 
 //  Get socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_curve_server (void *self);
 
 //  Set socket option `curve_server`.
+//  Available from libzmq 4.0.0.     
 CZMQ_EXPORT void
     zsock_set_curve_server (void *self, int curve_server);
 
 //  Get socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_publickey (void *self);
 
 //  Set socket option `curve_publickey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_publickey (void *self, const char *curve_publickey);
 
 //  Set socket option `curve_publickey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_publickey_bin (void *self, const byte *curve_publickey);
 
 //  Get socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_secretkey (void *self);
 
 //  Set socket option `curve_secretkey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_secretkey (void *self, const char *curve_secretkey);
 
 //  Set socket option `curve_secretkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_secretkey_bin (void *self, const byte *curve_secretkey);
 
 //  Get socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_curve_serverkey (void *self);
 
 //  Set socket option `curve_serverkey`.
+//  Available from libzmq 4.0.0.        
 CZMQ_EXPORT void
     zsock_set_curve_serverkey (void *self, const char *curve_serverkey);
 
 //  Set socket option `curve_serverkey` from 32-octet binary
+//  Available from libzmq 4.0.0.                            
 CZMQ_EXPORT void
     zsock_set_curve_serverkey_bin (void *self, const byte *curve_serverkey);
 
 //  Get socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_gssapi_server (void *self);
 
 //  Set socket option `gssapi_server`.
+//  Available from libzmq 4.0.0.      
 CZMQ_EXPORT void
     zsock_set_gssapi_server (void *self, int gssapi_server);
 
 //  Get socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_gssapi_plaintext (void *self);
 
 //  Set socket option `gssapi_plaintext`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_gssapi_plaintext (void *self, int gssapi_plaintext);
 
 //  Get socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_gssapi_principal (void *self);
 
 //  Set socket option `gssapi_principal`.
+//  Available from libzmq 4.0.0.         
 CZMQ_EXPORT void
     zsock_set_gssapi_principal (void *self, const char *gssapi_principal);
 
 //  Get socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_gssapi_service_principal (void *self);
 
 //  Set socket option `gssapi_service_principal`.
+//  Available from libzmq 4.0.0.                 
 CZMQ_EXPORT void
     zsock_set_gssapi_service_principal (void *self, const char *gssapi_service_principal);
 
-//  Get socket option `ipv6`.
+//  Get socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_ipv6 (void *self);
 
-//  Set socket option `ipv6`.
+//  Set socket option `ipv6`.   
+//  Available from libzmq 4.0.0.
 CZMQ_EXPORT void
     zsock_set_ipv6 (void *self, int ipv6);
 
 //  Get socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_immediate (void *self);
 
 //  Set socket option `immediate`.
+//  Available from libzmq 4.0.0.  
 CZMQ_EXPORT void
     zsock_set_immediate (void *self, int immediate);
 
-//  Get socket option `type`.
+//  Get socket option `type`.   
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_type (void *self);
 
-//  Get socket option `sndhwm`.
+//  Get socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndhwm (void *self);
 
-//  Set socket option `sndhwm`.
+//  Set socket option `sndhwm`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_sndhwm (void *self, int sndhwm);
 
-//  Get socket option `rcvhwm`.
+//  Get socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvhwm (void *self);
 
-//  Set socket option `rcvhwm`.
+//  Set socket option `rcvhwm`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rcvhwm (void *self, int rcvhwm);
 
 //  Get socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_affinity (void *self);
 
 //  Set socket option `affinity`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_affinity (void *self, int affinity);
 
 //  Set socket option `subscribe`.
+//  Available from libzmq 3.0.0.  
 CZMQ_EXPORT void
     zsock_set_subscribe (void *self, const char *subscribe);
 
 //  Set socket option `unsubscribe`.
+//  Available from libzmq 3.0.0.    
 CZMQ_EXPORT void
     zsock_set_unsubscribe (void *self, const char *unsubscribe);
 
 //  Get socket option `identity`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_identity (void *self);
 
 //  Set socket option `identity`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_identity (void *self, const char *identity);
 
-//  Get socket option `rate`.
+//  Get socket option `rate`.   
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rate (void *self);
 
-//  Set socket option `rate`.
+//  Set socket option `rate`.   
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rate (void *self, int rate);
 
 //  Get socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_recovery_ivl (void *self);
 
 //  Set socket option `recovery_ivl`.
+//  Available from libzmq 3.0.0.     
 CZMQ_EXPORT void
     zsock_set_recovery_ivl (void *self, int recovery_ivl);
 
-//  Get socket option `sndbuf`.
+//  Get socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndbuf (void *self);
 
-//  Set socket option `sndbuf`.
+//  Set socket option `sndbuf`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_sndbuf (void *self, int sndbuf);
 
-//  Get socket option `rcvbuf`.
+//  Get socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvbuf (void *self);
 
-//  Set socket option `rcvbuf`.
+//  Set socket option `rcvbuf`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_rcvbuf (void *self, int rcvbuf);
 
-//  Get socket option `linger`.
+//  Get socket option `linger`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_linger (void *self);
 
-//  Set socket option `linger`.
+//  Set socket option `linger`. 
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_linger (void *self, int linger);
 
 //  Get socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_reconnect_ivl (void *self);
 
 //  Set socket option `reconnect_ivl`.
+//  Available from libzmq 3.0.0.      
 CZMQ_EXPORT void
     zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
 
 //  Get socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_reconnect_ivl_max (void *self);
 
 //  Set socket option `reconnect_ivl_max`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
 
 //  Get socket option `backlog`.
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_backlog (void *self);
 
 //  Set socket option `backlog`.
+//  Available from libzmq 3.0.0.
 CZMQ_EXPORT void
     zsock_set_backlog (void *self, int backlog);
 
 //  Get socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_maxmsgsize (void *self);
 
 //  Set socket option `maxmsgsize`.
+//  Available from libzmq 3.0.0.   
 CZMQ_EXPORT void
     zsock_set_maxmsgsize (void *self, int maxmsgsize);
 
 //  Get socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_multicast_hops (void *self);
 
 //  Set socket option `multicast_hops`.
+//  Available from libzmq 3.0.0.       
 CZMQ_EXPORT void
     zsock_set_multicast_hops (void *self, int multicast_hops);
 
 //  Get socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvtimeo (void *self);
 
 //  Set socket option `rcvtimeo`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_rcvtimeo (void *self, int rcvtimeo);
 
 //  Get socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_sndtimeo (void *self);
 
 //  Set socket option `sndtimeo`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_sndtimeo (void *self, int sndtimeo);
 
 //  Set socket option `xpub_verbose`.
+//  Available from libzmq 3.0.0.     
 CZMQ_EXPORT void
     zsock_set_xpub_verbose (void *self, int xpub_verbose);
 
 //  Get socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive (void *self);
 
 //  Set socket option `tcp_keepalive`.
+//  Available from libzmq 3.0.0.      
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive (void *self, int tcp_keepalive);
 
 //  Get socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_idle (void *self);
 
 //  Set socket option `tcp_keepalive_idle`.
+//  Available from libzmq 3.0.0.           
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_idle (void *self, int tcp_keepalive_idle);
 
 //  Get socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_cnt (void *self);
 
 //  Set socket option `tcp_keepalive_cnt`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_cnt (void *self, int tcp_keepalive_cnt);
 
 //  Get socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_tcp_keepalive_intvl (void *self);
 
 //  Set socket option `tcp_keepalive_intvl`.
+//  Available from libzmq 3.0.0.            
 CZMQ_EXPORT void
     zsock_set_tcp_keepalive_intvl (void *self, int tcp_keepalive_intvl);
 
 //  Get socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_tcp_accept_filter (void *self);
 
 //  Set socket option `tcp_accept_filter`.
+//  Available from libzmq 3.0.0.          
 CZMQ_EXPORT void
     zsock_set_tcp_accept_filter (void *self, const char *tcp_accept_filter);
 
 //  Get socket option `rcvmore`.
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_rcvmore (void *self);
 
-//  Get socket option `fd`.
+//  Get socket option `fd`.     
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT SOCKET
     zsock_fd (void *self);
 
-//  Get socket option `events`.
+//  Get socket option `events`. 
+//  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_events (void *self);
 
 //  Get socket option `last_endpoint`.
+//  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zsock_last_endpoint (void *self);
 
 //  Set socket option `router_raw`.
+//  Available from libzmq 3.0.0.   
 CZMQ_EXPORT void
     zsock_set_router_raw (void *self, int router_raw);
 
 //  Get socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT int
     zsock_ipv4only (void *self);
 
 //  Set socket option `ipv4only`.
+//  Available from libzmq 3.0.0. 
 CZMQ_EXPORT void
     zsock_set_ipv4only (void *self, int ipv4only);
 
 //  Set socket option `delay_attach_on_connect`.
+//  Available from libzmq 3.0.0.                
 CZMQ_EXPORT void
     zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
 

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -71,10 +71,19 @@ to $(major_removed).0.0 \
 .   endif
 -->
 .   for option
+.       if ! defined (.minor)
+.           .minor = 0
+.       endif
+.       if defined (.major_removed)
+.           removed_string = " to $(major_removed).0.0"
+.       else
+.           removed_string = ""
+.       endif
 .       if mode = "rw" | mode = "r"
 
 <method name = "$(option.api_name:)" polymorphic = "1"$(state(option))>
     Get socket option `$(option.name:)`.
+    Available from libzmq $(major).$(minor).0$(removed_string).
     <return type = "$(option.api_type:)" fresh = "1" />
 </method>
 .       endif
@@ -82,6 +91,7 @@ to $(major_removed).0.0 \
 
 <method name = "set $(option.api_name:)" polymorphic = "1"$(state(option))>
     Set socket option `$(option.name:)`.
+    Available from libzmq $(major).$(minor).0$(removed_string).
     <argument name = "$(option.api_name:)" type = "$(option.api_type:)" />
 </method>
 .       endif
@@ -89,6 +99,7 @@ to $(major_removed).0.0 \
 
 <method name = "set $(option.api_name:) bin" polymorphic = "1">
     Set socket option `$(option.name:)` from 32-octet binary
+    Available from libzmq $(major).$(minor).0$(removed_string).
     <argument name = "$(option.api_name:)" type = "buffer" />
 </method>
 .       endif


### PR DESCRIPTION
Solution: for each option state the required minimum (and maximum if
applicable) version of libzmq.