### PR TITLE
Problem: public API/ABI changes depending on libzmq version

### DIFF
--- a/api/zsock_option.api
+++ b/api/zsock_option.api
@@ -472,12 +472,6 @@
 
 <!-- The following socket options are available in libzmq from version 3.0.0 -->
 
-<method name = "type" polymorphic = "1">
-    Get socket option `type`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
 <method name = "sndhwm" polymorphic = "1">
     Get socket option `sndhwm`.
     Available from libzmq 3.0.0.
@@ -502,138 +496,6 @@
     <argument name = "rcvhwm" type = "integer" />
 </method>
 
-<method name = "affinity" polymorphic = "1">
-    Get socket option `affinity`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set affinity" polymorphic = "1">
-    Set socket option `affinity`.
-    Available from libzmq 3.0.0.
-    <argument name = "affinity" type = "integer" />
-</method>
-
-<method name = "set subscribe" polymorphic = "1">
-    Set socket option `subscribe`.
-    Available from libzmq 3.0.0.
-    <argument name = "subscribe" type = "string" />
-</method>
-
-<method name = "set unsubscribe" polymorphic = "1">
-    Set socket option `unsubscribe`.
-    Available from libzmq 3.0.0.
-    <argument name = "unsubscribe" type = "string" />
-</method>
-
-<method name = "identity" polymorphic = "1">
-    Get socket option `identity`.
-    Available from libzmq 3.0.0.
-    <return type = "string" fresh = "1" />
-</method>
-
-<method name = "set identity" polymorphic = "1">
-    Set socket option `identity`.
-    Available from libzmq 3.0.0.
-    <argument name = "identity" type = "string" />
-</method>
-
-<method name = "rate" polymorphic = "1">
-    Get socket option `rate`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set rate" polymorphic = "1">
-    Set socket option `rate`.
-    Available from libzmq 3.0.0.
-    <argument name = "rate" type = "integer" />
-</method>
-
-<method name = "recovery ivl" polymorphic = "1">
-    Get socket option `recovery_ivl`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set recovery ivl" polymorphic = "1">
-    Set socket option `recovery_ivl`.
-    Available from libzmq 3.0.0.
-    <argument name = "recovery ivl" type = "integer" />
-</method>
-
-<method name = "sndbuf" polymorphic = "1">
-    Get socket option `sndbuf`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set sndbuf" polymorphic = "1">
-    Set socket option `sndbuf`.
-    Available from libzmq 3.0.0.
-    <argument name = "sndbuf" type = "integer" />
-</method>
-
-<method name = "rcvbuf" polymorphic = "1">
-    Get socket option `rcvbuf`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set rcvbuf" polymorphic = "1">
-    Set socket option `rcvbuf`.
-    Available from libzmq 3.0.0.
-    <argument name = "rcvbuf" type = "integer" />
-</method>
-
-<method name = "linger" polymorphic = "1">
-    Get socket option `linger`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set linger" polymorphic = "1">
-    Set socket option `linger`.
-    Available from libzmq 3.0.0.
-    <argument name = "linger" type = "integer" />
-</method>
-
-<method name = "reconnect ivl" polymorphic = "1">
-    Get socket option `reconnect_ivl`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set reconnect ivl" polymorphic = "1">
-    Set socket option `reconnect_ivl`.
-    Available from libzmq 3.0.0.
-    <argument name = "reconnect ivl" type = "integer" />
-</method>
-
-<method name = "reconnect ivl max" polymorphic = "1">
-    Get socket option `reconnect_ivl_max`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set reconnect ivl max" polymorphic = "1">
-    Set socket option `reconnect_ivl_max`.
-    Available from libzmq 3.0.0.
-    <argument name = "reconnect ivl max" type = "integer" />
-</method>
-
-<method name = "backlog" polymorphic = "1">
-    Get socket option `backlog`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set backlog" polymorphic = "1">
-    Set socket option `backlog`.
-    Available from libzmq 3.0.0.
-    <argument name = "backlog" type = "integer" />
-</method>
-
 <method name = "maxmsgsize" polymorphic = "1">
     Get socket option `maxmsgsize`.
     Available from libzmq 3.0.0.
@@ -656,30 +518,6 @@
     Set socket option `multicast_hops`.
     Available from libzmq 3.0.0.
     <argument name = "multicast hops" type = "integer" />
-</method>
-
-<method name = "rcvtimeo" polymorphic = "1">
-    Get socket option `rcvtimeo`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set rcvtimeo" polymorphic = "1">
-    Set socket option `rcvtimeo`.
-    Available from libzmq 3.0.0.
-    <argument name = "rcvtimeo" type = "integer" />
-</method>
-
-<method name = "sndtimeo" polymorphic = "1">
-    Get socket option `sndtimeo`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "set sndtimeo" polymorphic = "1">
-    Set socket option `sndtimeo`.
-    Available from libzmq 3.0.0.
-    <argument name = "sndtimeo" type = "integer" />
 </method>
 
 <method name = "set xpub verbose" polymorphic = "1">
@@ -748,24 +586,6 @@
     <argument name = "tcp accept filter" type = "string" />
 </method>
 
-<method name = "rcvmore" polymorphic = "1">
-    Get socket option `rcvmore`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
-<method name = "fd" polymorphic = "1">
-    Get socket option `fd`.
-    Available from libzmq 3.0.0.
-    <return type = "socket" fresh = "1" />
-</method>
-
-<method name = "events" polymorphic = "1">
-    Get socket option `events`.
-    Available from libzmq 3.0.0.
-    <return type = "integer" fresh = "1" />
-</method>
-
 <method name = "last endpoint" polymorphic = "1">
     Get socket option `last_endpoint`.
     Available from libzmq 3.0.0.
@@ -794,4 +614,234 @@
     Set socket option `delay_attach_on_connect`.
     Available from libzmq 3.0.0.
     <argument name = "delay attach on connect" type = "integer" />
