### PR TITLE
Problem: list of readers is scanned unnecessarily

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -174,10 +174,10 @@ zpoller_remove (zpoller_t *self, void *reader)
     else
         rc = zmq_poller_remove_fd (self->zmq_poller, *(SOCKET *) reader);
 #else
-    if (zlist_exists (self->reader_list, reader)) {
-        zlist_remove (self->reader_list, reader);
+    zlist_remove (self->reader_list, reader); // won't fail with non-existent reader
+    size_t num_readers_after = zlist_size (self->reader_list);
+    if (self->poll_size != num_readers_after)
         self->need_rebuild = true;
-    }
     else {
         errno = EINVAL;
         rc    = -1;


### PR DESCRIPTION
Solution: Compare before and after sizes of poll set instead.
This should improve performance of #1594.

I hope this is okay. Still not that experienced in C. 😅 

Can't compile it due to:
```
$ make
Making all in doc
asciidoc -d manpage -b docbook -f ./asciidoc.conf \
        -aczmq_version=4.0.3 -ozmakecert.xml zmakecert.txt
xmlto man zmakecert.xml
xmlto: /Users/paddor/dev/c/czmq/doc/zmakecert.xml does not validate (status 3)
xmlto: Fix document syntax or use --skip-validation option
I/O error : Attempt to load network entity http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd
/Users/paddor/dev/c/czmq/doc/zmakecert.xml:2: warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
D DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
                                                                               ^
I/O error : Attempt to load network entity http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd
warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
validity error : Could not load the external subset "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
Document /Users/paddor/dev/c/czmq/doc/zmakecert.xml does not validate
make[1]: *** [zmakecert.1] Error 13
rm zmakecert.xml
make: *** [all-recursive] Error 1
```

But I guess that's another issue.