### PR TITLE
ZSYS_INTERFACE variable can be a single digit

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -101,6 +101,32 @@ s_self_prepare_udp (self_t *self)
         send_to = INADDR_BROADCAST;
         found_iface = 1;
     }
+    // if ZSYS_INTERFACE is a single digit, use the corresponding interface in
+    // the interface list
+    else if (strlen(iface) == 1 && iface[0] >= '0' && iface[0] <= '9')
+    {
+      int if_number = atoi(iface);
+      ziflist_t *iflist = ziflist_new();
+      assert(iflist);
+      const char *name = ziflist_first(iflist);
+      int idx = -1;
+      while (name) {
+        idx++;
+        if (idx==if_number) {
+          //  Using inet_addr instead of inet_aton or inet_atop
+          //  because these are not supported in Win XP
+          send_to = inet_addr(ziflist_broadcast(iflist));
+          bind_to = inet_addr(ziflist_address(iflist));
+          if (self->verbose)
+            zsys_info("zbeacon: interface=%s address=%s broadcast=%s",
+              name, ziflist_address(iflist), ziflist_broadcast(iflist));
+          found_iface = 1;
+          break;      //  iface is known, so allow it
+        }
+        name = ziflist_next(iflist);
+      }
+      ziflist_destroy(&iflist);
+    }
     else {
         //  Look for matching interface, or first ziflist item
         ziflist_t *iflist = ziflist_new ();


### PR DESCRIPTION
problem : 
on windows system, in exotic languages, the interfaces names can be complex, include spaces and special characters, making the use of the variable ZSYS_INTERFACE for network interface selection difficult.

solution:
allow the ZSYS_INTERFACE variable to be a single digit, selecting the i-th number interface of the system.
keep the existing behaviour for other values. 

can be tested/validated with zbeacon self test