+</method>
+
+<!-- The following socket options are available in libzmq from version 2.0.0 -->
+
+<method name = "hwm" polymorphic = "1">
+    Get socket option `hwm`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set hwm" polymorphic = "1">
+    Set socket option `hwm`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <argument name = "hwm" type = "integer" />
+</method>
+
+<method name = "swap" polymorphic = "1">
+    Get socket option `swap`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set swap" polymorphic = "1">
+    Set socket option `swap`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <argument name = "swap" type = "integer" />
+</method>
+
+<method name = "affinity" polymorphic = "1">
+    Get socket option `affinity`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set affinity" polymorphic = "1">
+    Set socket option `affinity`.
+    Available from libzmq 2.0.0.
+    <argument name = "affinity" type = "integer" />
+</method>
+
+<method name = "identity" polymorphic = "1">
+    Get socket option `identity`.
+    Available from libzmq 2.0.0.
+    <return type = "string" fresh = "1" />
+</method>
+
+<method name = "set identity" polymorphic = "1">
+    Set socket option `identity`.
+    Available from libzmq 2.0.0.
+    <argument name = "identity" type = "string" />
+</method>
+
+<method name = "rate" polymorphic = "1">
+    Get socket option `rate`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set rate" polymorphic = "1">
+    Set socket option `rate`.
+    Available from libzmq 2.0.0.
+    <argument name = "rate" type = "integer" />
+</method>
+
+<method name = "recovery ivl" polymorphic = "1">
+    Get socket option `recovery_ivl`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set recovery ivl" polymorphic = "1">
+    Set socket option `recovery_ivl`.
+    Available from libzmq 2.0.0.
+    <argument name = "recovery ivl" type = "integer" />
+</method>
+
+<method name = "recovery ivl msec" polymorphic = "1">
+    Get socket option `recovery_ivl_msec`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set recovery ivl msec" polymorphic = "1">
+    Set socket option `recovery_ivl_msec`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <argument name = "recovery ivl msec" type = "integer" />
+</method>
+
+<method name = "mcast loop" polymorphic = "1">
+    Get socket option `mcast_loop`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set mcast loop" polymorphic = "1">
+    Set socket option `mcast_loop`.
+    Available from libzmq 2.0.0 to 3.0.0.
+    <argument name = "mcast loop" type = "integer" />
+</method>
+
+<method name = "rcvtimeo" polymorphic = "1">
+    Get socket option `rcvtimeo`.
+    Available from libzmq 2.2.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set rcvtimeo" polymorphic = "1">
+    Set socket option `rcvtimeo`.
+    Available from libzmq 2.2.0.
+    <argument name = "rcvtimeo" type = "integer" />
+</method>
+
+<method name = "sndtimeo" polymorphic = "1">
+    Get socket option `sndtimeo`.
+    Available from libzmq 2.2.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set sndtimeo" polymorphic = "1">
+    Set socket option `sndtimeo`.
+    Available from libzmq 2.2.0.
+    <argument name = "sndtimeo" type = "integer" />
+</method>
+
+<method name = "sndbuf" polymorphic = "1">
+    Get socket option `sndbuf`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set sndbuf" polymorphic = "1">
+    Set socket option `sndbuf`.
+    Available from libzmq 2.0.0.
+    <argument name = "sndbuf" type = "integer" />
+</method>
+
+<method name = "rcvbuf" polymorphic = "1">
+    Get socket option `rcvbuf`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set rcvbuf" polymorphic = "1">
+    Set socket option `rcvbuf`.
+    Available from libzmq 2.0.0.
+    <argument name = "rcvbuf" type = "integer" />
+</method>
+
+<method name = "linger" polymorphic = "1">
+    Get socket option `linger`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set linger" polymorphic = "1">
+    Set socket option `linger`.
+    Available from libzmq 2.0.0.
+    <argument name = "linger" type = "integer" />
+</method>
+
+<method name = "reconnect ivl" polymorphic = "1">
+    Get socket option `reconnect_ivl`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set reconnect ivl" polymorphic = "1">
+    Set socket option `reconnect_ivl`.
+    Available from libzmq 2.0.0.
+    <argument name = "reconnect ivl" type = "integer" />
+</method>
+
+<method name = "reconnect ivl max" polymorphic = "1">
+    Get socket option `reconnect_ivl_max`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set reconnect ivl max" polymorphic = "1">
+    Set socket option `reconnect_ivl_max`.
+    Available from libzmq 2.0.0.
+    <argument name = "reconnect ivl max" type = "integer" />
+</method>
+
+<method name = "backlog" polymorphic = "1">
+    Get socket option `backlog`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "set backlog" polymorphic = "1">
+    Set socket option `backlog`.
+    Available from libzmq 2.0.0.
+    <argument name = "backlog" type = "integer" />
+</method>
+
+<method name = "set subscribe" polymorphic = "1">
+    Set socket option `subscribe`.
+    Available from libzmq 2.0.0.
+    <argument name = "subscribe" type = "string" />
+</method>
+
+<method name = "set unsubscribe" polymorphic = "1">
+    Set socket option `unsubscribe`.
+    Available from libzmq 2.0.0.
+    <argument name = "unsubscribe" type = "string" />
+</method>
+
+<method name = "type" polymorphic = "1">
+    Get socket option `type`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "rcvmore" polymorphic = "1">
+    Get socket option `rcvmore`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
+</method>
+
+<method name = "fd" polymorphic = "1">
+    Get socket option `fd`.
+    Available from libzmq 2.0.0.
+    <return type = "socket" fresh = "1" />
+</method>
+
+<method name = "events" polymorphic = "1">
+    Get socket option `events`.
+    Available from libzmq 2.0.0.
+    <return type = "integer" fresh = "1" />
 </method>

--- a/include/zsock.h
+++ b/include/zsock.h
@@ -709,12 +709,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zsock_set_immediate (void *self, int immediate);
 
-//  Get socket option `type`.   
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_type (void *self);
-
 //  Get socket option `sndhwm`. 
 //  Available from libzmq 3.0.0.
 //  Caller owns return value and must destroy it when done.
@@ -737,126 +731,6 @@ CZMQ_EXPORT int
 CZMQ_EXPORT void
     zsock_set_rcvhwm (void *self, int rcvhwm);
 
