### PR TITLE
Problem: zproc_run method can't be expressed as zproject API model

### DIFF
--- a/api/zproc.api
+++ b/api/zproc.api
@@ -20,6 +20,12 @@
         Destroy zproc, wait until process ends.
     </destructor>
 
+    <method name = "set args" >
+        Setup the command line arguments, the first item must be an (absolute) filename
+        to run.
+        <argument name = "args" type = "zlistx" />
+    </method>
+
     <method name = "set stdin" >
         Connects process stdin with a readable ('>', connect) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc

--- a/api/zproc.api
+++ b/api/zproc.api
@@ -26,6 +26,11 @@
         <argument name = "args" type = "zlistx" />
     </method>
 
+    <method name = "set env" >
+        Setup the environment variables for the process.
+        <argument name = "args" type = "zhashx" />
+    </method>
+
     <method name = "set stdin" >
         Connects process stdin with a readable ('>', connect) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc

--- a/api/zproc.api
+++ b/api/zproc.api
@@ -70,6 +70,11 @@
         <return type="anything" />
     </method>
 
+    <method name = "run" >
+        Starts the process.
+        <return type = "integer" />
+    </method>
+
     <method name = "returncode">
         process exit code
         <return type="integer" />

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
@@ -32,6 +32,12 @@ Java_org_zeromq_czmq_Zproc__1_1setArgs (JNIEnv *env, jclass c, jlong self, jlong
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zproc__1_1setEnv (JNIEnv *env, jclass c, jlong self, jlong args)
+{
+    zproc_set_env ((zproc_t *) (intptr_t) self, (zhashx_t *) (intptr_t) args);
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zproc__1_1setStdin (JNIEnv *env, jclass c, jlong self, jlong socket)
 {
     zproc_set_stdin ((zproc_t *) (intptr_t) self, (void *) (intptr_t) socket);

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
@@ -26,6 +26,12 @@ Java_org_zeromq_czmq_Zproc__1_1destroy (JNIEnv *env, jclass c, jlong self)
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zproc__1_1setArgs (JNIEnv *env, jclass c, jlong self, jlong args)
+{
+    zproc_set_args ((zproc_t *) (intptr_t) self, (zlistx_t *) (intptr_t) args);
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zproc__1_1setStdin (JNIEnv *env, jclass c, jlong self, jlong socket)
 {
     zproc_set_stdin ((zproc_t *) (intptr_t) self, (void *) (intptr_t) socket);

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
@@ -77,6 +77,13 @@ Java_org_zeromq_czmq_Zproc__1_1stderr (JNIEnv *env, jclass c, jlong self)
 }
 
 JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zproc__1_1run (JNIEnv *env, jclass c, jlong self)
+{
+    jint run_ = (jint) zproc_run ((zproc_t *) (intptr_t) self);
+    return run_;
+}
+
+JNIEXPORT jint JNICALL
 Java_org_zeromq_czmq_Zproc__1_1returncode (JNIEnv *env, jclass c, jlong self)
 {
     jint returncode_ = (jint) zproc_returncode ((zproc_t *) (intptr_t) self);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -105,6 +105,13 @@ public class Zproc implements AutoCloseable{
         return __stderr (self);
     }
     /*
+    Starts the process.
+    */
+    native static int __run (long self);
+    public int run () {
+        return __run (self);
+    }
+    /*
     process exit code
     */
     native static int __returncode (long self);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -39,6 +39,14 @@ public class Zproc implements AutoCloseable{
         self = 0;
     }
     /*
+    Setup the command line arguments, the first item must be an (absolute) filename
+    to run.                                                                        
+    */
+    native static void __setArgs (long self, long args);
+    public void setArgs (Zlistx args) {
+        __setArgs (self, args.self);
+    }
+    /*
     Connects process stdin with a readable ('>', connect) zeromq socket. If
     socket argument is NULL, zproc creates own managed pair of inproc      
     sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -47,6 +47,13 @@ public class Zproc implements AutoCloseable{
         __setArgs (self, args.self);
     }
     /*
+    Setup the environment variables for the process.
+    */
+    native static void __setEnv (long self, long args);
+    public void setEnv (Zhashx args) {
+        __setEnv (self, args.self);
+    }
+    /*
     Connects process stdin with a readable ('>', connect) zeromq socket. If
     socket argument is NULL, zproc creates own managed pair of inproc      
     sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -2142,6 +2142,10 @@ void
 void
     zproc_set_args (zproc_t *self, zlistx_t *args);
 
+// Setup the environment variables for the process.
+void
+    zproc_set_env (zproc_t *self, zhashx_t *args);
+
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc      
 // sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -2137,6 +2137,11 @@ zproc_t *
 void
     zproc_destroy (zproc_t **self_p);
 
+// Setup the command line arguments, the first item must be an (absolute) filename
+// to run.                                                                        
+void
+    zproc_set_args (zproc_t *self, zlistx_t *args);
+
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc      
 // sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -2179,6 +2179,10 @@ void *
 void *
     zproc_stderr (zproc_t *self);
 
+// Starts the process.
+int
+    zproc_run (zproc_t *self);
+
 // process exit code
 int
     zproc_returncode (zproc_t *self);

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2044,6 +2044,13 @@ my_zproc.destroy ()
 Methods:
 
 ```
+nothing my_zproc.setArgs (Zlistx)
+```
+
+Setup the command line arguments, the first item must be an (absolute) filename
+to run.
+
+```
 integer my_zproc.returncode ()
 ```
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2057,6 +2057,12 @@ nothing my_zproc.setEnv (Zhashx)
 Setup the environment variables for the process.
 
 ```
+integer my_zproc.run ()
+```
+
+Starts the process.
+
+```
 integer my_zproc.returncode ()
 ```
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2051,6 +2051,12 @@ Setup the command line arguments, the first item must be an (absolute) filename
 to run.
 
 ```
+nothing my_zproc.setEnv (Zhashx)
+```
+
+Setup the environment variables for the process.
+
+```
 integer my_zproc.returncode ()
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -3794,6 +3794,7 @@ NAN_MODULE_INIT (Zproc::Init) {
     Nan::SetPrototypeMethod (tpl, "defined", defined);
     Nan::SetPrototypeMethod (tpl, "setArgs", _set_args);
     Nan::SetPrototypeMethod (tpl, "setEnv", _set_env);
+    Nan::SetPrototypeMethod (tpl, "run", _run);
     Nan::SetPrototypeMethod (tpl, "returncode", _returncode);
     Nan::SetPrototypeMethod (tpl, "pid", _pid);
     Nan::SetPrototypeMethod (tpl, "running", _running);
@@ -3866,6 +3867,12 @@ NAN_METHOD (Zproc::_set_env) {
     Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
     Zhashx *args = Nan::ObjectWrap::Unwrap<Zhashx>(info [0].As<Object>());
     zproc_set_env (zproc->self, args->self);
+}
+
+NAN_METHOD (Zproc::_run) {
+    Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
+    int result = zproc_run (zproc->self);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
 }
 
 NAN_METHOD (Zproc::_returncode) {

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -3792,6 +3792,7 @@ NAN_MODULE_INIT (Zproc::Init) {
     // Prototypes
     Nan::SetPrototypeMethod (tpl, "destroy", destroy);
     Nan::SetPrototypeMethod (tpl, "defined", defined);
+    Nan::SetPrototypeMethod (tpl, "setArgs", _set_args);
     Nan::SetPrototypeMethod (tpl, "returncode", _returncode);
     Nan::SetPrototypeMethod (tpl, "pid", _pid);
     Nan::SetPrototypeMethod (tpl, "running", _running);
@@ -3852,6 +3853,12 @@ NAN_METHOD (Zproc::destroy) {
 NAN_METHOD (Zproc::defined) {
     Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
     info.GetReturnValue ().Set (Nan::New (zproc->self != NULL));
+}
+
+NAN_METHOD (Zproc::_set_args) {
+    Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
+    Zlistx *args = Nan::ObjectWrap::Unwrap<Zlistx>(info [0].As<Object>());
+    zproc_set_args (zproc->self, args->self);
 }
 
 NAN_METHOD (Zproc::_returncode) {

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -3793,6 +3793,7 @@ NAN_MODULE_INIT (Zproc::Init) {
     Nan::SetPrototypeMethod (tpl, "destroy", destroy);
     Nan::SetPrototypeMethod (tpl, "defined", defined);
     Nan::SetPrototypeMethod (tpl, "setArgs", _set_args);
+    Nan::SetPrototypeMethod (tpl, "setEnv", _set_env);
     Nan::SetPrototypeMethod (tpl, "returncode", _returncode);
     Nan::SetPrototypeMethod (tpl, "pid", _pid);
     Nan::SetPrototypeMethod (tpl, "running", _running);
@@ -3859,6 +3860,12 @@ NAN_METHOD (Zproc::_set_args) {
     Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
     Zlistx *args = Nan::ObjectWrap::Unwrap<Zlistx>(info [0].As<Object>());
     zproc_set_args (zproc->self, args->self);
+}
+
+NAN_METHOD (Zproc::_set_env) {
+    Zproc *zproc = Nan::ObjectWrap::Unwrap <Zproc> (info.Holder ());
+    Zhashx *args = Nan::ObjectWrap::Unwrap<Zhashx>(info [0].As<Object>());
+    zproc_set_env (zproc->self, args->self);
 }
 
 NAN_METHOD (Zproc::_returncode) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -559,6 +559,7 @@ class Zproc: public Nan::ObjectWrap {
     static NAN_METHOD (destroy);
     static NAN_METHOD (defined);
     static NAN_METHOD (_set_args);
+    static NAN_METHOD (_set_env);
     static NAN_METHOD (_returncode);
     static NAN_METHOD (_pid);
     static NAN_METHOD (_running);

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -560,6 +560,7 @@ class Zproc: public Nan::ObjectWrap {
     static NAN_METHOD (defined);
     static NAN_METHOD (_set_args);
     static NAN_METHOD (_set_env);
+    static NAN_METHOD (_run);
     static NAN_METHOD (_returncode);
     static NAN_METHOD (_pid);
     static NAN_METHOD (_running);

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -558,6 +558,7 @@ class Zproc: public Nan::ObjectWrap {
     static NAN_METHOD (New);
     static NAN_METHOD (destroy);
     static NAN_METHOD (defined);
+    static NAN_METHOD (_set_args);
     static NAN_METHOD (_returncode);
     static NAN_METHOD (_pid);
     static NAN_METHOD (_running);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -4582,6 +4582,8 @@ lib.zproc_stdout.restype = c_void_p
 lib.zproc_stdout.argtypes = [zproc_p]
 lib.zproc_stderr.restype = c_void_p
 lib.zproc_stderr.argtypes = [zproc_p]
+lib.zproc_run.restype = c_int
+lib.zproc_run.argtypes = [zproc_p]
 lib.zproc_returncode.restype = c_int
 lib.zproc_returncode.argtypes = [zproc_p]
 lib.zproc_pid.restype = c_int
@@ -4742,6 +4744,12 @@ not initialized or external sockets.
 not initialized or external sockets.
         """
         return c_void_p(lib.zproc_stderr(self._as_parameter_))
+
+    def run(self):
+        """
+        Starts the process.
+        """
+        return lib.zproc_run(self._as_parameter_)
 
     def returncode(self):
         """

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -4566,6 +4566,8 @@ lib.zproc_new.restype = zproc_p
 lib.zproc_new.argtypes = []
 lib.zproc_destroy.restype = None
 lib.zproc_destroy.argtypes = [POINTER(zproc_p)]
+lib.zproc_set_args.restype = None
+lib.zproc_set_args.argtypes = [zproc_p, zlistx_p]
 lib.zproc_set_stdin.restype = None
 lib.zproc_set_stdin.argtypes = [zproc_p, c_void_p]
 lib.zproc_set_stdout.restype = None
@@ -4680,6 +4682,13 @@ returns NULL. Code needs to be ported there.
     def __nonzero__(self):
         "Determine whether the object is valid by converting to boolean" # Python 2
         return self._as_parameter_.__nonzero__()
+
+    def set_args(self, args):
+        """
+        Setup the command line arguments, the first item must be an (absolute) filename
+to run.
+        """
+        return lib.zproc_set_args(self._as_parameter_, args)
 
     def set_stdin(self, socket):
         """

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -4568,6 +4568,8 @@ lib.zproc_destroy.restype = None
 lib.zproc_destroy.argtypes = [POINTER(zproc_p)]
 lib.zproc_set_args.restype = None
 lib.zproc_set_args.argtypes = [zproc_p, zlistx_p]
+lib.zproc_set_env.restype = None
+lib.zproc_set_env.argtypes = [zproc_p, zhashx_p]
 lib.zproc_set_stdin.restype = None
 lib.zproc_set_stdin.argtypes = [zproc_p, c_void_p]
 lib.zproc_set_stdout.restype = None
@@ -4689,6 +4691,12 @@ returns NULL. Code needs to be ported there.
 to run.
         """
         return lib.zproc_set_args(self._as_parameter_, args)
+
+    def set_env(self, args):
+        """
+        Setup the environment variables for the process.
+        """
+        return lib.zproc_set_env(self._as_parameter_, args)
 
     def set_stdin(self, socket):
         """

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -2164,6 +2164,11 @@ zproc_t *
 void
     zproc_destroy (zproc_t **self_p);
 
+// Setup the command line arguments, the first item must be an (absolute) filename
+// to run.                                                                        
+void
+    zproc_set_args (zproc_t *self, zlistx_t *args);
+
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc      
 // sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -2169,6 +2169,10 @@ void
 void
     zproc_set_args (zproc_t *self, zlistx_t *args);
 
+// Setup the environment variables for the process.
+void
+    zproc_set_env (zproc_t *self, zhashx_t *args);
+
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc      
 // sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/python_cffi/czmq_cffi.py
+++ b/bindings/python_cffi/czmq_cffi.py
@@ -2206,6 +2206,10 @@ void *
 void *
     zproc_stderr (zproc_t *self);
 
+// Starts the process.
+int
+    zproc_run (zproc_t *self);
+
 // process exit code
 int
     zproc_returncode (zproc_t *self);

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -9,6 +9,13 @@
 
 
 ///
+//  Setup the command line arguments, the first item must be an (absolute) filename
+//  to run.                                                                        
+void QmlZproc::setArgs (QmlZlistx *args) {
+    zproc_set_args (self, args->self);
+};
+
+///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -67,6 +67,12 @@ void *QmlZproc::stderr () {
 };
 
 ///
+//  Starts the process.
+int QmlZproc::run () {
+    return zproc_run (self);
+};
+
+///
 //  process exit code
 int QmlZproc::returncode () {
     return zproc_returncode (self);

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -16,6 +16,12 @@ void QmlZproc::setArgs (QmlZlistx *args) {
 };
 
 ///
+//  Setup the environment variables for the process.
+void QmlZproc::setEnv (QmlZhashx *args) {
+    zproc_set_env (self, args->self);
+};
+
+///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -62,6 +62,9 @@ public slots:
     //  not initialized or external sockets.              
     void *stderr ();
 
+    //  Starts the process.
+    int run ();
+
     //  process exit code
     int returncode ();
 

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -32,6 +32,9 @@ public slots:
     //  to run.                                                                        
     void setArgs (QmlZlistx *args);
 
+    //  Setup the environment variables for the process.
+    void setEnv (QmlZhashx *args);
+
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc      
     //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -28,6 +28,10 @@ public:
     static QObject* qmlAttachedProperties(QObject* object); // defined in QmlZproc.cpp
     
 public slots:
+    //  Setup the command line arguments, the first item must be an (absolute) filename
+    //  to run.                                                                        
+    void setArgs (QmlZlistx *args);
+
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc      
     //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -32,6 +32,15 @@ QZproc::~QZproc ()
 }
 
 ///
+//  Setup the command line arguments, the first item must be an (absolute) filename
+//  to run.                                                                        
+void QZproc::setArgs (QZlistx *args)
+{
+    zproc_set_args (self, args->self);
+    
+}
+
+///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -106,6 +106,14 @@ void * QZproc::stderr ()
 }
 
 ///
+//  Starts the process.
+int QZproc::run ()
+{
+    int rv = zproc_run (self);
+    return rv;
+}
+
+///
 //  process exit code
 int QZproc::returncode ()
 {

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -41,6 +41,14 @@ void QZproc::setArgs (QZlistx *args)
 }
 
 ///
+//  Setup the environment variables for the process.
+void QZproc::setEnv (QZhashx *args)
+{
+    zproc_set_env (self, args->self);
+    
+}
+
+///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -29,6 +29,9 @@ public:
     //  to run.                                                                        
     void setArgs (QZlistx *args);
 
+    //  Setup the environment variables for the process.
+    void setEnv (QZhashx *args);
+
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc      
     //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -25,6 +25,10 @@ public:
     //  Destroy zproc, wait until process ends.
     ~QZproc ();
 
+    //  Setup the command line arguments, the first item must be an (absolute) filename
+    //  to run.                                                                        
+    void setArgs (QZlistx *args);
+
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc      
     //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -59,6 +59,9 @@ public:
     //  not initialized or external sockets.              
     void * stderr ();
 
+    //  Starts the process.
+    int run ();
+
     //  process exit code
     int returncode ();
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -728,6 +728,17 @@ module CZMQ
         end
       end
       begin # DRAFT method
+        attach_function :zproc_run, [:pointer], :int, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zproc_run()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zproc_run(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
+      begin # DRAFT method
         attach_function :zproc_returncode, [:pointer], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -651,6 +651,17 @@ module CZMQ
         end
       end
       begin # DRAFT method
+        attach_function :zproc_set_env, [:pointer, :pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zproc_set_env()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zproc_set_env(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
+      begin # DRAFT method
         attach_function :zproc_set_stdin, [:pointer, :pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -640,6 +640,17 @@ module CZMQ
         end
       end
       begin # DRAFT method
+        attach_function :zproc_set_args, [:pointer, :pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zproc_set_args()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zproc_set_args(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
+      begin # DRAFT method
         attach_function :zproc_set_stdin, [:pointer, :pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -189,6 +189,16 @@ module CZMQ
         result
       end
 
+      # Starts the process.
+      #
+      # @return [Integer]
+      def run()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zproc_run(self_p)
+        result
+      end
+
       # process exit code
       #
       # @return [Integer]

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -92,6 +92,19 @@ module CZMQ
         result
       end
 
+      # Setup the command line arguments, the first item must be an (absolute) filename
+      # to run.                                                                        
+      #
+      # @param args [Zlistx, #__ptr]
+      # @return [void]
+      def set_args(args)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        args = args.__ptr if args
+        result = ::CZMQ::FFI.zproc_set_args(self_p, args)
+        result
+      end
+
       # Connects process stdin with a readable ('>', connect) zeromq socket. If
       # socket argument is NULL, zproc creates own managed pair of inproc      
       # sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -105,6 +105,18 @@ module CZMQ
         result
       end
 
+      # Setup the environment variables for the process.
+      #
+      # @param args [Zhashx, #__ptr]
+      # @return [void]
+      def set_env(args)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        args = args.__ptr if args
+        result = ::CZMQ::FFI.zproc_set_env(self_p, args)
+        result
+      end
+
       # Connects process stdin with a readable ('>', connect) zeromq socket. If
       # socket argument is NULL, zproc creates own managed pair of inproc      
       # sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -89,6 +89,11 @@ CZMQ_EXPORT void *
     zproc_stderr (zproc_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Starts the process.
+CZMQ_EXPORT int
+    zproc_run (zproc_t *self);
+
+//  *** Draft method, for development use, may change without warning ***
 //  process exit code
 CZMQ_EXPORT int
     zproc_returncode (zproc_t *self);

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -39,6 +39,12 @@ CZMQ_EXPORT void
     zproc_destroy (zproc_t **self_p);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Setup the command line arguments, the first item must be an (absolute) filename
+//  to run.                                                                        
+CZMQ_EXPORT void
+    zproc_set_args (zproc_t *self, zlistx_t *args);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -45,6 +45,11 @@ CZMQ_EXPORT void
     zproc_set_args (zproc_t *self, zlistx_t *args);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Setup the environment variables for the process.
+CZMQ_EXPORT void
+    zproc_set_env (zproc_t *self, zhashx_t *args);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc      
 //  sockets.  The writable one is then accessbile via zproc_stdin method.  

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -169,19 +169,6 @@ arr_print (char**self) {
     }
 }
 
-static size_t
-arr_size (char **self) {
-    if (!self)
-        return 0;
-    char **foo = self;
-    size_t size = 0;
-    while (*foo) {
-        size ++;
-        foo ++;
-    }
-    return size;
-}
-
 //      ^^^^^^^                                     ^^^^^^^
 //      #######     internal helpers for zproc      #######
 
@@ -981,10 +968,6 @@ zproc_test (bool verbose)
 
     //  @selftest
     //  0. initialization
-    //  initialize arguments and environment
-    char *const xargv[] = {"zsp", "--stdout", NULL};
-    char *const xenvp[] = {"PATH=/bin/:/sbin/:/usr/bin/:/usr/sbin", NULL};
-
     //  find the right binary
     char *file = "src/zsp";
     if (zsys_file_exists ("_build/../src/zsp"))

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -75,7 +75,7 @@ struct _zpair_t {
 static zpair_t*
 zpair_new (char* endpoint) {
     zpair_t *self = (zpair_t*) zmalloc (sizeof (zpair_t));
-    self->endpoint = strdup (endpoint);
+    self->endpoint = endpoint;
     return self;
 }
 
@@ -1089,7 +1089,7 @@ zproc_test (bool verbose)
     //  @end
 
     // to have zpair print and arr print methods
-    zpair_t *pair = zpair_new ("e");
+    zpair_t *pair = zpair_new (strdup ("e"));
     assert (pair);
     if (verbose)
         zpair_print (pair);

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -612,6 +612,11 @@ zproc_run (zproc_t *self)
     assert (self);
     assert (!self->actor);
 
+    if (!self->args || zlistx_size (self->args) == 0) {
+        zsys_error ("No arguments, nothing to run. Call zproc_set_args before");
+        return -1;
+    }
+
     self->actor = zactor_new (s_zproc_actor, (void*) self);
     self->running = true;
     self->return_code = ZPROC_RUNNING;


### PR DESCRIPTION
Solution: see pull requests

In fact code is way more straightforward than before, because argv/env are built right before execve and not passed from zproc_run to actor and pipe handler.