### PR TITLE
Off-by-one error on expansion of base64 + null termination

### DIFF
--- a/src/zarmour.c
+++ b/src/zarmour.c
@@ -164,7 +164,7 @@ s_base64_decode (const char *data, size_t *size, const char *alphabet, size_t li
     const byte *ceiling = (const byte *) (data + length);
 
     length -= linebreakchars;
-    *size = 3 * (length / 4) + ((length % 4)? length % 4 - 1 : 0) + 1;
+    *size = 3 * (length / 4) + ((length % 4)? length % 4 - 1 : 0) + 2;
     byte *bytes = (byte *) zmalloc (*size);
     if (!bytes)
         return NULL;


### PR DESCRIPTION
Problem: s_base64_decode() has an off-by-one error on expansion. This shows up under valgrind as a corruption.