-//  Get socket option `affinity`.
-//  Available from libzmq 3.0.0. 
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_affinity (void *self);
-
-//  Set socket option `affinity`.
-//  Available from libzmq 3.0.0. 
-CZMQ_EXPORT void
-    zsock_set_affinity (void *self, int affinity);
-
-//  Set socket option `subscribe`.
-//  Available from libzmq 3.0.0.  
-CZMQ_EXPORT void
-    zsock_set_subscribe (void *self, const char *subscribe);
-
-//  Set socket option `unsubscribe`.
-//  Available from libzmq 3.0.0.    
-CZMQ_EXPORT void
-    zsock_set_unsubscribe (void *self, const char *unsubscribe);
-
-//  Get socket option `identity`.
-//  Available from libzmq 3.0.0. 
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT char *
-    zsock_identity (void *self);
-
-//  Set socket option `identity`.
-//  Available from libzmq 3.0.0. 
-CZMQ_EXPORT void
-    zsock_set_identity (void *self, const char *identity);
-
-//  Get socket option `rate`.   
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_rate (void *self);
-
-//  Set socket option `rate`.   
-//  Available from libzmq 3.0.0.
-CZMQ_EXPORT void
-    zsock_set_rate (void *self, int rate);
-
-//  Get socket option `recovery_ivl`.
-//  Available from libzmq 3.0.0.     
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_recovery_ivl (void *self);
-
-//  Set socket option `recovery_ivl`.
-//  Available from libzmq 3.0.0.     
-CZMQ_EXPORT void
-    zsock_set_recovery_ivl (void *self, int recovery_ivl);
-
-//  Get socket option `sndbuf`. 
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_sndbuf (void *self);
-
-//  Set socket option `sndbuf`. 
-//  Available from libzmq 3.0.0.
-CZMQ_EXPORT void
-    zsock_set_sndbuf (void *self, int sndbuf);
-
-//  Get socket option `rcvbuf`. 
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_rcvbuf (void *self);
-
-//  Set socket option `rcvbuf`. 
-//  Available from libzmq 3.0.0.
-CZMQ_EXPORT void
-    zsock_set_rcvbuf (void *self, int rcvbuf);
-
-//  Get socket option `linger`. 
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_linger (void *self);
-
-//  Set socket option `linger`. 
-//  Available from libzmq 3.0.0.
-CZMQ_EXPORT void
-    zsock_set_linger (void *self, int linger);
-
-//  Get socket option `reconnect_ivl`.
-//  Available from libzmq 3.0.0.      
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_reconnect_ivl (void *self);
-
-//  Set socket option `reconnect_ivl`.
-//  Available from libzmq 3.0.0.      
-CZMQ_EXPORT void
-    zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
-
-//  Get socket option `reconnect_ivl_max`.
-//  Available from libzmq 3.0.0.          
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_reconnect_ivl_max (void *self);
-
-//  Set socket option `reconnect_ivl_max`.
-//  Available from libzmq 3.0.0.          
-CZMQ_EXPORT void
-    zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
-
-//  Get socket option `backlog`.
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_backlog (void *self);
-
-//  Set socket option `backlog`.
-//  Available from libzmq 3.0.0.
-CZMQ_EXPORT void
-    zsock_set_backlog (void *self, int backlog);
-
 //  Get socket option `maxmsgsize`.
 //  Available from libzmq 3.0.0.   
 //  Caller owns return value and must destroy it when done.
@@ -878,28 +752,6 @@ CZMQ_EXPORT int
 //  Available from libzmq 3.0.0.       
 CZMQ_EXPORT void
     zsock_set_multicast_hops (void *self, int multicast_hops);
-
-//  Get socket option `rcvtimeo`.
-//  Available from libzmq 3.0.0. 
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_rcvtimeo (void *self);
-
-//  Set socket option `rcvtimeo`.
-//  Available from libzmq 3.0.0. 
-CZMQ_EXPORT void
-    zsock_set_rcvtimeo (void *self, int rcvtimeo);
-
-//  Get socket option `sndtimeo`.
-//  Available from libzmq 3.0.0. 
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_sndtimeo (void *self);
-
-//  Set socket option `sndtimeo`.
-//  Available from libzmq 3.0.0. 
-CZMQ_EXPORT void
-    zsock_set_sndtimeo (void *self, int sndtimeo);
 
 //  Set socket option `xpub_verbose`.
 //  Available from libzmq 3.0.0.     
@@ -961,24 +813,6 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT void
     zsock_set_tcp_accept_filter (void *self, const char *tcp_accept_filter);
 
-//  Get socket option `rcvmore`.
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_rcvmore (void *self);
-
-//  Get socket option `fd`.     
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT SOCKET
-    zsock_fd (void *self);
-
-//  Get socket option `events`. 
-//  Available from libzmq 3.0.0.
-//  Caller owns return value and must destroy it when done.
-CZMQ_EXPORT int
-    zsock_events (void *self);
-
 //  Get socket option `last_endpoint`.
 //  Available from libzmq 3.0.0.      
 //  Caller owns return value and must destroy it when done.
@@ -1005,6 +839,216 @@ CZMQ_EXPORT void
 //  Available from libzmq 3.0.0.                
 CZMQ_EXPORT void
     zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect);
