### PR TITLE
Problem: windows build via build.bat does not have enable/disable draft api switch

### DIFF
--- a/builds/msvc/vs2010/build.bat
+++ b/builds/msvc/vs2010/build.bat
@@ -23,8 +23,8 @@ IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools
 
 SET packages=
-IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2010\libzmq.import.props" (
-    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2010\libzmq.import.props" . > %log%
+IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" (
+    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" . > %log%
     IF errorlevel 1 GOTO error
 ) ELSE (
     ECHO Did not find libzmq, aborting.

--- a/builds/msvc/vs2010/czmq.import.props
+++ b/builds/msvc/vs2010/czmq.import.props
@@ -15,6 +15,13 @@
   <ItemGroup Label="BuildOptionsExtension">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)czmq.import.xml" />
   </ItemGroup>
+  
+  <!-- Configuration -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(Option-draftapi)' == 'true'">CZMQ_BUILD_DRAFT_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 
   <!-- Linkage -->
   <ItemDefinitionGroup>
@@ -33,22 +40,22 @@
   <Target Name="Linkage-czmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.pdb"
-          DestinationFiles="$(TargetDir)libczmq.pdb"
+          DestinationFiles="$(TargetDir)czmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Messages -->
   <Target Name="czmq-info" BeforeTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
-    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)libczmq.dll" Importance="high"/>
-    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)libczmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
+    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)czmq.dll" Importance="high"/>
+    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)czmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
   </Target>
 <!--
 ################################################################################

--- a/builds/msvc/vs2010/libczmq/libczmq.import.xml
+++ b/builds/msvc/vs2010/libczmq/libczmq.import.xml
@@ -6,6 +6,19 @@
 ################################################################################
 -->
 <ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework">
+  <Rule Name="czmq-options-uiextension" PageTemplate="tool" DisplayName="CZMQ Options" SwitchPrefix="/" Order="1">
+    <Rule.Categories>
+      <Category Name="draftapi" DisplayName="draftapi" />
+    </Rule.Categories>
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="" />
+    </Rule.DataSource>
+    <EnumProperty Name="Option-draftapi" DisplayName="Enable Draft API" Description="Enable Draft API build option" Category="draftapi">
+      <EnumValue Name="" DisplayName="No" />
+      <EnumValue Name="true" DisplayName="Yes" />
+    </EnumProperty>
+  </Rule>
+  
   <Rule Name="czmq-linkage-uiextension" PageTemplate="tool" DisplayName="Local Dependencies" SwitchPrefix="/" Order="1">
     <Rule.Categories>
       <Category Name="libczmq" DisplayName="CZMQ" />

--- a/builds/msvc/vs2010/libczmq/libczmq.vcxproj
+++ b/builds/msvc/vs2010/libczmq/libczmq.vcxproj
@@ -89,6 +89,19 @@
     <ClInclude Include="..\..\..\..\src\foreign/slre/slre.h" />
     <ClInclude Include="..\..\..\..\src\foreign/slre/readme.txt" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Option-draftapi)' == 'true'">
+    <ClCompile Include="..\..\..\..\src\zproc.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztimerset.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztrie.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+  </ItemGroup>
+  
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">
       <CompileAs>CompileAsCpp</CompileAs>
@@ -150,19 +163,10 @@
     <ClCompile Include="..\..\..\..\src\zpoller.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\src\zproc.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zsock.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zstr.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztimerset.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztrie.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zuuid.c">

--- a/builds/msvc/vs2012/build.bat
+++ b/builds/msvc/vs2012/build.bat
@@ -23,8 +23,8 @@ IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools
 
 SET packages=
-IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2012\libzmq.import.props" (
-    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2012\libzmq.import.props" . > %log%
+IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" (
+    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" . > %log%
     IF errorlevel 1 GOTO error
 ) ELSE (
     ECHO Did not find libzmq, aborting.

--- a/builds/msvc/vs2012/czmq.import.props
+++ b/builds/msvc/vs2012/czmq.import.props
@@ -15,6 +15,13 @@
   <ItemGroup Label="BuildOptionsExtension">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)czmq.import.xml" />
   </ItemGroup>
+  
+  <!-- Configuration -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(Option-draftapi)' == 'true'">CZMQ_BUILD_DRAFT_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 
   <!-- Linkage -->
   <ItemDefinitionGroup>
@@ -33,22 +40,22 @@
   <Target Name="Linkage-czmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.pdb"
-          DestinationFiles="$(TargetDir)libczmq.pdb"
+          DestinationFiles="$(TargetDir)czmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Messages -->
   <Target Name="czmq-info" BeforeTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
-    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)libczmq.dll" Importance="high"/>
-    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)libczmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
+    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)czmq.dll" Importance="high"/>
+    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)czmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
   </Target>
 <!--
 ################################################################################

