### PR TITLE
Problem: ziflist does not support IPv6

### DIFF
--- a/api/ziflist.api
+++ b/api/ziflist.api
@@ -55,4 +55,14 @@
     <method name = "print">
         Return the list of interfaces.
     </method>
+
+    <method name = "new ipv6" singleton = "1" state = "draft">
+        Get a list of network interfaces currently defined on the system
+        Includes IPv6 interfaces
+        <return type = "ziflist" fresh = "1" />
+    </method>
+
+    <method name = "reload ipv6" state = "draft">
+        Reload network interfaces from system, including IPv6
+    </method>
 </class>

--- a/api/ziflist.api
+++ b/api/ziflist.api
@@ -65,4 +65,9 @@
     <method name = "reload ipv6" state = "draft">
         Reload network interfaces from system, including IPv6
     </method>
+
+    <method name = "is ipv6" state = "draft">
+        Return true if the current interface uses IPv6
+        <return type = "boolean" />
+    </method>
 </class>

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Ziflist.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Ziflist.c
@@ -84,6 +84,19 @@ Java_org_zeromq_czmq_Ziflist__1_1print (JNIEnv *env, jclass c, jlong self)
     ziflist_print ((ziflist_t *) (intptr_t) self);
 }
 
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Ziflist__1_1newIpv6 (JNIEnv *env, jclass c)
+{
+    jlong new_ipv6_ = (jlong) (intptr_t) ziflist_new_ipv6 ();
+    return new_ipv6_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Ziflist__1_1reloadIpv6 (JNIEnv *env, jclass c, jlong self)
+{
+    ziflist_reload_ipv6 ((ziflist_t *) (intptr_t) self);
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Ziflist__1_1test (JNIEnv *env, jclass c, jboolean verbose)
 {

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Ziflist.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Ziflist.c
@@ -97,6 +97,13 @@ Java_org_zeromq_czmq_Ziflist__1_1reloadIpv6 (JNIEnv *env, jclass c, jlong self)
     ziflist_reload_ipv6 ((ziflist_t *) (intptr_t) self);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_org_zeromq_czmq_Ziflist__1_1isIpv6 (JNIEnv *env, jclass c, jlong self)
+{
+    jboolean is_ipv6_ = (jboolean) ziflist_is_ipv6 ((ziflist_t *) (intptr_t) self);
+    return is_ipv6_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Ziflist__1_1test (JNIEnv *env, jclass c, jboolean verbose)
 {

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
@@ -93,6 +93,21 @@ public class Ziflist implements AutoCloseable{
         __print (self);
     }
     /*
+    Get a list of network interfaces currently defined on the system
+    Includes IPv6 interfaces                                        
+    */
+    native static long __newIpv6 ();
+    public Ziflist newIpv6 () {
+        return new Ziflist (__newIpv6 ());
+    }
+    /*
+    Reload network interfaces from system, including IPv6
+    */
+    native static void __reloadIpv6 (long self);
+    public void reloadIpv6 () {
+        __reloadIpv6 (self);
+    }
+    /*
     Self test of this class.
     */
     native static void __test (boolean verbose);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Ziflist.java
@@ -108,6 +108,13 @@ public class Ziflist implements AutoCloseable{
         __reloadIpv6 (self);
     }
     /*
+    Return true if the current interface uses IPv6
+    */
+    native static boolean __isIpv6 (long self);
+    public boolean isIpv6 () {
+        return __isIpv6 (self);
+    }
+    /*
     Self test of this class.
     */
     native static void __test (boolean verbose);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1477,6 +1477,10 @@ ziflist_t *
 void
     ziflist_reload_ipv6 (ziflist_t *self);
 
+// Return true if the current interface uses IPv6
+bool
+    ziflist_is_ipv6 (ziflist_t *self);
+
 // Self test of this class.
 void
     ziflist_test (bool verbose);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1468,6 +1468,15 @@ const char *
 void
     ziflist_print (ziflist_t *self);
 
+// Get a list of network interfaces currently defined on the system
+// Includes IPv6 interfaces                                        
+ziflist_t *
+    ziflist_new_ipv6 (void);
+
+// Reload network interfaces from system, including IPv6
+void
+    ziflist_reload_ipv6 (ziflist_t *self);
+
 // Self test of this class.
 void
     ziflist_test (bool verbose);

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1546,6 +1546,12 @@ nothing my_ziflist.reloadIpv6 ()
 Reload network interfaces from system, including IPv6
 
 ```
+boolean my_ziflist.isIpv6 ()
+```
+
+Return true if the current interface uses IPv6
+
+```
 nothing my_ziflist.test (Boolean)
 ```
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1533,6 +1533,19 @@ nothing my_ziflist.print ()
 Return the list of interfaces.
 
 ```
+ziflist my_ziflist.newIpv6 ()
+```
+
+Get a list of network interfaces currently defined on the system
+Includes IPv6 interfaces
+
+```
+nothing my_ziflist.reloadIpv6 ()
+```
+
+Reload network interfaces from system, including IPv6
+
+```
 nothing my_ziflist.test (Boolean)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -2837,6 +2837,8 @@ NAN_MODULE_INIT (Ziflist::Init) {
     Nan::SetPrototypeMethod (tpl, "broadcast", _broadcast);
     Nan::SetPrototypeMethod (tpl, "netmask", _netmask);
     Nan::SetPrototypeMethod (tpl, "print", _print);
+    Nan::SetPrototypeMethod (tpl, "newIpv6", _new_ipv6);
+    Nan::SetPrototypeMethod (tpl, "reloadIpv6", _reload_ipv6);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -2919,6 +2921,22 @@ NAN_METHOD (Ziflist::_netmask) {
 NAN_METHOD (Ziflist::_print) {
     Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
     ziflist_print (ziflist->self);
+}
+
+NAN_METHOD (Ziflist::_new_ipv6) {
+    ziflist_t *result = ziflist_new_ipv6 ();
+    Ziflist *ziflist_result = new Ziflist (result);
+    if (ziflist_result) {
+    //  Don't yet know how to return a new object
+    //      ziflist->Wrap (info.This ());
+    //      info.GetReturnValue ().Set (info.This ());
+        info.GetReturnValue ().Set (Nan::New<Boolean>(true));
+    }
+}
+
+NAN_METHOD (Ziflist::_reload_ipv6) {
+    Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
+    ziflist_reload_ipv6 (ziflist->self);
 }
 
 NAN_METHOD (Ziflist::_test) {

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -2839,6 +2839,7 @@ NAN_MODULE_INIT (Ziflist::Init) {
     Nan::SetPrototypeMethod (tpl, "print", _print);
     Nan::SetPrototypeMethod (tpl, "newIpv6", _new_ipv6);
     Nan::SetPrototypeMethod (tpl, "reloadIpv6", _reload_ipv6);
+    Nan::SetPrototypeMethod (tpl, "isIpv6", _is_ipv6);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -2937,6 +2938,12 @@ NAN_METHOD (Ziflist::_new_ipv6) {
 NAN_METHOD (Ziflist::_reload_ipv6) {
     Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
     ziflist_reload_ipv6 (ziflist->self);
+}
+
+NAN_METHOD (Ziflist::_is_ipv6) {
+    Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
+    bool result = ziflist_is_ipv6 (ziflist->self);
+    info.GetReturnValue ().Set (Nan::New<Boolean>(result));
 }
 
 NAN_METHOD (Ziflist::_test) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -414,6 +414,7 @@ class Ziflist: public Nan::ObjectWrap {
     static NAN_METHOD (_print);
     static NAN_METHOD (_new_ipv6);
     static NAN_METHOD (_reload_ipv6);
+    static NAN_METHOD (_is_ipv6);
     static NAN_METHOD (_test);
 };
 

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -412,6 +412,8 @@ class Ziflist: public Nan::ObjectWrap {
     static NAN_METHOD (_broadcast);
     static NAN_METHOD (_netmask);
     static NAN_METHOD (_print);
+    static NAN_METHOD (_new_ipv6);
+    static NAN_METHOD (_reload_ipv6);
     static NAN_METHOD (_test);
 };
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -3116,6 +3116,10 @@ lib.ziflist_netmask.restype = c_char_p
 lib.ziflist_netmask.argtypes = [ziflist_p]
 lib.ziflist_print.restype = None
 lib.ziflist_print.argtypes = [ziflist_p]
+lib.ziflist_new_ipv6.restype = ziflist_p
+lib.ziflist_new_ipv6.argtypes = []
+lib.ziflist_reload_ipv6.restype = None
+lib.ziflist_reload_ipv6.argtypes = [ziflist_p]
 lib.ziflist_test.restype = None
 lib.ziflist_test.argtypes = [c_bool]
 
@@ -3214,6 +3218,20 @@ class Ziflist(object):
         Return the list of interfaces.
         """
         return lib.ziflist_print(self._as_parameter_)
+
+    @staticmethod
+    def new_ipv6():
+        """
+        Get a list of network interfaces currently defined on the system
+Includes IPv6 interfaces
+        """
+        return Ziflist(lib.ziflist_new_ipv6(), True)
+
+    def reload_ipv6(self):
+        """
+        Reload network interfaces from system, including IPv6
+        """
+        return lib.ziflist_reload_ipv6(self._as_parameter_)
 
     @staticmethod
     def test(verbose):

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -3120,6 +3120,8 @@ lib.ziflist_new_ipv6.restype = ziflist_p
 lib.ziflist_new_ipv6.argtypes = []
 lib.ziflist_reload_ipv6.restype = None
 lib.ziflist_reload_ipv6.argtypes = [ziflist_p]
+lib.ziflist_is_ipv6.restype = c_bool
+lib.ziflist_is_ipv6.argtypes = [ziflist_p]
 lib.ziflist_test.restype = None
 lib.ziflist_test.argtypes = [c_bool]
 
@@ -3232,6 +3234,12 @@ Includes IPv6 interfaces
         Reload network interfaces from system, including IPv6
         """
         return lib.ziflist_reload_ipv6(self._as_parameter_)
+
+    def is_ipv6(self):
+        """
+        Return true if the current interface uses IPv6
+        """
+        return lib.ziflist_is_ipv6(self._as_parameter_)
 
     @staticmethod
     def test(verbose):

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -1495,6 +1495,15 @@ const char *
 void
     ziflist_print (ziflist_t *self);
 
+// Get a list of network interfaces currently defined on the system
+// Includes IPv6 interfaces                                        
+ziflist_t *
+    ziflist_new_ipv6 (void);
+
+// Reload network interfaces from system, including IPv6
+void
+    ziflist_reload_ipv6 (ziflist_t *self);
+
 // Self test of this class.
 void
     ziflist_test (bool verbose);

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -1504,6 +1504,10 @@ ziflist_t *
 void
     ziflist_reload_ipv6 (ziflist_t *self);
 
+// Return true if the current interface uses IPv6
+bool
+    ziflist_is_ipv6 (ziflist_t *self);
+
 // Self test of this class.
 void
     ziflist_test (bool verbose);

--- a/bindings/qml/src/QmlZiflist.cpp
+++ b/bindings/qml/src/QmlZiflist.cpp
@@ -62,6 +62,12 @@ void QmlZiflist::reloadIpv6 () {
     ziflist_reload_ipv6 (self);
 };
 
+///
+//  Return true if the current interface uses IPv6
+bool QmlZiflist::isIpv6 () {
+    return ziflist_is_ipv6 (self);
+};
+
 
 QObject* QmlZiflist::qmlAttachedProperties(QObject* object) {
     return new QmlZiflistAttached(object);

--- a/bindings/qml/src/QmlZiflist.cpp
+++ b/bindings/qml/src/QmlZiflist.cpp
@@ -56,11 +56,26 @@ void QmlZiflist::print () {
     ziflist_print (self);
 };
 
+///
+//  Reload network interfaces from system, including IPv6
+void QmlZiflist::reloadIpv6 () {
+    ziflist_reload_ipv6 (self);
+};
+
 
 QObject* QmlZiflist::qmlAttachedProperties(QObject* object) {
     return new QmlZiflistAttached(object);
 }
 
+
+///
+//  Get a list of network interfaces currently defined on the system
+//  Includes IPv6 interfaces                                        
+QmlZiflist *QmlZiflistAttached::newIpv6 () {
+    QmlZiflist *retQ_ = new QmlZiflist ();
+    retQ_->self = ziflist_new_ipv6 ();
+    return retQ_;
+};
 
 ///
 //  Self test of this class.

--- a/bindings/qml/src/QmlZiflist.h
+++ b/bindings/qml/src/QmlZiflist.h
@@ -51,6 +51,9 @@ public slots:
 
     //  Return the list of interfaces.
     void print ();
+
+    //  Reload network interfaces from system, including IPv6
+    void reloadIpv6 ();
 };
 
 class QmlZiflistAttached : public QObject
@@ -64,6 +67,10 @@ public:
     };
     
 public slots:
+    //  Get a list of network interfaces currently defined on the system
+    //  Includes IPv6 interfaces                                        
+    QmlZiflist *newIpv6 ();
+
     //  Self test of this class.
     void test (bool verbose);
 

--- a/bindings/qml/src/QmlZiflist.h
+++ b/bindings/qml/src/QmlZiflist.h
@@ -54,6 +54,9 @@ public slots:
 
     //  Reload network interfaces from system, including IPv6
     void reloadIpv6 ();
+
+    //  Return true if the current interface uses IPv6
+    bool isIpv6 ();
 };
 
 class QmlZiflistAttached : public QObject

--- a/bindings/qt/src/qziflist.cpp
+++ b/bindings/qt/src/qziflist.cpp
@@ -94,6 +94,23 @@ void QZiflist::print ()
 }
 
 ///
+//  Get a list of network interfaces currently defined on the system
+//  Includes IPv6 interfaces                                        
+QZiflist * QZiflist::newIpv6 ()
+{
+    QZiflist *rv = new QZiflist (ziflist_new_ipv6 ());
+    return rv;
+}
+
+///
+//  Reload network interfaces from system, including IPv6
+void QZiflist::reloadIpv6 ()
+{
+    ziflist_reload_ipv6 (self);
+    
+}
+
+///
 //  Self test of this class.
 void QZiflist::test (bool verbose)
 {

--- a/bindings/qt/src/qziflist.cpp
+++ b/bindings/qt/src/qziflist.cpp
@@ -111,6 +111,14 @@ void QZiflist::reloadIpv6 ()
 }
 
 ///
+//  Return true if the current interface uses IPv6
+bool QZiflist::isIpv6 ()
+{
+    bool rv = ziflist_is_ipv6 (self);
+    return rv;
+}
+
+///
 //  Self test of this class.
 void QZiflist::test (bool verbose)
 {

--- a/bindings/qt/src/qziflist.h
+++ b/bindings/qt/src/qziflist.h
@@ -47,6 +47,13 @@ public:
     //  Return the list of interfaces.
     void print ();
 
+    //  Get a list of network interfaces currently defined on the system
+    //  Includes IPv6 interfaces                                        
+    static QZiflist * newIpv6 ();
+
+    //  Reload network interfaces from system, including IPv6
+    void reloadIpv6 ();
+
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/qt/src/qziflist.h
+++ b/bindings/qt/src/qziflist.h
@@ -54,6 +54,9 @@ public:
     //  Reload network interfaces from system, including IPv6
     void reloadIpv6 ();
 
+    //  Return true if the current interface uses IPv6
+    bool isIpv6 ();
+
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -453,6 +453,17 @@ module CZMQ
           raise NotImplementedError, "compile CZMQ with --enable-drafts"
         end
       end
+      begin # DRAFT method
+        attach_function :ziflist_is_ipv6, [:pointer], :bool, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function ziflist_is_ipv6()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.ziflist_is_ipv6(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
       attach_function :ziflist_test, [:bool], :void, **opts
 
       require_relative 'ffi/ziflist'

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -431,6 +431,28 @@ module CZMQ
       attach_function :ziflist_broadcast, [:pointer], :string, **opts
       attach_function :ziflist_netmask, [:pointer], :string, **opts
       attach_function :ziflist_print, [:pointer], :void, **opts
+      begin # DRAFT method
+        attach_function :ziflist_new_ipv6, [], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function ziflist_new_ipv6()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.ziflist_new_ipv6(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
+      begin # DRAFT method
+        attach_function :ziflist_reload_ipv6, [:pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function ziflist_reload_ipv6()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.ziflist_reload_ipv6(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
       attach_function :ziflist_test, [:bool], :void, **opts
 
       require_relative 'ffi/ziflist'

--- a/bindings/ruby/lib/czmq/ffi/ziflist.rb
+++ b/bindings/ruby/lib/czmq/ffi/ziflist.rb
@@ -190,6 +190,16 @@ module CZMQ
         result
       end
 
+      # Return true if the current interface uses IPv6
+      #
+      # @return [Boolean]
+      def is_ipv6()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.ziflist_is_ipv6(self_p)
+        result
+      end
+
       # Self test of this class.
       #
       # @param verbose [Boolean]

--- a/bindings/ruby/lib/czmq/ffi/ziflist.rb
+++ b/bindings/ruby/lib/czmq/ffi/ziflist.rb
@@ -170,6 +170,26 @@ module CZMQ
         result
       end
 
+      # Get a list of network interfaces currently defined on the system
+      # Includes IPv6 interfaces                                        
+      #
+      # @return [Ziflist]
+      def self.new_ipv6()
+        result = ::CZMQ::FFI.ziflist_new_ipv6()
+        result = Ziflist.__new result, true
+        result
+      end
+
+      # Reload network interfaces from system, including IPv6
+      #
+      # @return [void]
+      def reload_ipv6()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.ziflist_reload_ipv6(self_p)
+        result
+      end
+
       # Self test of this class.
       #
       # @param verbose [Boolean]

--- a/include/ziflist.h
+++ b/include/ziflist.h
@@ -23,6 +23,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-drafts to enable.
 //  Get a list of network interfaces currently defined on the system
 CZMQ_EXPORT ziflist_t *
     ziflist_new (void);
@@ -67,6 +69,20 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     ziflist_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Get a list of network interfaces currently defined on the system
+//  Includes IPv6 interfaces                                        
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT ziflist_t *
+    ziflist_new_ipv6 (void);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Reload network interfaces from system, including IPv6
+CZMQ_EXPORT void
+    ziflist_reload_ipv6 (ziflist_t *self);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @end
 
 

--- a/include/ziflist.h
+++ b/include/ziflist.h
@@ -82,6 +82,11 @@ CZMQ_EXPORT ziflist_t *
 CZMQ_EXPORT void
     ziflist_reload_ipv6 (ziflist_t *self);
 
+//  *** Draft method, for development use, may change without warning ***
+//  Return true if the current interface uses IPv6
+CZMQ_EXPORT bool
+    ziflist_is_ipv6 (ziflist_t *self);
+
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end
 

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -113,6 +113,11 @@ CZMQ_PRIVATE void
     ziflist_reload_ipv6 (ziflist_t *self);
 
 //  *** Draft method, defined for internal use only ***
+//  Return true if the current interface uses IPv6
+CZMQ_PRIVATE bool
+    ziflist_is_ipv6 (ziflist_t *self);
+
+//  *** Draft method, defined for internal use only ***
 //  Return message routing ID, if the message came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                      
 CZMQ_PRIVATE uint32_t

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -101,6 +101,18 @@ CZMQ_PRIVATE zhashx_t *
     zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
 
 //  *** Draft method, defined for internal use only ***
+//  Get a list of network interfaces currently defined on the system
+//  Includes IPv6 interfaces                                        
+//  Caller owns return value and must destroy it when done.
+CZMQ_PRIVATE ziflist_t *
+    ziflist_new_ipv6 (void);
+
+//  *** Draft method, defined for internal use only ***
+//  Reload network interfaces from system, including IPv6
+CZMQ_PRIVATE void
+    ziflist_reload_ipv6 (ziflist_t *self);
+
+//  *** Draft method, defined for internal use only ***
 //  Return message routing ID, if the message came from a ZMQ_SERVER socket.
 //  Else returns zero.                                                      
 CZMQ_PRIVATE uint32_t

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -103,29 +103,29 @@ s_self_prepare_udp (self_t *self)
     }
     // if ZSYS_INTERFACE is a single digit, use the corresponding interface in
     // the interface list
-    else if (strlen(iface) == 1 && iface[0] >= '0' && iface[0] <= '9')
+    else if (strlen (iface) == 1 && iface[0] >= '0' && iface[0] <= '9')
     {
-      int if_number = atoi(iface);
-      ziflist_t *iflist = ziflist_new();
-      assert(iflist);
-      const char *name = ziflist_first(iflist);
-      int idx = -1;
-      while (name) {
-        idx++;
-        if (idx==if_number) {
-          //  Using inet_addr instead of inet_aton or inet_atop
-          //  because these are not supported in Win XP
-          send_to = inet_addr(ziflist_broadcast(iflist));
-          bind_to = inet_addr(ziflist_address(iflist));
-          if (self->verbose)
-            zsys_info("zbeacon: interface=%s address=%s broadcast=%s",
-              name, ziflist_address(iflist), ziflist_broadcast(iflist));
-          found_iface = 1;
-          break;      //  iface is known, so allow it
+        int if_number = atoi (iface);
+        ziflist_t *iflist = ziflist_new ();
+        assert (iflist);
+        const char *name = ziflist_first (iflist);
+        int idx = -1;
+        while (name) {
+            idx++;
+            if (idx == if_number) {
+                //  Using inet_addr instead of inet_aton or inet_atop
+                //  because these are not supported in Win XP
+                send_to = inet_addr (ziflist_broadcast (iflist));
+                bind_to = inet_addr (ziflist_address (iflist));
+                if (self->verbose)
+                    zsys_info ("zbeacon: interface=%s address=%s broadcast=%s",
+                            name, ziflist_address (iflist), ziflist_broadcast (iflist));
+                found_iface = 1;
+                break;      //  iface is known, so allow it
+            }
+            name = ziflist_next (iflist);
         }
-        name = ziflist_next(iflist);
-      }
-      ziflist_destroy(&iflist);
+        ziflist_destroy (&iflist);
     }
     else {
         //  Look for matching interface, or first ziflist item

--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -30,6 +30,7 @@ typedef struct {
     char *address;
     char *netmask;
     char *broadcast;
+    bool is_ipv6;
 } interface_t;
 
 
@@ -98,6 +99,8 @@ s_interface_new (char *name, struct sockaddr *address, struct sockaddr *netmask,
         self->broadcast = strdup (zsys_ipv6_mcast_address ());
         assert (self->broadcast);
     }
+
+    self->is_ipv6 = address->sa_family == AF_INET6 ? true : false;
 
     return self;
 }
@@ -420,6 +423,18 @@ ziflist_netmask (ziflist_t *self)
         return iface->netmask;
     else
         return NULL;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return true if the current interface uses IPv6
+
+bool
+ziflist_is_ipv6 (ziflist_t *self)
+{
+    assert (self);
+    interface_t *iface = (interface_t *) zlistx_item ((zlistx_t *) self);
+    return iface->is_ipv6;
 }
 
 

--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -56,18 +56,49 @@ s_interface_destroy (interface_t **self_p)
 //  interface constructor
 
 static interface_t *
-s_interface_new (char *name, inaddr_t address, inaddr_t netmask, inaddr_t broadcast)
+s_interface_new (char *name, struct sockaddr *address, struct sockaddr *netmask,
+        struct sockaddr *broadcast)
 {
+    char hbuf[NI_MAXHOST];
+    int rc;
+
     interface_t *self = (interface_t *) zmalloc (sizeof (interface_t));
     assert (self);
     self->name = strdup (name);
     assert (self->name);
-    self->address = strdup (inet_ntoa (address.sin_addr));
+
+    rc = getnameinfo (address, address->sa_family == AF_INET ?
+            sizeof (struct sockaddr_in) : sizeof (struct sockaddr_in6),
+            hbuf, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+    assert (rc == 0);
+    self->address = strdup (hbuf);
     assert (self->address);
-    self->netmask = strdup (inet_ntoa (netmask.sin_addr));
+
+    rc = getnameinfo (netmask, netmask->sa_family == AF_INET ?
+            sizeof (struct sockaddr_in) : sizeof (struct sockaddr_in6),
+            hbuf, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+    assert (rc == 0);
+    self->netmask = strdup (hbuf);
     assert (self->netmask);
-    self->broadcast = strdup (inet_ntoa (broadcast.sin_addr));
-    assert (self->broadcast);
+
+    if (address->sa_family == AF_INET) {
+        //  If the returned broadcast address is the same as source
+        //  address, build the broadcast address from the source
+        //  address and netmask.
+        if (((inaddr_t *)address)->sin_addr.s_addr == ((inaddr_t *)broadcast)->sin_addr.s_addr)
+            ((inaddr_t *)broadcast)->sin_addr.s_addr |= ~(((inaddr_t *)netmask)->sin_addr.s_addr);
+
+        rc = getnameinfo (broadcast, sizeof (struct sockaddr_in), hbuf, NI_MAXHOST,
+                NULL, 0, NI_NUMERICHOST);
+        assert (rc == 0);
+        self->broadcast = strdup (hbuf);
+        assert (self->broadcast);
+    } else {
+        //  The default is link-local all-node multicast group fe02::1
+        self->broadcast = strdup (zsys_ipv6_mcast_address ());
+        assert (self->broadcast);
+    }
+
     return self;
 }
 
@@ -84,6 +115,20 @@ ziflist_new (void)
     assert (self);
     zlistx_set_destructor ((zlistx_t *) self, (czmq_destructor *) s_interface_destroy);
     ziflist_reload (self);
+    return self;
+}
+
+//  --------------------------------------------------------------------------
+//  Get a list of network interfaces currently defined on the system
+//  Includes IPv6 interfaces
+
+ziflist_t *
+ziflist_new_ipv6 (void)
+{
+    ziflist_t *self = (ziflist_t *) zlistx_new ();
+    assert (self);
+    zlistx_set_destructor ((zlistx_t *) self, (czmq_destructor *) s_interface_destroy);
+    ziflist_reload_ipv6 (self);
     return self;
 }
 
@@ -121,11 +166,12 @@ ziflist_destroy (ziflist_t **self_p)
 //  Helper function to verify if one interface's flags are what we want.
 
 static bool
-s_valid_flags (short flags)
+s_valid_flags (short flags, bool ipv6)
 {
     return (flags & IFF_UP)             //  Only use interfaces that are running
            && !(flags & IFF_LOOPBACK)   //  Ignore loopback interface
-           && (flags & IFF_BROADCAST)   //  Only use interfaces that have BROADCAST
+           && ((ipv6 || (flags & IFF_BROADCAST))  //  Only use interfaces that have BROADCAST
+                   && (!ipv6 || (flags & IFF_MULTICAST))) //  or IPv6 and MULTICAST
 #   if defined (IFF_SLAVE)
            && !(flags & IFF_SLAVE)      //  Ignore devices that are bonding slaves.
 #   endif
@@ -135,10 +181,10 @@ s_valid_flags (short flags)
 
 
 //  --------------------------------------------------------------------------
-//  Reload network interfaces from system
+//  Helper to reload network interfaces from system
 
-void
-ziflist_reload (ziflist_t *self)
+static void
+s_reload (ziflist_t *self, bool ipv6)
 {
     assert (self);
     zlistx_t *list = (zlistx_t *) self;
@@ -150,23 +196,16 @@ ziflist_reload (ziflist_t *self)
         struct ifaddrs *interface = interfaces;
         while (interface) {
             //  On Solaris, loopback interfaces have a NULL in ifa_broadaddr
-            if (interface->ifa_broadaddr
-            &&  interface->ifa_addr
-            &&  interface->ifa_addr->sa_family == AF_INET
-            &&  s_valid_flags (interface->ifa_flags)) {
-                inaddr_t address = *(inaddr_t *) interface->ifa_addr;
-                inaddr_t netmask = *(inaddr_t *) interface->ifa_netmask;
-                inaddr_t broadcast = *(inaddr_t *) interface->ifa_broadaddr;
-
-                //  If the returned broadcast address is the same as source
-                //  address, build the broadcast address from the source
-                //  address and netmask.
-                if (address.sin_addr.s_addr == broadcast.sin_addr.s_addr)
-                    broadcast.sin_addr.s_addr |= ~(netmask.sin_addr.s_addr);
-
-                interface_t *item =
-                    s_interface_new (interface->ifa_name, address, netmask,
-                                     broadcast);
+            if (interface->ifa_addr
+            && (interface->ifa_broadaddr
+                    || (ipv6 && (interface->ifa_addr->sa_family == AF_INET6)))
+            &&(interface->ifa_addr->sa_family == AF_INET
+                    || (ipv6 && (interface->ifa_addr->sa_family == AF_INET6)))
+            &&  s_valid_flags (interface->ifa_flags,
+                    ipv6 && (interface->ifa_addr->sa_family == AF_INET6))) {
+                interface_t *item = s_interface_new (interface->ifa_name,
+                        interface->ifa_addr, interface->ifa_netmask,
+                        interface->ifa_broadaddr);
                 if (item)
                     zlistx_add_end (list, item);
             }
@@ -191,8 +230,6 @@ ziflist_reload (ziflist_t *self)
             struct ifreq *ifr = &ifconfig.ifc_req [index];
             //  Check interface flags
             bool is_valid = false;
-            if (!ioctl (sock, SIOCGIFFLAGS, (caddr_t) ifr, sizeof (struct ifreq)))
-                is_valid = s_valid_flags (ifr->ifr_flags);
 
             //  Get interface properties
             inaddr_t address = { 0 };
@@ -200,6 +237,10 @@ ziflist_reload (ziflist_t *self)
                 address = *((inaddr_t *) &ifr->ifr_addr);
             else
                 is_valid = false;
+
+            if (!ioctl (sock, SIOCGIFFLAGS, (caddr_t) ifr, sizeof (struct ifreq)))
+                is_valid = s_valid_flags (ifr->ifr_flags,
+                        ipv6 && (address.sin_family == AF_INET6));
 
             inaddr_t broadcast = { 0 };
             if (!ioctl (sock, SIOCGIFBRDADDR, (caddr_t) ifr, sizeof (struct ifreq)))
@@ -214,8 +255,9 @@ ziflist_reload (ziflist_t *self)
                 is_valid = false;
 
             if (is_valid) {
-                interface_t *item = s_interface_new (ifr->ifr_name, address,
-                                                     netmask, broadcast);
+                interface_t *item = s_interface_new (ifr->ifr_name,
+                        (struct sockaddr *)&address, (struct sockaddr *)&netmask,
+                        (struct sockaddr *)&broadcast);
                 if (item)
                     zlistx_add_end (list, item);
             }
@@ -225,6 +267,7 @@ ziflist_reload (ziflist_t *self)
     }
 
 #   elif defined (__WINDOWS__)
+    // TODO: IPv6 support
     ULONG addr_size = 0;
     DWORD rc = GetAdaptersAddresses (AF_INET, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &addr_size);
     assert (rc == ERROR_BUFFER_OVERFLOW);
@@ -250,13 +293,16 @@ ziflist_reload (ziflist_t *self)
                      && (pPrefix->PrefixLength <= 32);
 
         if (valid) {
-            inaddr_t address = *(inaddr_t *) pUnicast->Address.lpSockaddr;
-            inaddr_t netmask;
+            struct sockaddr_in address, netmask, broadcast;
+            address = *(sockaddr_in *)pUnicast->Address.lpSockaddr;
+            address.sin_family = AF_INET;
             netmask.sin_addr.s_addr = htonl ((0xffffffffU) << (32 - pPrefix->PrefixLength));
-            inaddr_t broadcast = address;
+            netmask.sin_family = AF_INET;
+            broadcast = address;
             broadcast.sin_addr.s_addr |= ~(netmask.sin_addr.s_addr);
-            interface_t *item = s_interface_new (asciiFriendlyName, address,
-                                                 netmask, broadcast);
+            interface_t *item = s_interface_new (asciiFriendlyName,
+                    (struct sockaddr *)&address, (struct sockaddr *)&netmask,
+                    (struct sockaddr *)&broadcast);
             if (item)
                 zlistx_add_end (list, item);
         }
@@ -268,6 +314,26 @@ ziflist_reload (ziflist_t *self)
 #   else
 #       error "Interface detection TBD on this operating system"
 #   endif
+}
+
+
+//  --------------------------------------------------------------------------
+//  Reload network interfaces from system
+
+void
+ziflist_reload (ziflist_t *self)
+{
+    s_reload (self, false);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Reload network interfaces from system, including IPv6
+
+void
+ziflist_reload_ipv6 (ziflist_t *self)
+{
+    s_reload (self, true);
 }
 
 
@@ -366,6 +432,16 @@ ziflist_test (bool verbose)
     printf (" * ziflist: ");
     if (verbose)
         printf ("\n");
+
+    // TODO: for any Windows dev, any alternative to this?
+#if defined (__WINDOWS__)
+    WORD version_requested = MAKEWORD (2, 2);
+    WSADATA wsa_data;
+    int rc = WSAStartup (version_requested, &wsa_data);
+    assert (rc == 0);
+    assert (LOBYTE (wsa_data.wVersion) == 2 &&
+        HIBYTE (wsa_data.wVersion) == 2);
+#endif
 
     //  @selftest
     ziflist_t *iflist = ziflist_new ();

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -204,6 +204,9 @@ zsys_init (void)
 
     if (getenv ("ZSYS_IPV6_MCAST_ADDRESS"))
         zsys_set_ipv6_mcast_address (getenv ("ZSYS_IPV6_MCAST_ADDRESS"));
+    else
+        zsys_set_ipv6_mcast_address ("ff02:0:0:0:0:0:0:1");
+
 
     if (getenv ("ZSYS_LOGIDENT"))
         zsys_set_logident (getenv ("ZSYS_LOGIDENT"));
@@ -1480,8 +1483,8 @@ zsys_ipv6_address (void)
 
 
 //  --------------------------------------------------------------------------
-//  Set IPv6 milticast address to use for sending zbeacon messages. This needs
-//  to be set if IPv6 is enabled. If the environment variable
+//  Set IPv6 multicast address to use for sending zbeacon messages. The default
+//  is fe02::1 (link-local all-node). If the environment variable
 //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 //  address.
 
@@ -1496,13 +1499,13 @@ zsys_set_ipv6_mcast_address (const char *value)
 
 
 //  --------------------------------------------------------------------------
-//  Return IPv6 multicast address to use for sending zbeacon, or "" if none was
-//  set.
+//  Return IPv6 multicast address to use for sending zbeacon, or
+//  "ff02:0:0:0:0:0:0:1" if none was set.
 
 const char *
 zsys_ipv6_mcast_address (void)
 {
-    return s_ipv6_mcast_address? s_ipv6_mcast_address: "";
+    return s_ipv6_mcast_address ? s_ipv6_mcast_address : "ff02:0:0:0:0:0:0:1";
 }
 
 


### PR DESCRIPTION
Solution: see commits

Given the output would change I added 2 new draft ziflist_new_ipv6 and ziflist_reload_ipv6 to keep backward compatibility.
Not implemented for Windows, help needed!