+
+//  Get socket option `hwm`.             
+//  Available from libzmq 2.0.0 to 3.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_hwm (void *self);
+
+//  Set socket option `hwm`.             
+//  Available from libzmq 2.0.0 to 3.0.0.
+CZMQ_EXPORT void
+    zsock_set_hwm (void *self, int hwm);
+
+//  Get socket option `swap`.            
+//  Available from libzmq 2.0.0 to 3.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_swap (void *self);
+
+//  Set socket option `swap`.            
+//  Available from libzmq 2.0.0 to 3.0.0.
+CZMQ_EXPORT void
+    zsock_set_swap (void *self, int swap);
+
+//  Get socket option `affinity`.
+//  Available from libzmq 2.0.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_affinity (void *self);
+
+//  Set socket option `affinity`.
+//  Available from libzmq 2.0.0. 
+CZMQ_EXPORT void
+    zsock_set_affinity (void *self, int affinity);
+
+//  Get socket option `identity`.
+//  Available from libzmq 2.0.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT char *
+    zsock_identity (void *self);
+
+//  Set socket option `identity`.
+//  Available from libzmq 2.0.0. 
+CZMQ_EXPORT void
+    zsock_set_identity (void *self, const char *identity);
+
+//  Get socket option `rate`.   
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_rate (void *self);
+
+//  Set socket option `rate`.   
+//  Available from libzmq 2.0.0.
+CZMQ_EXPORT void
+    zsock_set_rate (void *self, int rate);
+
+//  Get socket option `recovery_ivl`.
+//  Available from libzmq 2.0.0.     
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_recovery_ivl (void *self);
+
+//  Set socket option `recovery_ivl`.
+//  Available from libzmq 2.0.0.     
+CZMQ_EXPORT void
+    zsock_set_recovery_ivl (void *self, int recovery_ivl);
+
+//  Get socket option `recovery_ivl_msec`.
+//  Available from libzmq 2.0.0 to 3.0.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_recovery_ivl_msec (void *self);
+
+//  Set socket option `recovery_ivl_msec`.
+//  Available from libzmq 2.0.0 to 3.0.0. 
+CZMQ_EXPORT void
+    zsock_set_recovery_ivl_msec (void *self, int recovery_ivl_msec);
+
+//  Get socket option `mcast_loop`.      
+//  Available from libzmq 2.0.0 to 3.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_mcast_loop (void *self);
+
+//  Set socket option `mcast_loop`.      
+//  Available from libzmq 2.0.0 to 3.0.0.
+CZMQ_EXPORT void
+    zsock_set_mcast_loop (void *self, int mcast_loop);
+
+//  Get socket option `rcvtimeo`.
+//  Available from libzmq 2.2.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_rcvtimeo (void *self);
+
+//  Set socket option `rcvtimeo`.
+//  Available from libzmq 2.2.0. 
+CZMQ_EXPORT void
+    zsock_set_rcvtimeo (void *self, int rcvtimeo);
+
+//  Get socket option `sndtimeo`.
+//  Available from libzmq 2.2.0. 
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_sndtimeo (void *self);
+
+//  Set socket option `sndtimeo`.
+//  Available from libzmq 2.2.0. 
+CZMQ_EXPORT void
+    zsock_set_sndtimeo (void *self, int sndtimeo);
+
+//  Get socket option `sndbuf`. 
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_sndbuf (void *self);
+
+//  Set socket option `sndbuf`. 
+//  Available from libzmq 2.0.0.
+CZMQ_EXPORT void
+    zsock_set_sndbuf (void *self, int sndbuf);
+
+//  Get socket option `rcvbuf`. 
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_rcvbuf (void *self);
+
+//  Set socket option `rcvbuf`. 
+//  Available from libzmq 2.0.0.
+CZMQ_EXPORT void
+    zsock_set_rcvbuf (void *self, int rcvbuf);
+
+//  Get socket option `linger`. 
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_linger (void *self);
+
+//  Set socket option `linger`. 
+//  Available from libzmq 2.0.0.
+CZMQ_EXPORT void
+    zsock_set_linger (void *self, int linger);
+
+//  Get socket option `reconnect_ivl`.
+//  Available from libzmq 2.0.0.      
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_reconnect_ivl (void *self);
+
+//  Set socket option `reconnect_ivl`.
+//  Available from libzmq 2.0.0.      
+CZMQ_EXPORT void
+    zsock_set_reconnect_ivl (void *self, int reconnect_ivl);
+
+//  Get socket option `reconnect_ivl_max`.
+//  Available from libzmq 2.0.0.          
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_reconnect_ivl_max (void *self);
+
+//  Set socket option `reconnect_ivl_max`.
+//  Available from libzmq 2.0.0.          
+CZMQ_EXPORT void
+    zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max);
+
+//  Get socket option `backlog`.
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_backlog (void *self);
+
+//  Set socket option `backlog`.
+//  Available from libzmq 2.0.0.
+CZMQ_EXPORT void
+    zsock_set_backlog (void *self, int backlog);
+
+//  Set socket option `subscribe`.
+//  Available from libzmq 2.0.0.  
+CZMQ_EXPORT void
+    zsock_set_subscribe (void *self, const char *subscribe);
+
+//  Set socket option `unsubscribe`.
+//  Available from libzmq 2.0.0.    
+CZMQ_EXPORT void
+    zsock_set_unsubscribe (void *self, const char *unsubscribe);
+
+//  Get socket option `type`.   
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_type (void *self);
+
+//  Get socket option `rcvmore`.
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_rcvmore (void *self);
+
+//  Get socket option `fd`.     
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT SOCKET
+    zsock_fd (void *self);
+
+//  Get socket option `events`. 
+//  Available from libzmq 2.0.0.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT int
+    zsock_events (void *self);
 
 //  Self test of this class.
 CZMQ_EXPORT void

--- a/src/sockopts.xml
+++ b/src/sockopts.xml
@@ -130,34 +130,10 @@
     
     <version major = "3" style = "macro">
         <!-- Options that are carried forward to 4.0 -->
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
         <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />
         <option name = "rcvhwm"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
-        </option>
-        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
-        </option>
-        <option name = "identity"          type = "string" mode = "rw" test = "DEALER">
-            <restrict type = "REQ" />
-            <restrict type = "REP" />
-            <restrict type = "DEALER" />
-            <restrict type = "ROUTER" />
-        </option>
-        <option name = "rate"              type = "int"    mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int"    mode = "rw" test = "SUB" />
-        <option name = "sndbuf"            type = "int"    mode = "rw" test = "PUB" />
-        <option name = "rcvbuf"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
-        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
         <option name = "maxmsgsize"        type = "int64"  mode = "rw" test = "SUB" />
         <option name = "multicast_hops"    type = "int"    mode = "rw" test = "SUB" />
-        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" />
-        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" />
         <option name = "xpub_verbose"      type = "int"    mode = "w"  test = "XPUB">
             <restrict type = "XPUB" />
         </option>
@@ -169,9 +145,6 @@
                                            type = "int"    mode = "rw" test = "SUB" />
         <option name = "tcp_accept_filter" type = "string" mode = "rw" test = "SUB"
                 test_value = "127.0.0.1" />
-        <option name = "rcvmore"           type = "int"    mode = "r"  test = "SUB" />
-        <option name = "fd"                type = "socket" mode = "r"  test = "SUB" />
-        <option name = "events"            type = "int"    mode = "r"  test = "SUB" />
         <option name = "last_endpoint"     type = "string" mode = "r"  test = "SUB" />
 
         <!-- Options that are deprecated in 4.0 -->
@@ -184,19 +157,24 @@
     </version>
 
     <!-- Legacy version 2 -->
-    <version major = "2" major_removed = "3" style = "macro">
-        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" />
+    <version major = "2" style = "macro">
+        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" major_removed = "3" />
+        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" major_removed = "3" />
         <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "identity"          type = "string" mode = "rw" test = "SUB" />
-        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "identity"          type = "string" mode = "rw" test = "DEALER">
+            <restrict type = "REQ" />
+            <restrict type = "REP" />
+            <restrict type = "DEALER" />
+            <restrict type = "ROUTER" />
+        </option>
+        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" major_changed = "3" type_new = "int" />
+        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" major_changed = "3" type_new = "int" />
+        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" major_removed = "3" />
+        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" major_removed = "3" />
         <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
         <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
-        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" major_changed = "3" type_new = "int" />
+        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" major_changed = "3" type_new = "int" />
         <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
         <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
         <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
@@ -208,8 +186,8 @@
             <restrict type = "SUB" />
         </option>
         <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
-        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" />
+        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" major_changed = "3" type_new = "int" />
         <option name = "fd"                type = "socket" mode = "r"  test = "SUB" />
-        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" />
+        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" major_changed = "3" type_new = "int" />
     </version>
 </options>

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -128,18 +128,7 @@ to $(major_removed).0.0 \
 */
 
 .for version
-.   if defined (.major_removed)
-#if (ZMQ_VERSION_MAJOR >= $(major)) && (ZMQ_VERSION_MAJOR < $(major_removed))
-.   else
-#if (ZMQ_VERSION_MAJOR >= $(major))
-.   endif
-.   if defined (.minor)
-#   if (ZMQ_VERSION_MINOR >= $(minor))
-.   endif
 .       for option
-.           if defined (option.major_removed)
-#   if (ZMQ_VERSION_MAJOR < $(option.major_removed))
-.           endif
 .       if mode = "rw" | mode = "w"
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_$(NAME) value
@@ -171,6 +160,9 @@ zsock_set_$(name) (void *self, $(ctype_const:) $(name))
         assert (false);
     }
 .           endif
