### PR TITLE
allow clean exit of executable on windows

### DIFF
--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -202,6 +202,7 @@ main (int argc, char **argv)
     else
         test_runall (verbose);
 
+    zsys_shutdown();
     return 0;
 }
 /*


### PR DESCRIPTION
Problem : czmq tests fail on windows

Solution : add zsys_shutdonw() before exit

this is an experiment, let's discuss this before merge