### PR TITLE
Problem: zsys_init() + fork() causes undefined behaviour

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -36,7 +36,8 @@ CZMQ_EXPORT void *
 //  when the process exits; however this call lets you force a shutdown
 //  earlier, avoiding any potential problems with atexit() ordering, especially
 //  with Windows DLL builds, where atexit() does not work and zsys_shutdown has
-//  to be called manually.
+//  to be called manually. Resets all zsys global state (i.e., HWM, LINGER, ...)
+//  to their initial values.
 CZMQ_EXPORT void
     zsys_shutdown (void);
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -219,6 +219,44 @@ zsys_init (void)
     return s_process_ctx;
 }
 
+//  --------------------------------------------------------------------------
+//  Restores all CZMQ global state to initial values. Internal function called
+//  by zsys_shutdown().
+
+static void
+zsys_reset (void){
+    s_process_ctx = NULL;
+    zsys_interrupted = 0;
+    zctx_interrupted = 0;
+
+    s_first_time = true;
+    handle_signals = true;
+
+    s_process_ctx = NULL;
+    s_initialized = false;
+
+    s_io_threads = 1;
+    s_max_sockets = 1024;
+    s_max_msgsz = INT_MAX;
+    s_linger = 0;
+    s_sndhwm = 1000;
+    s_rcvhwm = 1000;
+    s_pipehwm = 1000;
+    s_ipv6 = 0;
+    s_interface = NULL;
+    s_ipv6_address = NULL;
+    s_ipv6_mcast_address = NULL;
+    s_auto_use_fd = 0;
+    s_logident = NULL;
+    s_logstream = NULL;
+    s_logsystem = false;
+    s_logsender = NULL;
+
+    s_open_sockets = 0;
+
+    s_sockref_list = NULL;
+}
+
 //  atexit or manual termination for the process
 void
 zsys_shutdown (void)
@@ -282,6 +320,8 @@ zsys_shutdown (void)
     s_ipv6_mcast_address = NULL;
     free (s_logident);
     s_logident = NULL;
+
+    zsys_reset();
 
 #if defined (__UNIX__)
     closelog ();                //  Just to be pedantic


### PR DESCRIPTION
closes https://github.com/zeromq/czmq/issues/1659.

First PR here. I've read and agree to C4.1.

This change requires (some) version change, because code that depends on this fix must have a way to check for it. Not sure how new minor/patch versions are handled in the project.

Follow up to #1649 (as it turns out), extending it to reset all global state, not just dangling pointers.