+.           if defined (major_changed)
+#        if ZMQ_VERSION_MAJOR < $(major_changed)
+.           endif
 .           if type = "uint64"
     uint64_t value = $(name);
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &value, sizeof (uint64_t));
@@ -184,6 +176,24 @@ zsock_set_$(name) (void *self, $(ctype_const:) $(name))
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), sizeof (int));
 .           elsif type = "string" | type = "key"
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), strlen ($(name)));
+.           endif
+.           if defined (major_changed)
+#        else
+.           if type_new = "uint64"
+    uint64_t value = $(name);
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &value, sizeof (uint64_t));
+.           elsif type_new = "int64"
+    int64_t value = $(name);
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &value, sizeof (int64_t));
+.           elsif type_new = "uint32"
+    uint32_t value = $(name);
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &value, sizeof (uint32_t));
+.           elsif type_new = "int"
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), sizeof (int));
+.           elsif type_new = "string" | type = "key"
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), strlen ($(name)));
+.           endif
+#        endif
 .           endif
     assert (rc == 0 || zmq_errno () == ETERM);
 .       if style = "macro"
@@ -228,6 +238,9 @@ zsock_$(name) (void *self)
 #   if defined (ZMQ_$(NAME))
 .           endif
 .       runtime_check (version, option, 0)
+.           if defined (major_changed)
+#        if ZMQ_VERSION_MAJOR < $(major_changed)
+.           endif
 .           if type = "uint64"
     uint64_t $(name);
     size_t option_len = sizeof (uint64_t);
@@ -262,6 +275,44 @@ zsock_$(name) (void *self)
 .           else
     return ($(ctype:)) $(name);
 .           endif
+.           if defined (major_changed)
+#        else
+.           if type_new = "uint64"
+    uint64_t $(name);
+    size_t option_len = sizeof (uint64_t);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), &option_len);
+.           elsif type_new = "int64"
+    int64_t $(name);
+    size_t option_len = sizeof (int64_t);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), &option_len);
+.           elsif type_new = "uint32"
+    uint32_t $(name);
+    size_t option_len = sizeof (uint32_t);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), &option_len);
+.           elsif type_new = "int"
+    int $(name);
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), &option_len);
+.           elsif type_new = "string"
+    size_t option_len = 255;
+    char *$(name) = (char *) zmalloc (option_len);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), &option_len);
+.           elsif type_new = "key"
+    size_t option_len = 40 + 1;     //  Z85 key + terminator
+    char *$(name) = (char *) zmalloc (option_len);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), $(name), &option_len);
+.           elsif type_new = "socket"
+    SOCKET $(name);
+    size_t option_len = sizeof (SOCKET);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_$(NAME), &$(name), &option_len);
+.           endif
+.           if type_new = "int" | type_new = "socket"
+    return $(name);
+.           else
+    return ($(ctype_new:)) $(name);
+.           endif
+#        endif
+.           endif
 .           if style = "macro"
 #   else
 .               if type = "string" | type = "key"
@@ -274,18 +325,11 @@ zsock_$(name) (void *self)
 }
 
 .       endif
-.           if defined (option.major_removed)
-#   endif
-.           endif
 .       endfor
-.   if defined (.minor)
-#   endif
-.   endif
 .   for source
 $(string.trim(.):)
 
 .   endfor
-#endif
 
 .endfor
 //  --------------------------------------------------------------------------

--- a/src/zsock_option.inc
+++ b/src/zsock_option.inc
@@ -19,8 +19,6 @@
     =========================================================================
 */
 
-#if (ZMQ_VERSION_MAJOR >= 4)
-#   if (ZMQ_VERSION_MINOR >= 2)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_HEARTBEAT_IVL value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -723,11 +721,7 @@ zsock_vmci_connect_timeout (void *self)
 #   endif
 }
 
-#   endif
-#endif
 
-#if (ZMQ_VERSION_MAJOR >= 4)
-#   if (ZMQ_VERSION_MINOR >= 1)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_TOS value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -970,10 +964,7 @@ zsock_set_xpub_nodrop (void *self, int xpub_nodrop)
 }
 
 
-#   endif
-#endif
 
-#if (ZMQ_VERSION_MAJOR >= 4)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_ROUTER_MANDATORY value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -1856,33 +1847,6 @@ zsock_immediate (void *self)
 #   endif
 }
 
-#endif
-
-#if (ZMQ_VERSION_MAJOR >= 3)
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_TYPE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_type (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_TYPE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock type option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int type;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_TYPE, &type, &option_len);
-    return type;
-#   else
-    return 0;
-#   endif
-}
 
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_SNDHWM value
@@ -1979,536 +1943,6 @@ zsock_rcvhwm (void *self)
 }
 
 //  --------------------------------------------------------------------------
