### PR TITLE
Problem: zsock.c tests can be unreliable in 32-bit builds

### DIFF
--- a/src/zhash.c
+++ b/src/zhash.c
@@ -906,6 +906,9 @@ zhash_test (bool verbose)
     srandom ((unsigned) time (NULL));
     for (iteration = 0; iteration < 25000; iteration++) {
         testnbr = randof (testmax);
+        // printf("%d / %d\n", testnbr, testmax);
+        assert(testnbr!=testmax);
+        assert(testnbr<testmax);
         if (testset [testnbr].exists) {
             item = (char *) zhash_lookup (hash, testset [testnbr].name);
             assert (item);

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -1926,9 +1926,12 @@ zsock_test (bool verbose)
     //  Test zsock_send/recv pictures
     uint8_t  number1 = 123;
     uint16_t number2 = 123 * 123;
-    uint32_t number4 = 123 * 123 * 123;
+    uint32_t number4 = 123 * 123;
+    number4 *= 123;
     uint32_t number4_MAX = UINT32_MAX;
-    uint64_t number8 = 123 * 123 * 123 * 123;
+    uint64_t number8 = 123 * 123;
+    number8 *= 123;
+    number8 *= 123;
     uint64_t number8_MAX = UINT64_MAX;
 
     zchunk_t *chunk = zchunk_new ("HELLO", 5);


### PR DESCRIPTION
Solutions: Where I had issues, root out the possible rootcauses, and improve debugging (in case others have similar issues on their platforms)