### PR TITLE
Problem: zsys_shutdown does not call zmq_term when it closes sockets

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -251,6 +251,7 @@ zsys_shutdown (void)
         zmq_close (sockref->handle);
         free (sockref);
         sockref = (s_sockref_t *) zlist_pop (s_sockref_list);
+        --s_open_sockets;
     }
     zlist_destroy (&s_sockref_list);
     ZMUTEX_UNLOCK (s_mutex);


### PR DESCRIPTION
Solution: decrement count of open sockets if it manages to close them
from the internal list.
The total count of open sockets might go up without a socket being
appended to the list, but if a socket is appended to the list then
count is always incremented. So it's safe to decrement the count as
sockets are popped out of the list and closed.
This increases the chances that a clean exit is achieved even with
dangling sockets.