### PR TITLE
Problem: debian/kFreeBSD build broken

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -164,7 +164,7 @@
 #elif (defined (Mips))
 #   define __UTYPE_MIPS
 #   define __UNIX__
-#elif (defined (FreeBSD) || defined (__FreeBSD__))
+#elif (defined (FreeBSD) || defined (__FreeBSD__) || defined (__FreeBSD_kernel__))
 #   define __UTYPE_FREEBSD
 #   define __UNIX__
 #elif (defined (NetBSD) || defined (__NetBSD__))


### PR DESCRIPTION
Solution: add define and rework zuuid library detection and usage. If libuuid is available and detected just use it without checking for the OS.