-//  Set socket ZMQ_AFFINITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_affinity (void *self, int affinity)
-{
-    assert (self);
-#   if defined (ZMQ_AFFINITY)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    uint64_t value = affinity;
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_AFFINITY, &value, sizeof (uint64_t));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_AFFINITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_affinity (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_AFFINITY)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    uint64_t affinity;
-    size_t option_len = sizeof (uint64_t);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_AFFINITY, &affinity, &option_len);
-    return (int) affinity;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SUBSCRIBE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_subscribe (void *self, const char * subscribe)
-{
-    assert (self);
-#   if defined (ZMQ_SUBSCRIBE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock subscribe option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    if (zsock_type (self) != ZMQ_SUB) {
-        printf ("ZMQ_SUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SUBSCRIBE, subscribe, strlen (subscribe));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_UNSUBSCRIBE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_unsubscribe (void *self, const char * unsubscribe)
-{
-    assert (self);
-#   if defined (ZMQ_UNSUBSCRIBE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock unsubscribe option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    if (zsock_type (self) != ZMQ_SUB) {
-        printf ("ZMQ_UNSUBSCRIBE is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_UNSUBSCRIBE, unsubscribe, strlen (unsubscribe));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_IDENTITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_identity (void *self, const char * identity)
-{
-    assert (self);
-#   if defined (ZMQ_IDENTITY)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    if (zsock_type (self) != ZMQ_REQ
-    &&  zsock_type (self) != ZMQ_REP
-    &&  zsock_type (self) != ZMQ_DEALER
-    &&  zsock_type (self) != ZMQ_ROUTER) {
-        printf ("ZMQ_IDENTITY is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
-        assert (false);
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, strlen (identity));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_IDENTITY value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-char *
-zsock_identity (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_IDENTITY)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    size_t option_len = 255;
-    char *identity = (char *) zmalloc (option_len);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, &option_len);
-    return (char *) identity;
-#   else
-    return NULL;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RATE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rate (void *self, int rate)
-{
-    assert (self);
-#   if defined (ZMQ_RATE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &rate, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RATE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rate (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RATE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int rate;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
-    return rate;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECOVERY_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_recovery_ivl (void *self, int recovery_ivl)
-{
-    assert (self);
-#   if defined (ZMQ_RECOVERY_IVL)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECOVERY_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_recovery_ivl (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECOVERY_IVL)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int recovery_ivl;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
-    return recovery_ivl;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_sndbuf (void *self, int sndbuf)
-{
-    assert (self);
-#   if defined (ZMQ_SNDBUF)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_sndbuf (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_SNDBUF)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int sndbuf;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
-    return sndbuf;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rcvbuf (void *self, int rcvbuf)
-{
-    assert (self);
-#   if defined (ZMQ_RCVBUF)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVBUF value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvbuf (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVBUF)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int rcvbuf;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
-    return rcvbuf;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_LINGER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_linger (void *self, int linger)
-{
-    assert (self);
-#   if defined (ZMQ_LINGER)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_LINGER value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_linger (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_LINGER)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int linger;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, &option_len);
-    return linger;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_reconnect_ivl (void *self, int reconnect_ivl)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_reconnect_ivl (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int reconnect_ivl;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, &option_len);
-    return reconnect_ivl;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RECONNECT_IVL_MAX value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL_MAX)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RECONNECT_IVL_MAX value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_reconnect_ivl_max (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RECONNECT_IVL_MAX)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int reconnect_ivl_max;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, &option_len);
-    return reconnect_ivl_max;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_BACKLOG value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_backlog (void *self, int backlog)
-{
-    assert (self);
-#   if defined (ZMQ_BACKLOG)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_BACKLOG value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_backlog (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_BACKLOG)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int backlog;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, &option_len);
-    return backlog;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
 //  Set socket ZMQ_MAXMSGSIZE value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -2598,100 +2032,6 @@ zsock_multicast_hops (void *self)
     size_t option_len = sizeof (int);
     zmq_getsockopt (zsock_resolve (self), ZMQ_MULTICAST_HOPS, &multicast_hops, &option_len);
     return multicast_hops;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_RCVTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_rcvtimeo (void *self, int rcvtimeo)
-{
-    assert (self);
-#   if defined (ZMQ_RCVTIMEO)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvtimeo (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVTIMEO)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int rcvtimeo;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, &option_len);
-    return rcvtimeo;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Set socket ZMQ_SNDTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-void
-zsock_set_sndtimeo (void *self, int sndtimeo)
-{
-    assert (self);
-#   if defined (ZMQ_SNDTIMEO)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return;
-    }
-    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
-    assert (rc == 0 || zmq_errno () == ETERM);
-#   endif
-}
-
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_SNDTIMEO value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_sndtimeo (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_SNDTIMEO)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int sndtimeo;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, &option_len);
-    return sndtimeo;
 #   else
     return 0;
 #   endif
@@ -2959,81 +2299,6 @@ zsock_tcp_accept_filter (void *self)
 }
 
 //  --------------------------------------------------------------------------
-//  Return socket ZMQ_RCVMORE value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_rcvmore (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_RCVMORE)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock rcvmore option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int rcvmore;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
-    return rcvmore;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_FD value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-SOCKET
-zsock_fd (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_FD)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock fd option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    SOCKET fd;
-    size_t option_len = sizeof (SOCKET);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_FD, &fd, &option_len);
-    return fd;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
-//  Return socket ZMQ_EVENTS value
-//  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
-
-int
-zsock_events (void *self)
-{
-    assert (self);
-#   if defined (ZMQ_EVENTS)
-    int major, minor, patch;
-    zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (3, 0, 0)) {
-        zsys_error ("zsock events option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 3.0.0\n", major, minor, patch, NULL);
-        return 0;
-    }
-    int events;
-    size_t option_len = sizeof (int);
-    zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
-    return events;
-#   else
-    return 0;
-#   endif
-}
-
-//  --------------------------------------------------------------------------
 //  Return socket ZMQ_LAST_ENDPOINT value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
 
@@ -3153,9 +2418,7 @@ zsock_set_delay_attach_on_connect (void *self, int delay_attach_on_connect)
 }
 
 
-#endif
 
-#if (ZMQ_VERSION_MAJOR >= 2) && (ZMQ_VERSION_MAJOR < 3)
 //  --------------------------------------------------------------------------
 //  Set socket ZMQ_HWM value
 //  *** GENERATED SOURCE CODE, DO NOT EDIT, SEE INSTRUCTIONS AT START ***
@@ -3267,10 +2530,9 @@ zsock_set_affinity (void *self, int affinity)
 #   if defined (ZMQ_AFFINITY)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     uint64_t value = affinity;
@@ -3291,10 +2553,9 @@ zsock_affinity (void *self)
 #   if defined (ZMQ_AFFINITY)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock affinity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     uint64_t affinity;
@@ -3317,11 +2578,17 @@ zsock_set_identity (void *self, const char * identity)
 #   if defined (ZMQ_IDENTITY)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
+    }
+    if (zsock_type (self) != ZMQ_REQ
+    &&  zsock_type (self) != ZMQ_REP
+    &&  zsock_type (self) != ZMQ_DEALER
+    &&  zsock_type (self) != ZMQ_ROUTER) {
+        printf ("ZMQ_IDENTITY is not valid on %s sockets\n", zsys_sockname (zsock_type (self)));
+        assert (false);
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_IDENTITY, identity, strlen (identity));
     assert (rc == 0 || zmq_errno () == ETERM);
@@ -3340,10 +2607,9 @@ zsock_identity (void *self)
 #   if defined (ZMQ_IDENTITY)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock identity option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     size_t option_len = 255;
@@ -3366,14 +2632,17 @@ zsock_set_rate (void *self, int rate)
 #   if defined (ZMQ_RATE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     int64_t value = rate;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &value, sizeof (int64_t));
+#        else
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RATE, &rate, sizeof (int));
+#        endif
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
 }
@@ -3390,16 +2659,22 @@ zsock_rate (void *self)
 #   if defined (ZMQ_RATE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock rate option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     int64_t rate;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
     return (int) rate;
+#        else
+    int rate;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_RATE, &rate, &option_len);
+    return rate;
+#        endif
 #   else
     return 0;
 #   endif
@@ -3416,14 +2691,17 @@ zsock_set_recovery_ivl (void *self, int recovery_ivl)
 #   if defined (ZMQ_RECOVERY_IVL)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     int64_t value = recovery_ivl;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &value, sizeof (int64_t));
+#        else
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, sizeof (int));
+#        endif
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
 }
