### PR TITLE
Fixed examples to work with CZMQ API v3

### DIFF
--- a/examples/security/grasslands.c
+++ b/examples/security/grasslands.c
@@ -1,21 +1,23 @@
 //  The Grasslands Pattern
 //
 //  The Classic ZeroMQ model, plain text with no protection at all.
+//
+//  CZMQ APIv3
+//
+//  More info: http://hintjens.com/blog:49#toc2
+//
 
 #include <czmq.h>
 
 int main (void) 
 {
-    //  Create context
-    zctx_t *ctx = zctx_new ();
-    
     //  Create and bind server socket
-    void *server = zsocket_new (ctx, ZMQ_PUSH);
-    zsocket_bind (server, "tcp://*:9000");
+    zsock_t *server = zsock_new (ZMQ_PUSH);
+    zsock_bind (server, "tcp://*:9000");
 
     //  Create and connect client socket
-    void *client = zsocket_new (ctx, ZMQ_PULL);
-    zsocket_connect (client, "tcp://127.0.0.1:9000");
+    zsock_t *client = zsock_new (ZMQ_PULL);
+    zsock_connect (client, "tcp://127.0.0.1:9000");
     
     //  Send a single message from server to client
     zstr_send (server, "Hello");
@@ -24,6 +26,7 @@ int main (void)
     free (message);
     puts ("Grasslands test OK");
     
-    zctx_destroy (&ctx);
+    zsock_destroy (&client);
+    zsock_destroy (&server);
     return 0;
 }

--- a/examples/security/hello.c
+++ b/examples/security/hello.c
@@ -1,10 +1,13 @@
+//
+//  CZMQ APIv3
+//
+
 #include <czmq.h>
 
 int main (void) {
-    zctx_t *ctx = zctx_new ();
-    void *publisher = zsocket_new (ctx, ZMQ_PUB);
-    zsocket_set_curve_server (publisher, true);
+    zsock_t *publisher = zsock_new (ZMQ_PUB);
+    zsock_set_curve_server (publisher, true);
     puts ("Hello, Curve!");
-    zctx_destroy (&ctx);
+    zsock_destroy(&publisher);
     return 0;
 }

--- a/examples/security/ironhouse.c
+++ b/examples/security/ironhouse.c
@@ -2,20 +2,27 @@
 //
 //  Security doesn't get any stronger than this. An attacker is going to
 //  have to break into your systems to see data before/after encryption.
+//
+//  CZMQ APIv3
+//
+//
+//  For more info see: http://hintjens.com/blog:49#toc6
+//
 
 #include <czmq.h>
 
 int main (void) 
 {
-    //  Create context and start authentication engine
-    zctx_t *ctx = zctx_new ();
-    zauth_t *auth = zauth_new (ctx);
-    zauth_set_verbose (auth, true);
-    zauth_allow (auth, "127.0.0.1");
-    
-    //  Tell authenticator to use the certificate store in .curve
-    zauth_configure_curve (auth, "*", ".curve");
-    
+    //  Create and start authentication engine
+    zactor_t *auth = zactor_new (zauth,NULL);
+    zstr_send(auth,"VERBOSE");
+    zsock_wait(auth);
+    zstr_sendx(auth,"ALLOW","127.0.0.1",NULL);
+    zsock_wait(auth);
+
+    //  Tell the authenticator to use the certificate store in .curve
+    zstr_sendx (auth,"CURVE",".curve",NULL);
+
     //  We'll generate a new client certificate and save the public part
     //  in the certificate store (in practice this would be done by hand
     //  or some out-of-band process).
@@ -26,19 +33,19 @@ int main (void)
     
     //  Prepare the server certificate as we did in Stonehouse
     zcert_t *server_cert = zcert_new ();
-    char *server_key = zcert_public_txt (server_cert);
+    const char *server_key = zcert_public_txt (server_cert);
     
     //  Create and bind server socket
-    void *server = zsocket_new (ctx, ZMQ_PUSH);
+    zsock_t *server = zsock_new (ZMQ_PUSH);
     zcert_apply (server_cert, server);
-    zsocket_set_curve_server (server, 1);
-    zsocket_bind (server, "tcp://*:9000");
+    zsock_set_curve_server (server, 1);
+    zsock_bind (server, "tcp://*:9000");
 
     //  Create and connect client socket
-    void *client = zsocket_new (ctx, ZMQ_PULL);
+    zsock_t *client = zsock_new (ZMQ_PULL);
     zcert_apply (client_cert, client);
-    zsocket_set_curve_serverkey (client, server_key);
-    zsocket_connect (client, "tcp://127.0.0.1:9000");
+    zsock_set_curve_serverkey (client, server_key);
+    zsock_connect (client, "tcp://127.0.0.1:9000");
     
     //  Send a single message from server to client
     zstr_send (server, "Hello");
@@ -49,7 +56,9 @@ int main (void)
 
     zcert_destroy (&client_cert);
     zcert_destroy (&server_cert);
-    zauth_destroy (&auth);
-    zctx_destroy (&ctx);
+    zactor_destroy (&auth);
+    zsock_destroy (&client);
+    zsock_destroy (&server);
+
     return 0;
 }

