### PR TITLE
Problem: Global zsys state not cleared after clean zsys_shutdown()

### DIFF
--- a/include/zsys.h
+++ b/include/zsys.h
@@ -36,7 +36,8 @@ CZMQ_EXPORT void *
 //  when the process exits; however this call lets you force a shutdown
 //  earlier, avoiding any potential problems with atexit() ordering, especially
 //  with Windows DLL builds, where atexit() does not work and zsys_shutdown has
-//  to be called manually.
+//  to be called manually. A succesful shutdown resets the zsys global state
+//  (HWM, LINGER, etc).
 CZMQ_EXPORT void
     zsys_shutdown (void);
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -267,6 +267,17 @@ zsys_shutdown (void)
     {
       zmq_term(s_process_ctx);
       s_process_ctx = NULL;
+      s_io_threads = 1;
+      s_max_sockets = 1024;
+      s_max_msgsz = INT_MAX;
+      s_linger = 0;
+      s_sndhwm = 1000;
+      s_rcvhwm = 1000;
+      s_pipehwm = 1000;
+      s_ipv6 = 0;
+      s_auto_use_fd = 0;
+      s_logstream = NULL;
+      s_logsystem = false;
     }
     else
         zsys_error ("dangling sockets: cannot terminate ZMQ safely");
@@ -283,26 +294,10 @@ zsys_shutdown (void)
     free (s_logident);
     s_logident = NULL;
 
-    //  The following is a change in the side effects of public APIs
-    //  so it has to be managed carefully at release time. DRAFT for now.
-#ifdef CZMQ_BUILD_DRAFT_API
     zsys_interrupted = 0;
     zctx_interrupted = 0;
 
     zsys_handler_reset ();
-
-    s_io_threads = 1;
-    s_max_sockets = 1024;
-    s_max_msgsz = INT_MAX;
-    s_linger = 0;
-    s_sndhwm = 1000;
-    s_rcvhwm = 1000;
-    s_pipehwm = 1000;
-    s_ipv6 = 0;
-    s_auto_use_fd = 0;
-    s_logstream = NULL;
-    s_logsystem = false;
-#endif // CZMQ_BUILD_DRAFT_API
 
 #if defined (__UNIX__)
     closelog ();                //  Just to be pedantic


### PR DESCRIPTION
Solution: reset state if shutdown was clean. Until #1649, no code could rely on behavior wrt global state on a zsys shutdown+init (restart), because any attempt to call zsys_init() after zsys_shutdown() would assert and #1649 has not been part of of any official release yet , so there's no reason to punt on this for reasons of back-compat.

followup to  #1649 , #1660 , #1661 