--- a/builds/msvc/vs2012/libczmq/libczmq.import.xml
+++ b/builds/msvc/vs2012/libczmq/libczmq.import.xml
@@ -6,6 +6,19 @@
 ################################################################################
 -->
 <ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework">
+  <Rule Name="czmq-options-uiextension" PageTemplate="tool" DisplayName="CZMQ Options" SwitchPrefix="/" Order="1">
+    <Rule.Categories>
+      <Category Name="draftapi" DisplayName="draftapi" />
+    </Rule.Categories>
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="" />
+    </Rule.DataSource>
+    <EnumProperty Name="Option-draftapi" DisplayName="Enable Draft API" Description="Enable Draft API build option" Category="draftapi">
+      <EnumValue Name="" DisplayName="No" />
+      <EnumValue Name="true" DisplayName="Yes" />
+    </EnumProperty>
+  </Rule>
+  
   <Rule Name="czmq-linkage-uiextension" PageTemplate="tool" DisplayName="Local Dependencies" SwitchPrefix="/" Order="1">
     <Rule.Categories>
       <Category Name="libczmq" DisplayName="CZMQ" />

--- a/builds/msvc/vs2012/libczmq/libczmq.vcxproj
+++ b/builds/msvc/vs2012/libczmq/libczmq.vcxproj
@@ -89,6 +89,19 @@
     <ClInclude Include="..\..\..\..\src\foreign/slre/slre.h" />
     <ClInclude Include="..\..\..\..\src\foreign/slre/readme.txt" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Option-draftapi)' == 'true'">
+    <ClCompile Include="..\..\..\..\src\zproc.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztimerset.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztrie.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+  </ItemGroup>
+  
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">
       <CompileAs>CompileAsCpp</CompileAs>
@@ -150,19 +163,10 @@
     <ClCompile Include="..\..\..\..\src\zpoller.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\src\zproc.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zsock.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zstr.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztimerset.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztrie.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zuuid.c">

--- a/builds/msvc/vs2013/build.bat
+++ b/builds/msvc/vs2013/build.bat
@@ -23,8 +23,8 @@ IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools
 
 SET packages=
-IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2013\libzmq.import.props" (
-    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2013\libzmq.import.props" . > %log%
+IF EXIST "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" (
+    COPY /Y "..\..\..\..\libzmq\builds/msvc/vs2015\libzmq.import.props" . > %log%
     IF errorlevel 1 GOTO error
 ) ELSE (
     ECHO Did not find libzmq, aborting.

--- a/builds/msvc/vs2013/czmq.import.props
+++ b/builds/msvc/vs2013/czmq.import.props
@@ -15,6 +15,13 @@
   <ItemGroup Label="BuildOptionsExtension">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)czmq.import.xml" />
   </ItemGroup>
+  
+  <!-- Configuration -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(Option-draftapi)' == 'true'">CZMQ_BUILD_DRAFT_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 
   <!-- Linkage -->
   <ItemDefinitionGroup>
@@ -33,22 +40,22 @@
   <Target Name="Linkage-czmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.pdb"
-          DestinationFiles="$(TargetDir)libczmq.pdb"
+          DestinationFiles="$(TargetDir)czmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Messages -->
   <Target Name="czmq-info" BeforeTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
-    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)libczmq.dll" Importance="high"/>
-    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)libczmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
+    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)czmq.dll" Importance="high"/>
+    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)czmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
   </Target>
 <!--
 ################################################################################

--- a/builds/msvc/vs2013/libczmq/libczmq.import.xml
+++ b/builds/msvc/vs2013/libczmq/libczmq.import.xml
@@ -6,6 +6,19 @@
 ################################################################################
 -->
 <ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework">
+  <Rule Name="czmq-options-uiextension" PageTemplate="tool" DisplayName="CZMQ Options" SwitchPrefix="/" Order="1">
+    <Rule.Categories>
+      <Category Name="draftapi" DisplayName="draftapi" />
+    </Rule.Categories>
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="" />
+    </Rule.DataSource>
+    <EnumProperty Name="Option-draftapi" DisplayName="Enable Draft API" Description="Enable Draft API build option" Category="draftapi">
+      <EnumValue Name="" DisplayName="No" />
+      <EnumValue Name="true" DisplayName="Yes" />
+    </EnumProperty>
+  </Rule>
+
   <Rule Name="czmq-linkage-uiextension" PageTemplate="tool" DisplayName="Local Dependencies" SwitchPrefix="/" Order="1">
     <Rule.Categories>
       <Category Name="libczmq" DisplayName="CZMQ" />

--- a/builds/msvc/vs2013/libczmq/libczmq.vcxproj
+++ b/builds/msvc/vs2013/libczmq/libczmq.vcxproj
@@ -89,6 +89,19 @@
     <ClInclude Include="..\..\..\..\src\foreign/slre/slre.h" />
     <ClInclude Include="..\..\..\..\src\foreign/slre/readme.txt" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Option-draftapi)' == 'true'">
