### PR TITLE
Problem: zpoller_test fails without ZMQ_POLLER

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -174,9 +174,10 @@ zpoller_remove (zpoller_t *self, void *reader)
     else
         rc = zmq_poller_remove_fd (self->zmq_poller, *(SOCKET *) reader);
 #else
+    size_t num_readers_before = zlist_size (self->reader_list);
     zlist_remove (self->reader_list, reader); // won't fail with non-existent reader
     size_t num_readers_after = zlist_size (self->reader_list);
-    if (self->poll_size != num_readers_after)
+    if (num_readers_before != num_readers_after)
         self->need_rebuild = true;
     else {
         errno = EINVAL;


### PR DESCRIPTION
Solution: in zpoller_remove, compare the size before and after
removing the element with zlist_size, rather than the self poll_size,
as the latter only gets updated when the zpoller list is rebuilt, so
unless zpoller_wait is called it will not change