--- a/examples/security/ironhouse2_v2.c
+++ b/examples/security/ironhouse2_v2.c
@@ -1,0 +1,107 @@
+//  The Ironhouse Pattern
+//
+//  This is exactly the same example but broken into two threads
+//  so you can better see what client and server do, separately.
+//
+//  WARNING: CZMQ APIv2 will not compile with the current version of CZMQ
+//
+//
+//  For more info see: http://hintjens.com/blog:49#toc7
+//
+
+#include <czmq.h>
+
+//  The client task runs in its own context, and receives the 
+//  server public key as an argument.
+
+static void *
+client_task (void *args)
+{
+    //  Load our persistent certificate from disk
+    zcert_t *client_cert = zcert_load ("client_cert.txt");
+    assert (client_cert);
+
+    //  Create client socket and configure it to use full encryption
+    zctx_t *ctx = zctx_new ();
+    assert (ctx);
+    void *client = zsocket_new (ctx, ZMQ_PULL);
+    assert (client);
+    zcert_apply (client_cert, client);
+    zsocket_set_curve_serverkey (client, (char *) args);
+    int rc = zsocket_connect (client, "tcp://127.0.0.1:9000");
+    assert (rc == 0);
+
+    //  Wait for our message, that signals the test was successful
+    char *message = zstr_recv (client);
+    assert (streq (message, "Hello"));
+    free (message);
+    puts ("Ironhouse test OK");
+
+    //  Free all memory we used
+    zcert_destroy (&client_cert);
+    zctx_destroy (&ctx);
+    return NULL;
+}
+
+static void *
+server_task (void *args)
+{
+    zctx_t *ctx = zctx_new ();
+    assert (ctx);
+    
+    //  Start the authenticator and tell it do authenticate clients
+    //  via the certificates stored in the .curve directory.
+    zauth_t *auth = zauth_new (ctx);
+    assert (auth);
+    zauth_set_verbose (auth, true);
+    zauth_allow (auth, "127.0.0.1");
+    zauth_configure_curve (auth, "*", ".curve");
+    
+    //  Create server socket and configure it to use full encryption
+    void *server = zsocket_new (ctx, ZMQ_PUSH);
+    assert (server);
+    zcert_apply ((zcert_t *) args, server);
+    zsocket_set_curve_server (server, 1);
+    int rc = zsocket_bind (server, "tcp://*:9000");
+    assert (rc != -1);
+
+    //  Send our test message, just once
+    zstr_send (server, "Hello");
+    zclock_sleep (200);
+    
+    //  Free all memory we used
+    zauth_destroy (&auth);
+    zctx_destroy (&ctx);
+    return NULL;
+}
+
+int main (void) 
+{
+    //  Create the certificate store directory and client certs
+    zcert_t *client_cert = zcert_new ();
+    int rc = zsys_dir_create (".curve");
+    assert (rc == 0);
+    zcert_set_meta (client_cert, "name", "Client test certificate");
+    zcert_save_public (client_cert, ".curve/testcert.pub");
+    rc = zcert_save (client_cert, "client_cert.txt");
+    assert (rc == 0);
+    zcert_destroy (&client_cert);
+
+    //  Create the server certificate
+    zcert_t *server_cert = zcert_new ();
+    
+    //  Now start the two detached threads; each of these has their
+    //  own ZeroMQ context.
+    zthread_new (server_task, server_cert);
+    zthread_new (client_task, zcert_public_txt (server_cert));
+    
+    //  As we're using detached threads this is the simplest way 
+    //  to ensure they both end, before we exit the process. 200
+    //  milliseconds should be enough for anyone. In real code,
+    //  you would use messages to synchronize threads.
+    zclock_sleep (200);
+
+    //  Free the memory we used
+    zcert_destroy (&server_cert);
+    return 0;
+}

--- a/examples/security/stonehouse.c
+++ b/examples/security/stonehouse.c
@@ -3,38 +3,45 @@
 //  Where we allow any clients to connect, but we promise clients
 //  that we are who we claim to be, and our conversations won't be
 //  tampered with or modified, or spied on.
