### PR TITLE
Problem: zsys_reset changes public API side effects

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -36,8 +36,7 @@ CZMQ_EXPORT void *
 //  when the process exits; however this call lets you force a shutdown
 //  earlier, avoiding any potential problems with atexit() ordering, especially
 //  with Windows DLL builds, where atexit() does not work and zsys_shutdown has
-//  to be called manually. Resets all zsys global state (i.e., HWM, LINGER, ...)
-//  to their initial values.
+//  to be called manually.
 CZMQ_EXPORT void
     zsys_shutdown (void);
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -219,44 +219,6 @@ zsys_init (void)
     return s_process_ctx;
 }
 
-//  --------------------------------------------------------------------------
-//  Restores all CZMQ global state to initial values. Internal function called
-//  by zsys_shutdown().
-
-static void
-zsys_reset (void){
-    s_process_ctx = NULL;
-    zsys_interrupted = 0;
-    zctx_interrupted = 0;
-
-    s_first_time = true;
-    handle_signals = true;
-
-    s_process_ctx = NULL;
-    s_initialized = false;
-
-    s_io_threads = 1;
-    s_max_sockets = 1024;
-    s_max_msgsz = INT_MAX;
-    s_linger = 0;
-    s_sndhwm = 1000;
-    s_rcvhwm = 1000;
-    s_pipehwm = 1000;
-    s_ipv6 = 0;
-    s_interface = NULL;
-    s_ipv6_address = NULL;
-    s_ipv6_mcast_address = NULL;
-    s_auto_use_fd = 0;
-    s_logident = NULL;
-    s_logstream = NULL;
-    s_logsystem = false;
-    s_logsender = NULL;
-
-    s_open_sockets = 0;
-
-    s_sockref_list = NULL;
-}
-
 //  atexit or manual termination for the process
 void
 zsys_shutdown (void)
@@ -321,7 +283,26 @@ zsys_shutdown (void)
     free (s_logident);
     s_logident = NULL;
 
-    zsys_reset();
+    //  The following is a change in the side effects of public APIs
+    //  so it has to be managed carefully at release time. DRAFT for now.
+#ifdef CZMQ_BUILD_DRAFT_API
+    zsys_interrupted = 0;
+    zctx_interrupted = 0;
+
+    zsys_handler_reset ();
+
+    s_io_threads = 1;
+    s_max_sockets = 1024;
+    s_max_msgsz = INT_MAX;
+    s_linger = 0;
+    s_sndhwm = 1000;
+    s_rcvhwm = 1000;
+    s_pipehwm = 1000;
+    s_ipv6 = 0;
+    s_auto_use_fd = 0;
+    s_logstream = NULL;
+    s_logsystem = false;
+#endif // CZMQ_BUILD_DRAFT_API
 
 #if defined (__UNIX__)
     closelog ();                //  Just to be pedantic


### PR DESCRIPTION
Solution: hide it behind DRAFT flag for now. We have to be careful in
not changing public API freely, but in a controlled and safe manner.
Also remove inline to avoid compiler errors about unused function,
and remove redundant resets.

Followup on #1660