@@ -3440,16 +2718,22 @@ zsock_recovery_ivl (void *self)
 #   if defined (ZMQ_RECOVERY_IVL)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock recovery_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     int64_t recovery_ivl;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
     return (int) recovery_ivl;
+#        else
+    int recovery_ivl;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_RECOVERY_IVL, &recovery_ivl, &option_len);
+    return recovery_ivl;
+#        endif
 #   else
     return 0;
 #   endif
@@ -3566,10 +2850,9 @@ zsock_set_rcvtimeo (void *self, int rcvtimeo)
 #   if defined (ZMQ_RCVTIMEO)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)) {
         zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.2.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
@@ -3589,10 +2872,9 @@ zsock_rcvtimeo (void *self)
 #   if defined (ZMQ_RCVTIMEO)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)) {
         zsys_error ("zsock rcvtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.2.0\n", major, minor, patch, NULL);
         return 0;
     }
     int rcvtimeo;
@@ -3615,10 +2897,9 @@ zsock_set_sndtimeo (void *self, int sndtimeo)
 #   if defined (ZMQ_SNDTIMEO)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)) {
         zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.2.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
@@ -3638,10 +2919,9 @@ zsock_sndtimeo (void *self)
 #   if defined (ZMQ_SNDTIMEO)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 2, 0)) {
         zsys_error ("zsock sndtimeo option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.2.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.2.0\n", major, minor, patch, NULL);
         return 0;
     }
     int sndtimeo;
@@ -3664,14 +2944,17 @@ zsock_set_sndbuf (void *self, int sndbuf)
 #   if defined (ZMQ_SNDBUF)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     uint64_t value = sndbuf;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &value, sizeof (uint64_t));
+#        else
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, sizeof (int));
+#        endif
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
 }
@@ -3688,16 +2971,22 @@ zsock_sndbuf (void *self)
 #   if defined (ZMQ_SNDBUF)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock sndbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     uint64_t sndbuf;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
     return (int) sndbuf;
+#        else
+    int sndbuf;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_SNDBUF, &sndbuf, &option_len);
+    return sndbuf;
+#        endif
 #   else
     return 0;
 #   endif
@@ -3714,14 +3003,17 @@ zsock_set_rcvbuf (void *self, int rcvbuf)
 #   if defined (ZMQ_RCVBUF)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     uint64_t value = rcvbuf;
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &value, sizeof (uint64_t));
+#        else
+    int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, sizeof (int));
+#        endif
     assert (rc == 0 || zmq_errno () == ETERM);
 #   endif
 }
@@ -3738,16 +3030,22 @@ zsock_rcvbuf (void *self)
 #   if defined (ZMQ_RCVBUF)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock rcvbuf option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     uint64_t rcvbuf;
     size_t option_len = sizeof (uint64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
     return (int) rcvbuf;
+#        else
+    int rcvbuf;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVBUF, &rcvbuf, &option_len);
+    return rcvbuf;
+#        endif
 #   else
     return 0;
 #   endif
@@ -3764,10 +3062,9 @@ zsock_set_linger (void *self, int linger)
 #   if defined (ZMQ_LINGER)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_LINGER, &linger, sizeof (int));
@@ -3787,10 +3084,9 @@ zsock_linger (void *self)
 #   if defined (ZMQ_LINGER)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock linger option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     int linger;
@@ -3813,10 +3109,9 @@ zsock_set_reconnect_ivl (void *self, int reconnect_ivl)
 #   if defined (ZMQ_RECONNECT_IVL)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL, &reconnect_ivl, sizeof (int));
@@ -3836,10 +3131,9 @@ zsock_reconnect_ivl (void *self)
 #   if defined (ZMQ_RECONNECT_IVL)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock reconnect_ivl option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     int reconnect_ivl;
@@ -3862,10 +3156,9 @@ zsock_set_reconnect_ivl_max (void *self, int reconnect_ivl_max)
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_RECONNECT_IVL_MAX, &reconnect_ivl_max, sizeof (int));
@@ -3885,10 +3178,9 @@ zsock_reconnect_ivl_max (void *self)
 #   if defined (ZMQ_RECONNECT_IVL_MAX)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock reconnect_ivl_max option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     int reconnect_ivl_max;
@@ -3911,10 +3203,9 @@ zsock_set_backlog (void *self, int backlog)
 #   if defined (ZMQ_BACKLOG)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_BACKLOG, &backlog, sizeof (int));
@@ -3934,10 +3225,9 @@ zsock_backlog (void *self)
 #   if defined (ZMQ_BACKLOG)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock backlog option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     int backlog;
@@ -3960,10 +3250,9 @@ zsock_set_subscribe (void *self, const char * subscribe)
 #   if defined (ZMQ_SUBSCRIBE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock subscribe option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     if (zsock_type (self) != ZMQ_SUB) {
@@ -3987,10 +3276,9 @@ zsock_set_unsubscribe (void *self, const char * unsubscribe)
 #   if defined (ZMQ_UNSUBSCRIBE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock unsubscribe option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return;
     }
     if (zsock_type (self) != ZMQ_SUB) {
@@ -4014,10 +3302,9 @@ zsock_type (void *self)
 #   if defined (ZMQ_TYPE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock type option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     int type;
@@ -4040,16 +3327,22 @@ zsock_rcvmore (void *self)
 #   if defined (ZMQ_RCVMORE)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock rcvmore option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     int64_t rcvmore;
     size_t option_len = sizeof (int64_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
     return (int) rcvmore;
+#        else
+    int rcvmore;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_RCVMORE, &rcvmore, &option_len);
+    return rcvmore;
+#        endif
 #   else
     return 0;
 #   endif
@@ -4066,10 +3359,9 @@ zsock_fd (void *self)
 #   if defined (ZMQ_FD)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock fd option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
     SOCKET fd;
@@ -4092,22 +3384,27 @@ zsock_events (void *self)
 #   if defined (ZMQ_EVENTS)
     int major, minor, patch;
     zmq_version (&major, &minor, &patch);
-    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)
-            || ZMQ_MAKE_VERSION (major, minor, patch) >= ZMQ_MAKE_VERSION (3, 0, 0)) {
+    if (ZMQ_MAKE_VERSION (major, minor, patch) < ZMQ_MAKE_VERSION (2, 0, 0)) {
         zsys_error ("zsock events option not supported by libzmq version %d.%d.%d, "
-            "run with libzmq >= 2.0.0 and < 3.0.0\n", major, minor, patch, NULL);
+            "run with libzmq >= 2.0.0\n", major, minor, patch, NULL);
         return 0;
     }
+#        if ZMQ_VERSION_MAJOR < 3
     uint32_t events;
     size_t option_len = sizeof (uint32_t);
     zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
     return (int) events;