+//
+//  CZMQ APIv3
+//
+//
+//  For more info see: http://hintjens.com/blog:49#toc5
+//
 
 #include <czmq.h>
 
 int main (void) 
 {
-    //  Create context and start authentication engine
-    zctx_t *ctx = zctx_new ();
-    zauth_t *auth = zauth_new (ctx);
-    zauth_set_verbose (auth, true);
-    zauth_allow (auth, "127.0.0.1");
-    
+    //  Create and start authentication engine
+    zactor_t *auth = zactor_new (zauth,NULL);
+    zstr_send(auth,"VERBOSE");
+    zsock_wait(auth);
+    zstr_sendx(auth,"ALLOW","127.0.0.1",NULL);
+    zsock_wait(auth);
+ 
     //  Tell the authenticator how to handle CURVE requests
-    zauth_configure_curve (auth, "*", CURVE_ALLOW_ANY);
+    zstr_sendx (auth,"CURVE",CURVE_ALLOW_ANY,NULL);
 
     //  We need two certificates, one for the client and one for
     //  the server. The client must know the server's public key
     //  to make a CURVE connection.
     zcert_t *client_cert = zcert_new ();
     zcert_t *server_cert = zcert_new ();
-    char *server_key = zcert_public_txt (server_cert);
+    const char *server_key = zcert_public_txt (server_cert);
         
     //  Create and bind server socket
-    void *server = zsocket_new (ctx, ZMQ_PUSH);
+    zsock_t *server = zsock_new (ZMQ_PUSH);
     zcert_apply (server_cert, server);
-    zsocket_set_curve_server (server, 1);
-    zsocket_bind (server, "tcp://*:9000");
+    zsock_set_curve_server (server, 1);
+    zsock_bind (server, "tcp://*:9000");
 
     //  Create and connect client socket
-    void *client = zsocket_new (ctx, ZMQ_PULL);
+    zsock_t *client = zsock_new (ZMQ_PULL);
     zcert_apply (client_cert, client);
-    zsocket_set_curve_serverkey (client, server_key);
-    zsocket_connect (client, "tcp://127.0.0.1:9000");
+    zsock_set_curve_serverkey (client, server_key);
+    zsock_connect (client, "tcp://127.0.0.1:9000");
     
     //  Send a single message from server to client
     zstr_send (server, "Hello");
@@ -45,7 +52,8 @@ int main (void)
 
     zcert_destroy (&client_cert);
     zcert_destroy (&server_cert);
-    zauth_destroy (&auth);
-    zctx_destroy (&ctx);
+    zactor_destroy (&auth);
+    zsock_destroy (&client);
+    zsock_destroy (&server);
     return 0;
 }

--- a/examples/security/strawhouse.c
+++ b/examples/security/strawhouse.c
@@ -3,33 +3,37 @@
 //  We allow or deny clients according to their IP address. It may keep 
 //  spammers and idiots away, but won't stop a real attacker for more 
 //  than a heartbeat.
-
+//
+//  CZMQ APIv3
+//
+//  For more info see: http://hintjens.com/blog:49#toc3
+//
 #include <czmq.h>
 
 int main (void) 
 {
-    //  Create context
-    zctx_t *ctx = zctx_new ();
-    
     //  Start an authentication engine for this context. This engine
     //  allows or denies incoming connections (talking to the libzmq
     //  core over a protocol called ZAP).
-    zauth_t *auth = zauth_new (ctx);
+    zactor_t *auth = zactor_new(zauth,NULL);
     
     //  Get some indication of what the authenticator is deciding
-    zauth_set_verbose (auth, true);
+    zstr_send (auth,"VERBOSE");
+    zsock_wait (auth);
     
     //  Whitelist our address; any other address will be rejected
-    zauth_allow (auth, "127.0.0.1");
-        
+    //  Add as much address as argument as you like before the NULL-Argument
+    //  e.g. zstr_sendx (auth,"127.0.0.1","192.168.1.20",NULL);
+    zstr_sendx (auth,"PLAIN","127.0.0.1",NULL);    
+    zsock_wait (auth);
+    
     //  Create and bind server socket
-    void *server = zsocket_new (ctx, ZMQ_PUSH);
-    zsocket_set_zap_domain (server, "global");
-    zsocket_bind (server, "tcp://*:9000");
+    zsock_t *server = zsock_new (ZMQ_PUSH);
+    zsock_bind (server, "tcp://*:9000");
 
     //  Create and connect client socket
-    void *client = zsocket_new (ctx, ZMQ_PULL);
-    zsocket_connect (client, "tcp://127.0.0.1:9000");
+    zsock_t *client = zsock_new (ZMQ_PULL);
+    zsock_connect (client, "tcp://127.0.0.1:9000");
     
     //  Send a single message from server to client
     zstr_send (server, "Hello");
@@ -38,7 +42,8 @@ int main (void)
     free (message);
     puts ("Strawhouse test OK");
 
-    zauth_destroy (&auth);
-    zctx_destroy (&ctx);
+    zactor_destroy (&auth);
+    zsock_destroy (&client);
+    zsock_destroy (&server);    
     return 0;
 }


### PR DESCRIPTION
The current examples in examples/security do not compile with the current version of CZMQ.
I fixed all samples but the ironhouse2-sample which was using zthread. I'm not familiar with zactor,yet. Therefore I just renamed the file to ironhouse2_v2.c to indicate this file is still based on API v2.