+    <ClCompile Include="..\..\..\..\src\zproc.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztimerset.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztrie.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+  </ItemGroup>
+  
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">
       <CompileAs>CompileAsCpp</CompileAs>
@@ -149,20 +162,11 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zpoller.c">
       <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\zproc.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
+    </ClCompile>  
     <ClCompile Include="..\..\..\..\src\zsock.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zstr.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztimerset.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztrie.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zuuid.c">

--- a/builds/msvc/vs2015/czmq.import.props
+++ b/builds/msvc/vs2015/czmq.import.props
@@ -15,6 +15,13 @@
   <ItemGroup Label="BuildOptionsExtension">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)czmq.import.xml" />
   </ItemGroup>
+  
+  <!-- Configuration -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(Option-draftapi)' == 'true'">CZMQ_BUILD_DRAFT_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 
   <!-- Linkage -->
   <ItemDefinitionGroup>
@@ -33,22 +40,22 @@
   <Target Name="Linkage-czmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libczmq.pdb"
-          DestinationFiles="$(TargetDir)libczmq.pdb"
+          DestinationFiles="$(TargetDir)czmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
           SourceFiles="$(ProjectDir)..\..\..\..\..\czmq\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libczmq.dll"
-          DestinationFiles="$(TargetDir)libczmq.dll"
+          DestinationFiles="$(TargetDir)czmq.dll"
           SkipUnchangedFiles="true" />
   </Target>
 
   <!-- Messages -->
   <Target Name="czmq-info" BeforeTargets="AfterBuild" Condition="'$(Linkage-czmq)' == 'dynamic'">
-    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)libczmq.dll" Importance="high"/>
-    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)libczmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
+    <Message Text="Copying libczmq.dll -&gt; $(TargetDir)czmq.dll" Importance="high"/>
+    <Message Text="Copying libczmq.pdb -&gt; $(TargetDir)czmq.pdb" Importance="high" Condition="$(Configuration.IndexOf('Debug')) != -1" />
   </Target>
 <!--
 ################################################################################

--- a/builds/msvc/vs2015/libczmq/libczmq.import.xml
+++ b/builds/msvc/vs2015/libczmq/libczmq.import.xml
@@ -6,6 +6,19 @@
 ################################################################################
 -->
 <ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework">
+  <Rule Name="czmq-options-uiextension" PageTemplate="tool" DisplayName="CZMQ Options" SwitchPrefix="/" Order="1">
+    <Rule.Categories>
+      <Category Name="draftapi" DisplayName="draftapi" />
+    </Rule.Categories>
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="" />
+    </Rule.DataSource>
+    <EnumProperty Name="Option-draftapi" DisplayName="Enable Draft API" Description="Enable Draft API build option" Category="draftapi">
+      <EnumValue Name="" DisplayName="No" />
+      <EnumValue Name="true" DisplayName="Yes" />
+    </EnumProperty>
+  </Rule>
+  
   <Rule Name="czmq-linkage-uiextension" PageTemplate="tool" DisplayName="Local Dependencies" SwitchPrefix="/" Order="1">
     <Rule.Categories>
       <Category Name="libczmq" DisplayName="CZMQ" />

--- a/builds/msvc/vs2015/libczmq/libczmq.vcxproj
+++ b/builds/msvc/vs2015/libczmq/libczmq.vcxproj
@@ -89,6 +89,19 @@
     <ClInclude Include="..\..\..\..\src\foreign/slre/slre.h" />
     <ClInclude Include="..\..\..\..\src\foreign/slre/readme.txt" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(Option-draftapi)' == 'true'">
+    <ClCompile Include="..\..\..\..\src\zproc.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztimerset.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\ztrie.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+  </ItemGroup>
+  
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\zactor.c">
       <CompileAs>CompileAsCpp</CompileAs>
@@ -150,19 +163,10 @@
     <ClCompile Include="..\..\..\..\src\zpoller.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\src\zproc.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\src\zsock.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zstr.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztimerset.c">
-      <CompileAs>CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\src\ztrie.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\zuuid.c">


### PR DESCRIPTION
Solution: expose the optional configuration using a property in `czmq.import.props`. Add the option to VS UI in `libczmq.import.xml`. Use the condition in `libczmq.vcxproj` to include draft classes only when option is true.

To use the switch, pass `/p:Option-draftapi=[false|true]` to msbuild. Example from `build.bat`:

`msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 /p:Option-draftapi=false %packages% %solution% %target% >> %log%`

Probably these changes should go to zproject in someway, as the involved files have the "THIS FILE IS 100% GENERATED BY ZPROJECT; DO NOT EDIT EXCEPT EXPERIMENTALLY" comment.

