### PR TITLE
Fix win32 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,10 +299,10 @@ target_link_libraries(
     ${LIBZMQ_LIBRARIES}
     ${OPTIONAL_LIBRARIES}
 )
-set_target_properties(
-    zmakecert
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
-)
+#set_target_properties(
+#    zmakecert
+#    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
+#)
 install(TARGETS zmakecert
     RUNTIME DESTINATION bin
 )
@@ -316,10 +316,10 @@ target_link_libraries(
     ${LIBZMQ_LIBRARIES}
     ${OPTIONAL_LIBRARIES}
 )
-set_target_properties(
-    czmq_selftest
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
-)
+#set_target_properties(
+#    czmq_selftest
+#    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${SOURCE_DIR}/src"
+#)
 
 ########################################################################
 # tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ after_build:
   - cmd: cd "%CZMQ_BUILDDIR%\%Configuration%"
   - cmd: copy "%SODIUM_LIBRARY_DIR%\libsodium.dll" .
   - cmd: copy "%LIBZMQ_BUILDDIR%\bin\%Configuration%\libzmq-*dll" .
-  - cmd: 7z a -y -bd -mx=9 czmq.zip "%APPVEYOR_BUILD_FOLDER%\src\%CONFIGURATION%\zmakecert.exe" "%APPVEYOR_BUILD_FOLDER%\src\%CONFIGURATION%\czmq_selftest.exe" czmq.dll libsodium.dll libzmq-*.dll
+  - cmd: 7z a -y -bd -mx=9 czmq.zip zmakecert.exe czmq_selftest.exe czmq.dll libsodium.dll libzmq-*.dll
   - ps: Push-AppveyorArtifact "czmq.zip" -Filename "czmq-${env:Platform}-${env:Configuration}.zip"
   - cmd: cd "%CZMQ_BUILDDIR%"
   - cmd: ctest -C "%Configuration%" -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
   - cmd: msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration% libzmq.vcxproj
   - cmd: set ZEROMQ_INCLUDE_DIR="%LIBZMQ_SOURCEDIR%\include"
   - cmd: set ZEROMQ_LIBRARY_DIR="%LIBZMQ_BUILDDIR%\lib\%Configuration%"
-  - cmd: move "%ZEROMQ_LIBRARY_DIR%\libzmq-*lib" "%ZEROMQ_LIBRARY_DIR%\zmq.lib"
+#  - cmd: move "%ZEROMQ_LIBRARY_DIR%\libzmq-*lib" "%ZEROMQ_LIBRARY_DIR%\zmq.lib"
 
 clone_folder: C:\projects\czmq
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
   - cmd: msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration% libzmq.vcxproj
   - cmd: set ZEROMQ_INCLUDE_DIR="%LIBZMQ_SOURCEDIR%\include"
   - cmd: set ZEROMQ_LIBRARY_DIR="%LIBZMQ_BUILDDIR%\lib\%Configuration%"
-#  - cmd: move "%ZEROMQ_LIBRARY_DIR%\libzmq-*lib" "%ZEROMQ_LIBRARY_DIR%\zmq.lib"
+  - cmd: move "%ZEROMQ_LIBRARY_DIR%\libzmq-*lib" "%ZEROMQ_LIBRARY_DIR%\zmq.lib"
 
 clone_folder: C:\projects\czmq
 

--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -202,8 +202,10 @@ main (int argc, char **argv)
     else
         test_runall (verbose);
 
-    // call on win32 only
+#if defined (__WINDOWS__)
     zsys_shutdown();
+#endif
+
     return 0;
 }
 /*

--- a/src/czmq_selftest.c
+++ b/src/czmq_selftest.c
@@ -202,6 +202,8 @@ main (int argc, char **argv)
     else
         test_runall (verbose);
 
+    // call on win32 only
+    zsys_shutdown();
     return 0;
 }
 /*


### PR DESCRIPTION
problem : unit tests do not run on appveyor

solution :
the issue is that the exe and dlls were not on the same folder, so I propose to build czmq_selftest and zmakecert in the same folder as the dlls. BTW, this makes debugging wihtin visual studio much easier.
The explicit call to zsys_shutdown is also required.

Please note that the solution propose here implies the change in a generated file (CMakeLists.txt) so the real fix should be in zproject I guess, so this may not be merged "as is"