+#        else
+    int events;
+    size_t option_len = sizeof (int);
+    zmq_getsockopt (zsock_resolve (self), ZMQ_EVENTS, &events, &option_len);
+    return events;
+#        endif
 #   else
     return 0;
 #   endif
 }
 
-#endif
 
 //  --------------------------------------------------------------------------
 //  Selftest
@@ -4358,12 +3655,6 @@ zsock_option_test (bool verbose)
 #endif
 
 #if (ZMQ_VERSION_MAJOR >= 3)
-#     if defined (ZMQ_TYPE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_type (self);
-    zsock_destroy (&self);
-#     endif
 #     if defined (ZMQ_SNDHWM)
     self = zsock_new (ZMQ_PUB);
     assert (self);
@@ -4380,99 +3671,6 @@ zsock_option_test (bool verbose)
     zsock_rcvhwm (self);
     zsock_destroy (&self);
 #     endif
-#     if defined (ZMQ_AFFINITY)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_affinity (self, 1);
-    assert (zsock_affinity (self) == 1);
-    zsock_affinity (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SUBSCRIBE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_subscribe (self, "test");
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_UNSUBSCRIBE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_unsubscribe (self, "test");
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_IDENTITY)
-    self = zsock_new (ZMQ_DEALER);
-    assert (self);
-    zsock_set_identity (self, "test");
-    char *identity = zsock_identity (self);
-    assert (identity);
-    free (identity);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RATE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rate (self, 1);
-    assert (zsock_rate (self) == 1);
-    zsock_rate (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECOVERY_IVL)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_recovery_ivl (self, 1);
-    assert (zsock_recovery_ivl (self) == 1);
-    zsock_recovery_ivl (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SNDBUF)
-    self = zsock_new (ZMQ_PUB);
-    assert (self);
-    zsock_set_sndbuf (self, 1);
-    assert (zsock_sndbuf (self) == 1);
-    zsock_sndbuf (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVBUF)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rcvbuf (self, 1);
-    assert (zsock_rcvbuf (self) == 1);
-    zsock_rcvbuf (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_LINGER)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_linger (self, 1);
-    assert (zsock_linger (self) == 1);
-    zsock_linger (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECONNECT_IVL)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_reconnect_ivl (self, 1);
-    assert (zsock_reconnect_ivl (self) == 1);
-    zsock_reconnect_ivl (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RECONNECT_IVL_MAX)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_reconnect_ivl_max (self, 1);
-    assert (zsock_reconnect_ivl_max (self) == 1);
-    zsock_reconnect_ivl_max (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_BACKLOG)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_backlog (self, 1);
-    assert (zsock_backlog (self) == 1);
-    zsock_backlog (self);
-    zsock_destroy (&self);
-#     endif
 #     if defined (ZMQ_MAXMSGSIZE)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4487,22 +3685,6 @@ zsock_option_test (bool verbose)
     zsock_set_multicast_hops (self, 1);
     assert (zsock_multicast_hops (self) == 1);
     zsock_multicast_hops (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_RCVTIMEO)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_rcvtimeo (self, 1);
-    assert (zsock_rcvtimeo (self) == 1);
-    zsock_rcvtimeo (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_SNDTIMEO)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_set_sndtimeo (self, 1);
-    assert (zsock_sndtimeo (self) == 1);
-    zsock_sndtimeo (self);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_XPUB_VERBOSE)
@@ -4552,24 +3734,6 @@ zsock_option_test (bool verbose)
     free (tcp_accept_filter);
     zsock_destroy (&self);
 #     endif
-#     if defined (ZMQ_RCVMORE)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_rcvmore (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_FD)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_fd (self);
-    zsock_destroy (&self);
-#     endif
-#     if defined (ZMQ_EVENTS)
-    self = zsock_new (ZMQ_SUB);
-    assert (self);
-    zsock_events (self);
-    zsock_destroy (&self);
-#     endif
 #     if defined (ZMQ_LAST_ENDPOINT)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4600,7 +3764,8 @@ zsock_option_test (bool verbose)
 #     endif
 #endif
 
-#if (ZMQ_VERSION_MAJOR >= 2) && (ZMQ_VERSION_MAJOR < 3)
+#if (ZMQ_VERSION_MAJOR >= 2)
+#   if (ZMQ_VERSION_MAJOR < 3)
 #     if defined (ZMQ_HWM)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4609,6 +3774,8 @@ zsock_option_test (bool verbose)
     zsock_hwm (self);
     zsock_destroy (&self);
 #     endif
+#   endif
+#   if (ZMQ_VERSION_MAJOR < 3)
 #     if defined (ZMQ_SWAP)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4617,6 +3784,7 @@ zsock_option_test (bool verbose)
     zsock_swap (self);
     zsock_destroy (&self);
 #     endif
+#   endif
 #     if defined (ZMQ_AFFINITY)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4626,7 +3794,7 @@ zsock_option_test (bool verbose)
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_IDENTITY)
-    self = zsock_new (ZMQ_SUB);
+    self = zsock_new (ZMQ_DEALER);
     assert (self);
     zsock_set_identity (self, "test");
     char *identity = zsock_identity (self);
@@ -4650,6 +3818,7 @@ zsock_option_test (bool verbose)
     zsock_recovery_ivl (self);
     zsock_destroy (&self);
 #     endif
+#   if (ZMQ_VERSION_MAJOR < 3)
 #     if defined (ZMQ_RECOVERY_IVL_MSEC)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4658,6 +3827,8 @@ zsock_option_test (bool verbose)
     zsock_recovery_ivl_msec (self);
     zsock_destroy (&self);
 #     endif
+#   endif
+#   if (ZMQ_VERSION_MAJOR < 3)
 #     if defined (ZMQ_MCAST_LOOP)
     self = zsock_new (ZMQ_SUB);
     assert (self);
@@ -4666,6 +3837,7 @@ zsock_option_test (bool verbose)
     zsock_mcast_loop (self);
     zsock_destroy (&self);
 #     endif
+#   endif
 #     if defined (ZMQ_RCVTIMEO)
     self = zsock_new (ZMQ_SUB);
     assert (self);


### PR DESCRIPTION
Solution: keep the public API stable regardless of the libzmq version
available at build time.
All the zsock_* options functions will always be available, but with
both build time and runtime checks.
This ensure full transparent compatibility with all versions of
libzmq, and avoids API breakages during rebuilds.
Achieved by removing the global ifdefs around the libzmq version and
by avoiding redefining the same option for different versions in
sockopts.xml.
Since libzmq does strict type size enforcement we can't simply cast
up or down. Introduce new attributes "major_changed" and "type_new"
to signal when an option type changes and to what.

Fixes #1603