### PR TITLE
Problem: zhash_autofree implies the value must be a string, but the documentation does not mention this

### DIFF
--- a/README.md
+++ b/README.md
@@ -3017,7 +3017,8 @@ This is the class interface:
     CZMQ_EXPORT int
         zhash_refresh (zhash_t *self);
     
-    //  Set hash for automatic value destruction
+    //  Set hash for automatic value destruction. Note that this assumes that
+    //  values are NULL-terminated strings. Do not use with different types. 
     CZMQ_EXPORT void
         zhash_autofree (zhash_t *self);
     
@@ -3150,6 +3151,8 @@ This is the class self test code:
     srandom ((unsigned) time (NULL));
     for (iteration = 0; iteration < 25000; iteration++) {
         testnbr = randof (testmax);
+        assert (testnbr != testmax);
+        assert (testnbr < testmax);
         if (testset [testnbr].exists) {
             item = (char *) zhash_lookup (hash, testset [testnbr].name);
             assert (item);
@@ -3221,11 +3224,11 @@ This is the class interface:
     typedef int (zhashx_comparator_fn) (
         const void *item1, const void *item2);
     
-    // compare two items, for sorting
+    // Destroy an item.
     typedef void (zhashx_free_fn) (
         void *data);
     
-    // compare two items, for sorting
+    // Hash function for keys.
     typedef size_t (zhashx_hash_fn) (
         const void *key);
     
@@ -7073,9 +7076,12 @@ This is the class self test code:
     //  Test zsock_send/recv pictures
     uint8_t  number1 = 123;
     uint16_t number2 = 123 * 123;
-    uint32_t number4 = 123 * 123 * 123;
-    uint64_t number4_MAX = UINT32_MAX;
-    uint64_t number8 = 123 * 123 * 123 * 123;
+    uint32_t number4 = 123 * 123;
+    number4 *= 123;
+    uint32_t number4_MAX = UINT32_MAX;
+    uint64_t number8 = 123 * 123;
+    number8 *= 123;
+    number8 *= 123;
     uint64_t number8_MAX = UINT64_MAX;
     
     zchunk_t *chunk = zchunk_new ("HELLO", 5);
@@ -7108,7 +7114,7 @@ This is the class self test code:
     byte *data;
     size_t size;
     char *pointer;
-    number8_MAX = number8 = number4 = number2 = number1 = 0;
+    number8_MAX = number8 = number4_MAX = number4 = number2 = number1 = 0ULL;
     rc = zsock_recv (reader, "i124488zsbcfUhp",
                      &integer, &number1, &number2, &number4, &number4_MAX,
                      &number8, &number8_MAX, &string, &data, &size, &chunk,

--- a/api/zhash.api
+++ b/api/zhash.api
@@ -178,6 +178,7 @@
     </method>
 
     <method name = "autofree">
-        Set hash for automatic value destruction
+        Set hash for automatic value destruction. Note that this assumes that
+        values are NULL-terminated strings. Do not use with different types.
     </method>
 </class>

--- a/api/zhashx.api
+++ b/api/zhashx.api
@@ -29,12 +29,12 @@
     </callback_type>
 
     <callback_type name = "free_fn">
-        compare two items, for sorting
+        Destroy an item.
         <argument name = "data" type = "anything" />
     </callback_type>
 
     <callback_type name = "hash_fn">
-        compare two items, for sorting
+        Hash function for keys.
         <argument name = "key" type = "anything" mutable = "0"/>
         <return type = "size"/>
     </callback_type>

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
@@ -206,7 +206,8 @@ public class Zhash implements AutoCloseable{
         return __refresh (self);
     }
     /*
-    Set hash for automatic value destruction
+    Set hash for automatic value destruction. Note that this assumes that
+    values are NULL-terminated strings. Do not use with different types. 
     */
     native static void __autofree (long self);
     public void autofree () {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -83,11 +83,11 @@ typedef void * (zhashx_duplicator_fn) (
 typedef int (zhashx_comparator_fn) (
     const void *item1, const void *item2);
 
-// compare two items, for sorting
+// Destroy an item.
 typedef void (zhashx_free_fn) (
     void *data);
 
-// compare two items, for sorting
+// Hash function for keys.
 typedef size_t (zhashx_hash_fn) (
     const void *key);
 
@@ -1215,7 +1215,8 @@ int
 int
     zhash_refresh (zhash_t *self);
 
-// Set hash for automatic value destruction
+// Set hash for automatic value destruction. Note that this assumes that
+// values are NULL-terminated strings. Do not use with different types. 
 void
     zhash_autofree (zhash_t *self);
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1328,7 +1328,8 @@ file.
 nothing my_zhash.autofree ()
 ```
 
-Set hash for automatic value destruction
+Set hash for automatic value destruction. Note that this assumes that
+values are NULL-terminated strings. Do not use with different types.
 
 ```
 nothing my_zhash.test (Boolean)

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -2703,7 +2703,8 @@ file.
 
     def autofree(self):
         """
-        Set hash for automatic value destruction
+        Set hash for automatic value destruction. Note that this assumes that
+values are NULL-terminated strings. Do not use with different types.
         """
         return lib.zhash_autofree(self._as_parameter_)
 

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -110,11 +110,11 @@ typedef void * (zhashx_duplicator_fn) (
 typedef int (zhashx_comparator_fn) (
     const void *item1, const void *item2);
 
-// compare two items, for sorting
+// Destroy an item.
 typedef void (zhashx_free_fn) (
     void *data);
 
-// compare two items, for sorting
+// Hash function for keys.
 typedef size_t (zhashx_hash_fn) (
     const void *key);
 
@@ -1242,7 +1242,8 @@ int
 int
     zhash_refresh (zhash_t *self);
 
-// Set hash for automatic value destruction
+// Set hash for automatic value destruction. Note that this assumes that
+// values are NULL-terminated strings. Do not use with different types. 
 void
     zhash_autofree (zhash_t *self);
 

--- a/bindings/qml/src/QmlZhash.cpp
+++ b/bindings/qml/src/QmlZhash.cpp
@@ -169,7 +169,8 @@ int QmlZhash::refresh () {
 };
 
 ///
-//  Set hash for automatic value destruction
+//  Set hash for automatic value destruction. Note that this assumes that
+//  values are NULL-terminated strings. Do not use with different types. 
 void QmlZhash::autofree () {
     zhash_autofree (self);
 };

--- a/bindings/qml/src/QmlZhash.h
+++ b/bindings/qml/src/QmlZhash.h
@@ -131,7 +131,8 @@ public slots:
     //  file.                                                                   
     int refresh ();
 
-    //  Set hash for automatic value destruction
+    //  Set hash for automatic value destruction. Note that this assumes that
+    //  values are NULL-terminated strings. Do not use with different types. 
     void autofree ();
 };
 

--- a/bindings/qt/src/qzhash.cpp
+++ b/bindings/qt/src/qzhash.cpp
@@ -227,7 +227,8 @@ int QZhash::refresh ()
 }
 
 ///
-//  Set hash for automatic value destruction
+//  Set hash for automatic value destruction. Note that this assumes that
+//  values are NULL-terminated strings. Do not use with different types. 
 void QZhash::autofree ()
 {
     zhash_autofree (self);

--- a/bindings/qt/src/qzhash.h
+++ b/bindings/qt/src/qzhash.h
@@ -131,7 +131,8 @@ public:
     //  file.                                                                   
     int refresh ();
 
-    //  Set hash for automatic value destruction
+    //  Set hash for automatic value destruction. Note that this assumes that
+    //  values are NULL-terminated strings. Do not use with different types. 
     void autofree ();
 
     //  Self test of this class.

--- a/bindings/ruby/lib/czmq/ffi/zhash.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhash.rb
@@ -356,7 +356,8 @@ module CZMQ
         result
       end
 
-      # Set hash for automatic value destruction
+      # Set hash for automatic value destruction. Note that this assumes that
+      # values are NULL-terminated strings. Do not use with different types. 
       #
       # @return [void]
       def autofree()

--- a/bindings/ruby/lib/czmq/ffi/zhashx.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhashx.rb
@@ -123,7 +123,7 @@ module CZMQ
       end
 
       # Create a new callback of the following type:
-      # compare two items, for sorting
+      # Destroy an item.
       #     typedef void (zhashx_free_fn) (
       #         void *data);               
       #
@@ -139,7 +139,7 @@ module CZMQ
       end
 
       # Create a new callback of the following type:
-      # compare two items, for sorting
+      # Hash function for keys.
       #     typedef size_t (zhashx_hash_fn) (
       #         const void *key);            
       #

--- a/include/zhash.h
+++ b/include/zhash.h
@@ -164,7 +164,8 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zhash_refresh (zhash_t *self);
 
-//  Set hash for automatic value destruction
+//  Set hash for automatic value destruction. Note that this assumes that
+//  values are NULL-terminated strings. Do not use with different types. 
 CZMQ_EXPORT void
     zhash_autofree (zhash_t *self);
 

--- a/include/zhashx.h
+++ b/include/zhashx.h
@@ -38,11 +38,11 @@ typedef void * (zhashx_duplicator_fn) (
 typedef int (zhashx_comparator_fn) (
     const void *item1, const void *item2);
 
-// compare two items, for sorting
+// Destroy an item.
 typedef void (zhashx_free_fn) (
     void *data);
 
-// compare two items, for sorting
+// Hash function for keys.
 typedef size_t (zhashx_hash_fn) (
     const void *key);
 

--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -1002,7 +1002,7 @@ zhashx_set_duplicator (zhashx_t *self, zhashx_duplicator_fn duplicator)
 
 
 //  --------------------------------------------------------------------------
-//  Set a user-defined deallocator for keyss; by default keys are
+//  Set a user-defined deallocator for keys; by default keys are
 //  freed when the hash is destroyed by calling free().
 
 void


### PR DESCRIPTION
Solution: update documentation and regenerate

Fixes https://github.com/zeromq/czmq/issues/1032