### PR TITLE
Problem: Ruby bindings don't work on Windows

### DIFF
--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -1062,7 +1062,7 @@ module CZMQ
       attach_function :zsock_tcp_accept_filter, [:pointer], :pointer, **opts
       attach_function :zsock_set_tcp_accept_filter, [:pointer, :string], :void, **opts
       attach_function :zsock_rcvmore, [:pointer], :int, **opts
-      attach_function :zsock_fd, [:pointer], (::FFI::Platform.unix? ? :int : :uint64_t), **opts
+      attach_function :zsock_fd, [:pointer], (::FFI::Platform.unix? ? :int : :uint64), **opts
       attach_function :zsock_events, [:pointer], :int, **opts
       attach_function :zsock_last_endpoint, [:pointer], :pointer, **opts
       attach_function :zsock_set_router_raw, [:pointer, :int], :void, **opts


### PR DESCRIPTION
Because :uint64_t type is used. It doesn't exist in ffi gem. We should use :uint64 instead. :uint64 exists in ffi gem.

It has been fixed by zeromq/zproject#771.

Solution: Regenerate Ruby bindings.

Fix #1581
