### PR TITLE
Problem: getaddrinfo in zbeacon fails on Android and FreeBSD

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -117,7 +117,10 @@ s_self_prepare_udp (self_t *self)
     struct addrinfo *send_to = NULL;
     struct addrinfo hint;
     memset (&hint, 0, sizeof(struct addrinfo));
-    hint.ai_flags = AI_NUMERICHOST | AI_V4MAPPED;
+    hint.ai_flags = AI_NUMERICHOST;
+#if !defined (CZMQ_HAVE_ANDROID) && !defined (CZMQ_HAVE_FREEBSD)
+    hint.ai_flags |= AI_V4MAPPED;
+#endif
     hint.ai_socktype = SOCK_DGRAM;
     hint.ai_protocol = IPPROTO_UDP;
     hint.ai_family = zsys_ipv6 () ? AF_INET6 : AF_INET;


### PR DESCRIPTION
Solution: do not use AI_V4MAPPED on those systems as it's not
supported
Fixes #1641