### PR TITLE
Problem: dangling pointers are bug futures

### DIFF
--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -24,6 +24,8 @@
 //  External API
 #include "../include/czmq.h"
 
+#define FREE_AND_NULL(x) do {free(x); x = NULL;} while(0)
+
 //  Extra headers
 
 //  Opaque class structures to allow forward references

--- a/src/test_zgossip.c
+++ b/src/test_zgossip.c
@@ -13,8 +13,8 @@ assert_status (zactor_t *actor, int count)
             assert (atoi (status) == count);
             ready = true;
         }
-        free (command);
-        free (status);
+        FREE_AND_NULL (command);
+        FREE_AND_NULL (status);
     }
 }
 
@@ -165,7 +165,7 @@ main (int argn, char *argv [])
         zstr_recvx (which, &command, NULL);
         assert (streq (command, "DELIVER"));
         pending--;
-        free (command);
+        FREE_AND_NULL (command);
         if (zclock_mono () > ticker) {
             printf ("(%d%%)", (int) ((100 * (total - pending)) / total));
             fflush (stdout);

--- a/src/zactor.c
+++ b/src/zactor.c
@@ -69,7 +69,7 @@ s_thread_shim (void *args)
     zsock_set_sndtimeo (shim->pipe, 0);
     zsock_signal (shim->pipe, 0);
     zsock_destroy (&shim->pipe);
-    free (shim);
+    FREE_AND_NULL (shim);
     return NULL;
 }
 
@@ -86,7 +86,7 @@ s_thread_shim (void *args)
     zsock_set_sndtimeo (shim->pipe, 0);
     zsock_signal (shim->pipe, 0);
     zsock_destroy (&shim->pipe);
-    free (shim);
+    FREE_AND_NULL (shim);
     _endthreadex (0);           //  Terminates thread
     return 0;
 }
@@ -164,7 +164,7 @@ zactor_destroy (zactor_t **self_p)
             zsock_destroy (&self->pipe);
         }
         self->tag = 0xDeadBeef;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -262,7 +262,7 @@ echo_actor (zsock_t *pipe, void *args)
             puts ("E: invalid message to actor");
             assert (false);
         }
-        free (command);
+        FREE_AND_NULL (command);
         zmsg_destroy (&msg);
     }
 }
@@ -282,7 +282,7 @@ zactor_test (bool verbose)
     zstr_sendx (actor, "ECHO", "This is a string", NULL);
     char *string = zstr_recv (actor);
     assert (streq (string, "This is a string"));
-    free (string);
+    FREE_AND_NULL (string);
     zactor_destroy (&actor);
 
 #if defined (__WINDOWS__)

--- a/src/zarmour.c
+++ b/src/zarmour.c
@@ -92,8 +92,8 @@ zarmour_destroy (zarmour_t **self_p)
     assert (self_p);
     if (*self_p) {
         zarmour_t *self = *self_p;
-        free (self->line_end);
-        free (self);
+        FREE_AND_NULL (self->line_end);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -355,7 +355,7 @@ s_z85_encode (const byte *data, size_t length)
     char *str = (char *) zmalloc (5 * length / 4 + 1);
     char *result = zmq_z85_encode (str, (uint8_t *) data, length);
     if (result == NULL) {
-        free (str);
+        FREE_AND_NULL (str);
         str = NULL;
     }
     return str;
@@ -376,7 +376,7 @@ s_z85_decode (const char *data, size_t *size)
     byte *bytes = (byte *) zmalloc (*size);
     uint8_t *result = zmq_z85_decode (bytes, (char *) data);
     if (result == NULL) {
-        free (bytes);
+        FREE_AND_NULL (bytes);
         bytes = NULL;
     }
     return bytes;
@@ -449,7 +449,7 @@ zarmour_encode (zarmour_t *self, const byte *data, size_t data_size)
             memcpy (dest, src, strlen (src));
             dest += strlen (src);
         }
-        free (temp);
+        FREE_AND_NULL (temp);
         *dest = 0;
     }
     return encoded;
@@ -499,7 +499,7 @@ zarmour_decode (zarmour_t *self, const char *data)
             break;
     }
     zchunk_t *ret = zchunk_new (decoded, size);
-    free (decoded);
+    FREE_AND_NULL (decoded);
     return ret;
 }
 
@@ -674,7 +674,7 @@ s_armour_test (zarmour_t *self, const char *test_string, const char *expected, b
     assert (strlen (encoded) == strlen (expected));
     assert (streq (encoded, expected));
     s_armour_decode (self, encoded, test_string, verbose);
-    free (encoded);
+    FREE_AND_NULL (encoded);
 }
 
 static void
@@ -697,7 +697,7 @@ s_armour_test_long (zarmour_t *self, byte *test_data, size_t length, bool verbos
     zchunk_destroy (&chunk);
     if (verbose)
         zsys_debug ("    decoded %d bytes, all match", length);
-    free (test_string);
+    FREE_AND_NULL (test_string);
 }
 
 

--- a/src/zauth.c
+++ b/src/zauth.c
@@ -56,7 +56,7 @@ s_self_destroy (self_t **self_p)
             zsock_unbind (self->handler, ZAP_ENDPOINT);
             zsock_destroy (&self->handler);
         }
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -204,17 +204,17 @@ s_zap_request_destroy (zap_request_t **self_p)
     assert (self_p);
     if (*self_p) {
         zap_request_t *self = *self_p;
-        free (self->version);
-        free (self->sequence);
-        free (self->domain);
-        free (self->address);
-        free (self->identity);
-        free (self->mechanism);
-        free (self->username);
-        free (self->password);
-        free (self->client_key);
-        free (self->principal);
-        free (self);
+        FREE_AND_NULL (self->version);
+        FREE_AND_NULL (self->sequence);
+        FREE_AND_NULL (self->domain);
+        FREE_AND_NULL (self->address);
+        FREE_AND_NULL (self->identity);
+        FREE_AND_NULL (self->mechanism);
+        FREE_AND_NULL (self->username);
+        FREE_AND_NULL (self->password);
+        FREE_AND_NULL (self->client_key);
+        FREE_AND_NULL (self->principal);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -58,7 +58,7 @@ s_self_destroy (self_t **self_p)
         zframe_destroy (&self->filter);
         if (self->udpsock) // don't close STDIN
             zsys_udp_close (self->udpsock);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -537,10 +537,10 @@ zbeacon_test (bool verbose)
     if (!*hostname) {
         printf ("OK (skipping test, no UDP broadcasting)\n");
         zactor_destroy (&speaker);
-        free (hostname);
+        FREE_AND_NULL (hostname);
         return;
     }
-    free (hostname);
+    FREE_AND_NULL (hostname);
 
     //  Create listener beacon on port 9999 to lookup service
     zactor_t *listener = zactor_new (zbeacon, NULL);
@@ -550,7 +550,7 @@ zbeacon_test (bool verbose)
     zsock_send (listener, "si", "CONFIGURE", 9999);
     hostname = zstr_recv (listener);
     assert (*hostname);
-    free (hostname);
+    FREE_AND_NULL (hostname);
 
     //  We will broadcast the magic value 0xCAFE
     byte announcement [2] = { 0xCA, 0xFE };
@@ -579,21 +579,21 @@ zbeacon_test (bool verbose)
     zsock_send (node1, "si", "CONFIGURE", 5670);
     hostname = zstr_recv (node1);
     assert (*hostname);
-    free (hostname);
+    FREE_AND_NULL (hostname);
 
     zactor_t *node2 = zactor_new (zbeacon, NULL);
     assert (node2);
     zsock_send (node2, "si", "CONFIGURE", 5670);
     hostname = zstr_recv (node2);
     assert (*hostname);
-    free (hostname);
+    FREE_AND_NULL (hostname);
 
     zactor_t *node3 = zactor_new (zbeacon, NULL);
     assert (node3);
     zsock_send (node3, "si", "CONFIGURE", 5670);
     hostname = zstr_recv (node3);
     assert (*hostname);
-    free (hostname);
+    FREE_AND_NULL (hostname);
 
     zsock_send (node1, "sbi", "PUBLISH", "NODE/1", 6, 250);
     zsock_send (node2, "sbi", "PUBLISH", "NODE/2", 6, 250);

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -110,7 +110,7 @@ zcert_destroy (zcert_t **self_p)
         zcert_t *self = *self_p;
         zhash_destroy (&self->metadata);
         zconfig_destroy (&self->config);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -117,8 +117,8 @@ s_disk_loader_state_destroy (void **self_p)
     assert (self_p);
     if (*self_p) {
         disk_loader_state *self = (disk_loader_state *)*self_p;
-        free (self->location);
-        free (self);
+        FREE_AND_NULL (self->location);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -176,7 +176,7 @@ zcertstore_destroy (zcertstore_t **self_p)
         if (self->destructor)
             self->destructor (&self->state);
 
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -291,7 +291,7 @@ s_test_destructor (void **self_p)
     assert (self_p);
     if (*self_p) {
         test_loader_state *self = (test_loader_state *)*self_p;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -337,7 +337,7 @@ zcertstore_test (bool verbose)
     assert (cert);
 #endif
 
-    free (client_key);
+    FREE_AND_NULL (client_key);
 
     if (verbose)
         zcertstore_print (certstore);

--- a/src/zchunk.c
+++ b/src/zchunk.c
@@ -76,10 +76,10 @@ zchunk_destroy (zchunk_t **self_p)
         assert (zchunk_is (self));
         //  If data was reallocated independently, free it independently
         if (self->data != (byte *) self + sizeof (zchunk_t))
-            free (self->data);
+            FREE_AND_NULL (self->data);
         self->tag = 0xDeadBeef;
         zdigest_destroy (&self->digest);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -552,10 +552,10 @@ zchunk_test (bool verbose)
     assert (streq (zchunk_digest (chunk), "01B307ACBA4F54F55AAFC33BB06BBBF6CA803E9A"));
     char *string = zchunk_strdup (chunk);
     assert (streq (string, "1234567890"));
-    free (string);
+    FREE_AND_NULL (string);
     string = zchunk_strhex (chunk);
     assert (streq (string, "31323334353637383930"));
-    free (string);
+    FREE_AND_NULL (string);
 
     zframe_t *frame = zchunk_pack (chunk);
     assert (frame);

--- a/src/zclock.c
+++ b/src/zclock.c
@@ -226,7 +226,7 @@ zclock_test (bool verbose)
     char *timestr = zclock_timestr ();
     if (verbose)
         puts (timestr);
-    free (timestr);
+    FREE_AND_NULL (timestr);
 
 #if defined (__WINDOWS__)
     zsys_shutdown();

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -130,9 +130,9 @@ zconfig_destroy (zconfig_t **self_p)
         //  Destroy other properties and then self
         zlist_destroy (&self->comments);
         zfile_destroy (&self->file);
-        free (self->name);
-        free (self->value);
-        free (self);
+        FREE_AND_NULL (self->name);
+        FREE_AND_NULL (self->value);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -225,7 +225,7 @@ void
 zconfig_set_name (zconfig_t *self, const char *name)
 {
     assert (self);
-    free (self->name);
+    FREE_AND_NULL (self->name);
     self->name = name? strdup (name): NULL;
 }
 
@@ -514,7 +514,7 @@ zconfig_loadf (const char *format, ...)
     va_end (argptr);
     if (filename) {
         zconfig_t *config = zconfig_load (filename);
-        free (filename);
+        FREE_AND_NULL (filename);
         return config;
     }
     else
@@ -658,7 +658,7 @@ zconfig_chunk_load (zchunk_t *chunk)
                 }
                 else {
                     zclock_log ("E (zconfig): (%d) indentation error", lineno);
-                    free (value);
+                    FREE_AND_NULL (value);
                     valid = false;
                 }
             }
@@ -667,7 +667,7 @@ zconfig_chunk_load (zchunk_t *chunk)
         if (s_verify_eoln (scanner, lineno))
             valid = false;
 
-        free (name);
+        FREE_AND_NULL (name);
         if (!valid)
             break;
     }
@@ -733,7 +733,7 @@ s_collect_name (char **start, int lineno)
     && (name [0] == '/'
     ||  name [length - 1] == '/')) {
         zclock_log ("E (zconfig): (%d) '/' not valid at name start or end", lineno);
-        free (name);
+        FREE_AND_NULL (name);
         name = NULL;
     }
     return name;
@@ -811,7 +811,7 @@ s_collect_value (char **start, int lineno)
     }
     //  If we had an error, drop value and return NULL
     if (rc) {
-        free (value);
+        FREE_AND_NULL (value);
         value = NULL;
     }
     return value;
@@ -1002,7 +1002,7 @@ zconfig_test (bool verbose)
     char *string = zconfig_str_save (root);
     assert (string);
     assert (streq (string, (char *) zchunk_data (chunk)));
-    free (string);
+    FREE_AND_NULL (string);
     assert (chunk);
     zconfig_destroy (&root);
 

--- a/src/zdigest.c
+++ b/src/zdigest.c
@@ -62,7 +62,7 @@ zdigest_destroy (zdigest_t **self_p)
     assert (self_p);
     if (*self_p) {
         zdigest_t *self = *self_p;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -152,7 +152,7 @@ zdigest_test (bool verbose)
     assert (streq (zdigest_string (digest),
                    "DEB23807D4FE025E900FE9A9C7D8410C3DDE9671"));
     zdigest_destroy (&digest);
-    free (buffer);
+    FREE_AND_NULL (buffer);
 
 #if defined (__WINDOWS__)
     zsys_shutdown();

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -162,7 +162,7 @@ zdir_new (const char *path, const char *parent)
     sprintf (wildcard, "%s/*", self->path);
     WIN32_FIND_DATAA entry;
     HANDLE handle = FindFirstFileA (wildcard, &entry);
-    free (wildcard);
+    FREE_AND_NULL (wildcard);
 
     if (handle != INVALID_HANDLE_VALUE) {
         //  We have read an entry, so return those values
@@ -243,8 +243,8 @@ zdir_destroy (zdir_t **self_p)
             }
         zlist_destroy (&self->subdirs);
         zlist_destroy (&self->files);
-        free (self->path);
-        free (self);
+        FREE_AND_NULL (self->path);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -376,7 +376,7 @@ void
 zdir_flatten_free (zfile_t ***files_p)
 {
     assert (files_p);
-    free (*files_p);
+    FREE_AND_NULL (*files_p);
     *files_p = NULL;
 }
 
@@ -520,8 +520,8 @@ zdir_diff (zdir_t *older, zdir_t *newer, const char *alias)
         old_index++;
         new_index++;
     }
-    free (old_files);
-    free (new_files);
+    FREE_AND_NULL (old_files);
+    FREE_AND_NULL (new_files);
 
     return patches;
 }
@@ -550,7 +550,7 @@ zdir_resync (zdir_t *self, const char *alias)
             break;
         }
     }
-    free (files);
+    FREE_AND_NULL (files);
     return patches;
 }
 
@@ -594,12 +594,12 @@ zdir_cache (zdir_t *self)
             }
         }
     }
-    free (files);
+    FREE_AND_NULL (files);
 
     //  Save cache to disk for future reference
     if (cache)
         zhash_save (cache, cache_file);
-    free (cache_file);
+    FREE_AND_NULL (cache_file);
     return cache;
 }
 
@@ -718,7 +718,7 @@ s_zdir_watch_destroy (zdir_watch_t **watch_p)
         zloop_destroy (&watch->loop);
         zhash_destroy (&watch->subs);
 
-        free (watch);
+        FREE_AND_NULL (watch);
         *watch_p = NULL;
     }
 }
@@ -729,7 +729,7 @@ s_sub_free (void *data)
     zdir_watch_sub_t *sub = (zdir_watch_sub_t *) data;
     zdir_destroy (&sub->dir);
 
-    free (sub);
+    FREE_AND_NULL (sub);
 }
 
 static void
@@ -838,7 +838,7 @@ s_on_command (zloop_t *loop, zsock_t *reader, void *arg)
         char *path = zmsg_popstr (msg);
         if (path) {
             s_zdir_watch_subscribe (watch, path);
-            free (path);
+            FREE_AND_NULL (path);
         }
         else {
             if (watch->verbose)
@@ -852,7 +852,7 @@ s_on_command (zloop_t *loop, zsock_t *reader, void *arg)
         if (path) {
             assert (path);
             s_zdir_watch_unsubscribe (watch, path);
-            free (path);
+            FREE_AND_NULL (path);
         }
         else {
             if (watch->verbose)
@@ -866,7 +866,7 @@ s_on_command (zloop_t *loop, zsock_t *reader, void *arg)
         if (timeout_string) {
             int timeout = atoi (timeout_string);
             zsock_signal (watch->pipe, s_zdir_watch_timeout (watch, timeout));
-            free (timeout_string);
+            FREE_AND_NULL (timeout_string);
         }
         else {
             if (watch->verbose)
@@ -880,7 +880,7 @@ s_on_command (zloop_t *loop, zsock_t *reader, void *arg)
         zsock_signal (watch->pipe, 1);
     }
 
-    free (command);
+    FREE_AND_NULL (command);
     zmsg_destroy (&msg);
     return 0;
 }
@@ -1006,7 +1006,7 @@ zdir_test (bool verbose)
     assert (rc == 0);
 
     assert (streq (path, "zdir-test-dir"));
-    free (path);
+    FREE_AND_NULL (path);
 
     assert (zlist_size (patches) == 1);
 
@@ -1032,7 +1032,7 @@ zdir_test (bool verbose)
     assert (rc == 0);
 
     assert (streq (path, "zdir-test-dir"));
-    free (path);
+    FREE_AND_NULL (path);
 
     assert (zlist_size (patches) == 1);
 

--- a/src/zdir_patch.c
+++ b/src/zdir_patch.c
@@ -74,11 +74,11 @@ zdir_patch_destroy (zdir_patch_t **self_p)
     assert (self_p);
     if (*self_p) {
         zdir_patch_t *self = *self_p;
-        free (self->path);
-        free (self->vpath);
-        free (self->digest);
+        FREE_AND_NULL (self->path);
+        FREE_AND_NULL (self->vpath);
+        FREE_AND_NULL (self->digest);
         zfile_destroy (&self->file);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -116,10 +116,10 @@ zfile_destroy (zfile_t **self_p)
         zdigest_destroy (&self->digest);
         if (self->handle)
             fclose (self->handle);
-        free (self->fullname);
-        free (self->curline);
-        free (self->link);
-        free (self);
+        FREE_AND_NULL (self->fullname);
+        FREE_AND_NULL (self->curline);
+        FREE_AND_NULL (self->link);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -362,11 +362,11 @@ zfile_output (zfile_t *self)
 
     //  Wipe symbolic link if that's what the file was
     if (self->link) {
-        free (self->link);
+        FREE_AND_NULL (self->link);
         self->link = NULL;
     }
     rc = zsys_dir_create (file_path);
-    free (file_path);
+    FREE_AND_NULL (file_path);
     if (rc != 0)
         return -1;
 

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -95,7 +95,7 @@ zframe_destroy (zframe_t **self_p)
         assert (zframe_is (self));
         zmq_msg_close (&self->zmsg);
         self->tag = 0xDeadBeef;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -617,10 +617,10 @@ zframe_test (bool verbose)
     zframe_reset (frame, "END", 3);
     char *string = zframe_strhex (frame);
     assert (streq (string, "454E44"));
-    free (string);
+    FREE_AND_NULL (string);
     string = zframe_strdup (frame);
     assert (streq (string, "END"));
-    free (string);
+    FREE_AND_NULL (string);
     rc = zframe_send (&frame, output, 0);
     assert (rc == 0);
 

--- a/src/zgossip.c
+++ b/src/zgossip.c
@@ -143,9 +143,9 @@ static void
 tuple_free (void *argument)
 {
     tuple_t *self = (tuple_t *) argument;
-    free (self->key);
-    free (self->value);
-    free (self);
+    FREE_AND_NULL (self->key);
+    FREE_AND_NULL (self->value);
+    FREE_AND_NULL (self);
 }
 
 //  Handle traffic from remotes

--- a/src/zgossip_engine.inc
+++ b/src/zgossip_engine.inc
@@ -374,8 +374,8 @@ s_client_destroy (s_client_t **self_p)
         //  Provide visual clue if application misuses client reference
         engine_set_log_prefix (&self->client, "*** TERMINATED ***");
         client_terminate (&self->client);
-        free (self->hashkey);
-        free (self);
+        FREE_AND_NULL (self->hashkey);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -717,7 +717,7 @@ s_server_destroy (s_server_t **self_p)
         zsock_destroy (&self->router);
         zconfig_destroy (&self->config);
         zloop_destroy (&self->loop);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -786,7 +786,7 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
     else
     if (streq (method, "$TERM")) {
         //  Shutdown the engine
-        free (method);
+        FREE_AND_NULL (method);
         zmsg_destroy (&msg);
         return -1;
     }
@@ -797,7 +797,7 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
         self->port = zsock_bind (self->router, "%s", endpoint);
         if (self->port == -1)
             zsys_warning ("could not bind to %s", endpoint);
-        free (endpoint);
+        FREE_AND_NULL (endpoint);
     }
     else
     if (streq (method, "PORT")) {
@@ -818,7 +818,7 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
             zsys_warning ("cannot load config file '%s'", filename);
             self->config = zconfig_new ("root", NULL);
         }
-        free (filename);
+        FREE_AND_NULL (filename);
     }
     else
     if (streq (method, "SET")) {
@@ -830,15 +830,15 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
             self->verbose = (atoi (value) == 1);
         }
         s_server_config_global (self);
-        free (path);
-        free (value);
+        FREE_AND_NULL (path);
+        FREE_AND_NULL (value);
     }
     else
     if (streq (method, "SAVE")) {
         char *filename = zmsg_popstr (msg);
         if (zconfig_save (self->config, filename))
             zsys_warning ("cannot save config file '%s'", filename);
-        free (filename);
+        FREE_AND_NULL (filename);
     }
     else {
         //  Execute custom method
@@ -846,7 +846,7 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
         //  If reply isn't null, send it to caller
         zmsg_send (&reply, self->pipe);
     }
-    free (method);
+    FREE_AND_NULL (method);
     zmsg_destroy (&msg);
     return 0;
 }
@@ -871,7 +871,7 @@ s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
             zhash_insert (self->clients, hashkey, client);
             zhash_freefn (self->clients, hashkey, s_client_free);
         }
-        free (hashkey);
+        FREE_AND_NULL (hashkey);
         //  Any input from client counts as activity
         if (client->ticket)
             zloop_ticket_reset (self->loop, client->ticket);

--- a/src/zgossip_msg.c
+++ b/src/zgossip_msg.c
@@ -186,7 +186,7 @@ struct _zgossip_msg_t {
         zsys_warning ("zgossip_msg: GET_LONGSTR failed"); \
         goto malformed; \
     } \
-    free ((host)); \
+    FREE_AND_NULL ((host)); \
     (host) = (char *) malloc (string_size + 1); \
     memcpy ((host), self->needle, string_size); \
     (host) [string_size] = 0; \
@@ -217,10 +217,10 @@ zgossip_msg_destroy (zgossip_msg_t **self_p)
 
         //  Free class properties
         zframe_destroy (&self->routing_id);
-        free (self->value);
+        FREE_AND_NULL (self->value);
 
         //  Free object itself
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -562,7 +562,7 @@ zgossip_msg_set_value (zgossip_msg_t *self, const char *value)
 {
     assert (self);
     assert (value);
-    free (self->value);
+    FREE_AND_NULL (self->value);
     self->value = strdup (value);
 }
 

--- a/src/zhash.c
+++ b/src/zhash.c
@@ -101,11 +101,11 @@ zhash_destroy (zhash_t **self_p)
             }
         }
         if (self->items)
-            free (self->items);
+            FREE_AND_NULL (self->items);
 
         zlist_destroy (&self->comments);
-        free (self->filename);
-        free (self);
+        FREE_AND_NULL (self->filename);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -135,12 +135,12 @@ s_item_destroy (zhash_t *self, item_t *item, bool hard)
             (item->free_fn) (item->value);
         else
         if (self->autofree)
-            free (item->value);
+            FREE_AND_NULL (item->value);
 
-        free (item->key);
+        FREE_AND_NULL (item->key);
         self->cursor_item = NULL;
         self->cursor_key = NULL;
-        free (item);
+        FREE_AND_NULL (item);
     }
 }
 
@@ -180,7 +180,7 @@ zhash_insert (zhash_t *self, const char *key, void *value)
             }
         }
         //  Destroy old hash table
-        free (self->items);
+        FREE_AND_NULL (self->items);
         self->items = new_items;
         self->limit = new_limit;
     }
@@ -276,7 +276,7 @@ zhash_update (zhash_t *self, const char *key, void *value)
             (item->free_fn) (item->value);
         else
         if (self->autofree)
-            free (item->value);
+            FREE_AND_NULL (item->value);
 
         //  If necessary, take duplicate of item (string) value
         if (self->autofree) {
@@ -334,7 +334,7 @@ zhash_rename (zhash_t *self, const char *old_key, const char *new_key)
     item_t *new_item = s_item_lookup (self, new_key);
     if (old_item && !new_item) {
         s_item_destroy (self, old_item, false);
-        free (old_item->key);
+        FREE_AND_NULL (old_item->key);
         old_item->key = strdup (new_key);
         assert (old_item->key);
         old_item->index = self->cached_index;
@@ -578,7 +578,7 @@ zhash_load (zhash_t *self, const char *filename)
     //  Take copy of filename in case self->filename is same string.
     char *filename_copy = strdup (filename);
     assert (filename_copy);
-    free (self->filename);
+    FREE_AND_NULL (self->filename);
     self->filename = filename_copy;
     self->modified = zsys_file_modified (self->filename);
 
@@ -599,7 +599,7 @@ zhash_load (zhash_t *self, const char *filename)
             *equals++ = 0;
             zhash_update (self, buffer, equals);
         }
-        free (buffer);
+        FREE_AND_NULL (buffer);
         fclose (handle);
     }
     else

--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -148,11 +148,11 @@ zhashx_destroy (zhashx_t **self_p)
         zhashx_t *self = *self_p;
         if (self->items) {
             s_purge (self);
-            free (self->items);
+            FREE_AND_NULL (self->items);
         }
         zlistx_destroy (&self->comments);
-        free (self->filename);
-        free (self);
+        FREE_AND_NULL (self->filename);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -189,7 +189,7 @@ s_item_destroy (zhashx_t *self, item_t *item, bool hard)
 
         if (self->key_destructor)
             (self->key_destructor)((void **) &item->key);
-        free (item);
+        FREE_AND_NULL (item);
     }
 }
 
@@ -225,7 +225,7 @@ s_zhashx_rehash (zhashx_t *self, uint new_prime_index)
         }
     }
     //  Destroy old hash table
-    free (self->items);
+    FREE_AND_NULL (self->items);
     self->items = new_items;
     self->prime_index = new_prime_index;
     return 0;
@@ -699,7 +699,7 @@ zhashx_load (zhashx_t *self, const char *filename)
     //  Take copy of filename in case self->filename is same string.
     char *filename_copy = strdup (filename);
     assert (filename_copy);
-    free (self->filename);
+    FREE_AND_NULL (self->filename);
     self->filename = filename_copy;
     self->modified = zsys_file_modified (self->filename);
     FILE *handle = fopen (self->filename, "r");
@@ -719,7 +719,7 @@ zhashx_load (zhashx_t *self, const char *filename)
             *equals++ = 0;
             zhashx_update (self, buffer, equals);
         }
-        free (buffer);
+        FREE_AND_NULL (buffer);
         fclose (handle);
     }
     else
@@ -797,7 +797,7 @@ zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer)
     //  Now serialize items into the frame
     zframe_t *frame = zframe_new (NULL, frame_size);
     if (!frame) {
-        free (values);
+        FREE_AND_NULL (values);
         return NULL;
     }
 
@@ -829,7 +829,7 @@ zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer)
             vindex++;
         }
     }
-    free (values);
+    FREE_AND_NULL (values);
     return frame;
 }
 
@@ -1110,7 +1110,7 @@ static void
 s_test_destroy_int (void **item)
 {
     int *int_item = (int *) *item;
-    free (int_item);
+    FREE_AND_NULL (int_item);
 }
 #endif // CZMQ_BUILD_DRAFT_API
 

--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -43,11 +43,11 @@ s_interface_destroy (interface_t **self_p)
     assert (self_p);
     interface_t *self = *self_p;
     if (self) {
-        free (self->name);
-        free (self->address);
-        free (self->netmask);
-        free (self->broadcast);
-        free (self);
+        FREE_AND_NULL (self->name);
+        FREE_AND_NULL (self->address);
+        FREE_AND_NULL (self->netmask);
+        FREE_AND_NULL (self->broadcast);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -265,7 +265,7 @@ s_reload (ziflist_t *self, bool ipv6)
                     zlistx_add_end (list, item);
             }
         }
-        free (ifconfig.ifc_buf);
+        FREE_AND_NULL (ifconfig.ifc_buf);
         close (sock);
     }
 
@@ -286,7 +286,7 @@ s_reload (ziflist_t *self, bool ipv6)
                                    GAA_FLAG_INCLUDE_PREFIX, NULL, pip_addresses, &addr_size);
         
         if (rc == ERROR_BUFFER_OVERFLOW) {
-            free (pip_addresses);
+            FREE_AND_NULL (pip_addresses);
             pip_addresses = NULL;
         } 
         else {
@@ -328,10 +328,10 @@ s_reload (ziflist_t *self, bool ipv6)
             if (item)
                 zlistx_add_end (list, item);
         }
-        free (asciiFriendlyName);
+        FREE_AND_NULL (asciiFriendlyName);
         cur_address = cur_address->Next;
     }
-    free (pip_addresses);
+    FREE_AND_NULL (pip_addresses);
 
 #   else
 #       error "Interface detection TBD on this operating system"

--- a/src/zlist.c
+++ b/src/zlist.c
@@ -70,7 +70,7 @@ zlist_destroy (zlist_t **self_p)
     if (*self_p) {
         zlist_t *self = *self_p;
         zlist_purge (self);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -242,7 +242,7 @@ zlist_pop (zlist_t *self)
         self->head = node->next;
         if (self->tail == node)
             self->tail = NULL;
-        free (node);
+        FREE_AND_NULL (node);
         self->size--;
     }
     self->cursor = NULL;
@@ -310,12 +310,12 @@ zlist_remove (zlist_t *self, void *item)
             self->cursor = prev;
 
         if (self->autofree)
-            free (node->item);
+            FREE_AND_NULL (node->item);
         else
         if (node->free_fn)
             (node->free_fn)(node->item);
 
-        free (node);
+        FREE_AND_NULL (node);
         self->size--;
     }
 }
@@ -363,12 +363,12 @@ zlist_purge (zlist_t *self)
     while (node) {
         node_t *next = node->next;
         if (self->autofree)
-            free (node->item);
+            FREE_AND_NULL (node->item);
         else
         if (node->free_fn)
             (node->free_fn)(node->item);
 
-        free (node);
+        FREE_AND_NULL (node);
         node = next;
     }
     self->head = NULL;
@@ -617,10 +617,10 @@ zlist_test (bool verbose)
     assert (streq ((const char *) zlist_first (list), bread));
     item = (char *) zlist_pop (list);
     assert (streq (item, bread));
-    free (item);
+    FREE_AND_NULL (item);
     item = (char *) zlist_pop (list);
     assert (streq (item, cheese));
-    free (item);
+    FREE_AND_NULL (item);
 
     zlist_destroy (&list);
     assert (list == NULL);

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -127,8 +127,8 @@ zlistx_destroy (zlistx_t **self_p)
     if (*self_p) {
         zlistx_t *self = *self_p;
         zlistx_purge (self);
-        free (self->head);
-        free (self);
+        FREE_AND_NULL (self->head);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -365,7 +365,7 @@ zlistx_detach (zlistx_t *self, void *handle)
         s_node_relink (node, node->prev, node->next);
         node->tag = 0xDeadBeef;
         void *item = node->item;
-        free (node);
+        FREE_AND_NULL (node);
         self->size--;
         return item;
     }
@@ -681,7 +681,7 @@ zlistx_test (bool verbose)
     assert (zlistx_size (list) == 1);
     char *string = (char *) zlistx_detach (list, NULL);
     assert (streq (string, "world"));
-    free (string);
+    FREE_AND_NULL (string);
     assert (zlistx_size (list) == 0);
 
     //  Check next/back work

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -117,7 +117,7 @@ s_reader_destroy (s_reader_t **self_p)
     assert (self_p);
     s_reader_t *self = *self_p;
     if (self) {
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -140,7 +140,7 @@ s_poller_destroy (s_poller_t **self_p)
     assert (self_p);
     s_poller_t *self = *self_p;
     if (self) {
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -166,7 +166,7 @@ s_timer_destroy (s_timer_t **self_p)
     assert (self_p);
     s_timer_t *self = *self_p;
     if (self) {
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -203,7 +203,7 @@ s_ticket_destroy (s_ticket_t **self_p)
     s_ticket_t *self = *self_p;
     if (self) {
         self->tag = 0xDeadBeef;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -245,15 +245,15 @@ s_rebuild_pollset (zloop_t *self)
 {
     self->poll_size = zlistx_size (self->readers) + zlistx_size (self->pollers);
 
-    free (self->pollset);
+    FREE_AND_NULL (self->pollset);
     self->pollset = (zmq_pollitem_t *) zmalloc (self->poll_size * sizeof (zmq_pollitem_t));
     assert (self->pollset);
 
-    free (self->readact);
+    FREE_AND_NULL (self->readact);
     self->readact = (s_reader_t *) zmalloc (self->poll_size * sizeof (s_reader_t));
     assert (self->readact);
 
-    free (self->pollact);
+    FREE_AND_NULL (self->pollact);
     self->pollact = (s_poller_t *) zmalloc (self->poll_size * sizeof (s_poller_t));
     assert (self->pollact);
 
@@ -365,10 +365,10 @@ zloop_destroy (zloop_t **self_p)
         zlistx_destroy (&self->pollers);
         zlistx_destroy (&self->timers);
         zlistx_destroy (&self->tickets);
-        free (self->pollset);
-        free (self->readact);
-        free (self->pollact);
-        free (self);
+        FREE_AND_NULL (self->pollset);
+        FREE_AND_NULL (self->readact);
+        FREE_AND_NULL (self->pollact);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zmakecert.c
+++ b/src/zmakecert.c
@@ -54,7 +54,7 @@ int main (int argc, char *argv [])
     char *timestr = zclock_timestr ();
     zcert_set_meta (cert, "created-by", "CZMQ zmakecert");
     zcert_set_meta (cert, "date-created", "%s", timestr);
-    free (timestr);
+    FREE_AND_NULL (timestr);
     zcert_dump (cert);
     zcert_save (cert, filename);
     zsys_info ("CURVE certificate created in %s and %s_secret", filename, filename);

--- a/src/zmonitor.c
+++ b/src/zmonitor.c
@@ -50,7 +50,7 @@ s_self_destroy (self_t **self_p)
 #endif
         zpoller_destroy (&self->poller);
         zsock_destroy (&self->sink);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -147,7 +147,7 @@ s_self_start (self_t *self)
     rc = zsock_connect (self->sink, "%s", endpoint);
     assert (rc == 0);
     zpoller_add (self->poller, self->sink);
-    free (endpoint);
+    FREE_AND_NULL (endpoint);
 }
 
 
@@ -290,7 +290,7 @@ s_self_handle_sink (self_t *self)
     zstr_sendfm (self->pipe, "%s", name);
     zstr_sendfm (self->pipe, "%d", value);
     zstr_send (self->pipe, address);
-    free (address);
+    FREE_AND_NULL (address);
 #endif
 }
 
@@ -332,7 +332,7 @@ s_assert_event (zactor_t *self, char *expected)
     assert (msg);
     char *event = zmsg_popstr (msg);
     assert (streq (event, expected));
-    free (event);
+    FREE_AND_NULL (event);
     zmsg_destroy (&msg);
 }
 #endif

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -67,7 +67,7 @@ zmsg_destroy (zmsg_t **self_p)
             zframe_destroy (&frame);
         zlist_destroy (&self->frames);
         self->tag = 0xDeadBeef;
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -1068,7 +1068,7 @@ zmsg_test (bool verbose)
     assert (zmsg_size (msg) == 3);
     char *body = zmsg_popstr (msg);
     assert (streq (body, "Frame0"));
-    free (body);
+    FREE_AND_NULL (body);
     zmsg_destroy (&msg);
 
     //  Test encoding/decoding
@@ -1094,7 +1094,7 @@ zmsg_test (bool verbose)
     assert (rc == 0);
     rc = zmsg_addmem (msg, blank, 65537);
     assert (rc == 0);
-    free (blank);
+    FREE_AND_NULL (blank);
     assert (zmsg_size (msg) == 9);
     frame = zmsg_encode (msg);
     zmsg_destroy (&msg);
@@ -1118,7 +1118,7 @@ zmsg_test (bool verbose)
     assert (submsg);
     body = zmsg_popstr (submsg);
     assert (streq (body, "joska"));
-    free (body);
+    FREE_AND_NULL (body);
     zmsg_destroy (&submsg);
     frame = zmsg_pop (msg);
     assert (frame == NULL);

--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -46,9 +46,9 @@ struct _zpoller_t {
 static int
 s_rebuild_poll_set (zpoller_t *self)
 {
-    free (self->poll_set);
+    FREE_AND_NULL (self->poll_set);
     self->poll_set = NULL;
-    free (self->poll_readers);
+    FREE_AND_NULL (self->poll_readers);
     self->poll_readers = NULL;
 
     self->poll_size = zlist_size (self->reader_list);
@@ -124,10 +124,10 @@ zpoller_destroy (zpoller_t **self_p)
         zmq_poller_destroy (&self->zmq_poller);
 #else
         zlist_destroy (&self->reader_list);
-        free (self->poll_readers);
-        free (self->poll_set);
+        FREE_AND_NULL (self->poll_readers);
+        FREE_AND_NULL (self->poll_set);
 #endif
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -89,7 +89,7 @@ zpair_destroy (zpair_t **self_p) {
         if (self->read_owned)
             zsock_destroy ((zsock_t**)&self->read);
         zstr_free (&self->endpoint);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -148,9 +148,9 @@ arr_free (char **self) {
     assert (self);
     char **foo = self;
     while (*self) {
-        free (*(self++));
+        FREE_AND_NULL (*(self++));
     }
-    free (foo);
+    FREE_AND_NULL (foo);
 }
 
 static void
@@ -253,7 +253,7 @@ zproc_destroy (zproc_t **self_p) {
 
         zlistx_destroy (&self->args);
         zhashx_destroy (&self->env);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -81,7 +81,7 @@ s_self_destroy (self_t **self_p)
             zstr_free (&self->public_key [index]);
             zstr_free (&self->secret_key [index]);
         }
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zrex.c
+++ b/src/zrex.c
@@ -95,7 +95,7 @@ zrex_destroy (zrex_t **self_p)
     if (*self_p) {
         zrex_t *self = *self_p;
         zstr_free (&self->hit_set);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }

--- a/src/zsock.c
+++ b/src/zsock.c
@@ -110,9 +110,9 @@ zsock_destroy_checked (zsock_t **self_p, const char *filename, size_t line_nbr)
         self->tag = 0xDeadBeef;
         int rc = zsys_close (self->handle, filename, line_nbr);
         assert (rc == 0);
-        free (self->endpoint);
-        free (self->cache);
-        free (self);
+        FREE_AND_NULL (self->endpoint);
+        FREE_AND_NULL (self->cache);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -995,7 +995,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             int *int_p = va_arg (argptr, int *);
             if (int_p)
                 *int_p = string? atoi (string): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == '1') {
@@ -1003,7 +1003,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             uint8_t *uint8_p = va_arg (argptr, uint8_t *);
             if (uint8_p)
                 *uint8_p = string? (uint8_t) atoi (string): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == '2') {
@@ -1011,7 +1011,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             uint16_t *uint16_p = va_arg (argptr, uint16_t *);
             if (uint16_p)
                 *uint16_p = string? (uint16_t) atol (string): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == '4') {
@@ -1019,7 +1019,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             uint32_t *uint32_p = va_arg (argptr, uint32_t *);
             if (uint32_p)
                 *uint32_p = string? (uint32_t) strtoul (string, NULL, 10): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == '8') {
@@ -1027,7 +1027,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             uint64_t *uint64_p = va_arg (argptr, uint64_t *);
             if (uint64_p)
                 *uint64_p = string? (uint64_t) strtoull (string, NULL, 10): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == 'u') {  //  Deprecated, use 4 or 8 instead
@@ -1035,7 +1035,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             uint *uint_p = va_arg (argptr, uint *);
             if (uint_p)
                 *uint_p = string? (uint) strtoul (string, NULL, 10): 0;
-            free (string);
+            FREE_AND_NULL (string);
         }
         else
         if (*picture == 's') {
@@ -1044,7 +1044,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             if (string_p)
                 *string_p = string;
             else
-                free (string);
+                FREE_AND_NULL (string);
         }
         else
         if (*picture == 'b') {
@@ -1854,7 +1854,7 @@ zsock_test (bool verbose)
     assert (msg);
     char *string = zmsg_popstr (msg);
     assert (streq (string, "Hello, World"));
-    free (string);
+    FREE_AND_NULL (string);
     zmsg_destroy (&msg);
 
     //  Test resolve libzmq socket
@@ -1995,9 +1995,9 @@ zsock_test (bool verbose)
     value = (char *) zhashx_lookup (hash, "2");
     assert (streq (value, "value B"));
     assert (original == pointer);
-    free (string);
-    free (data);
-    free (uuid_str);
+    FREE_AND_NULL (string);
+    FREE_AND_NULL (data);
+    FREE_AND_NULL (uuid_str);
     zframe_destroy (&frame);
     zchunk_destroy (&chunk);
     zhashx_destroy (&hash);

--- a/src/zsock_option.gsl
+++ b/src/zsock_option.gsl
@@ -375,7 +375,7 @@ zsock_option_test (bool verbose)
 .           if type = "string" | type = "key"
     char *$(name) = zsock_$(name) (self);
     assert ($(name));
-    free ($(name));
+    FREE_AND_NULL ($(name));
 .           else
     zsock_$(name) (self);
 .           endif

--- a/src/zsock_option.inc
+++ b/src/zsock_option.inc
@@ -3552,7 +3552,7 @@ zsock_option_test (bool verbose)
     zsock_set_socks_proxy (self, "127.0.0.1");
     char *socks_proxy = zsock_socks_proxy (self);
     assert (socks_proxy);
-    free (socks_proxy);
+    FREE_AND_NULL (socks_proxy);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_XPUB_NODROP)
@@ -3601,7 +3601,7 @@ zsock_option_test (bool verbose)
     zsock_set_zap_domain (self, "test");
     char *zap_domain = zsock_zap_domain (self);
     assert (zap_domain);
-    free (zap_domain);
+    FREE_AND_NULL (zap_domain);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_MECHANISM)
@@ -3624,7 +3624,7 @@ zsock_option_test (bool verbose)
     zsock_set_plain_username (self, "test");
     char *plain_username = zsock_plain_username (self);
     assert (plain_username);
-    free (plain_username);
+    FREE_AND_NULL (plain_username);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_PLAIN_PASSWORD)
@@ -3633,7 +3633,7 @@ zsock_option_test (bool verbose)
     zsock_set_plain_password (self, "test");
     char *plain_password = zsock_plain_password (self);
     assert (plain_password);
-    free (plain_password);
+    FREE_AND_NULL (plain_password);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_IPV6)
@@ -3731,7 +3731,7 @@ zsock_option_test (bool verbose)
     zsock_set_tcp_accept_filter (self, "127.0.0.1");
     char *tcp_accept_filter = zsock_tcp_accept_filter (self);
     assert (tcp_accept_filter);
-    free (tcp_accept_filter);
+    FREE_AND_NULL (tcp_accept_filter);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_LAST_ENDPOINT)
@@ -3739,7 +3739,7 @@ zsock_option_test (bool verbose)
     assert (self);
     char *last_endpoint = zsock_last_endpoint (self);
     assert (last_endpoint);
-    free (last_endpoint);
+    FREE_AND_NULL (last_endpoint);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_ROUTER_RAW)
@@ -3799,7 +3799,7 @@ zsock_option_test (bool verbose)
     zsock_set_identity (self, "test");
     char *identity = zsock_identity (self);
     assert (identity);
-    free (identity);
+    FREE_AND_NULL (identity);
     zsock_destroy (&self);
 #     endif
 #     if defined (ZMQ_RATE)

--- a/src/zstr.c
+++ b/src/zstr.c
@@ -348,19 +348,19 @@ zstr_test (bool verbose)
     char *request = zstr_recv (server);
     assert (streq (request, "Hello"));
     assert (zsock_routing_id (server));
-    free (request);
+    FREE_AND_NULL (request);
 
     rc = zstr_send (server, "World");
     assert (rc == 0);
     char *reply = zstr_recv (client);
     assert (streq (reply, "World"));
-    free (reply);
+    FREE_AND_NULL (reply);
 
     rc = zstr_sendf (server, "%s", "World");
     assert (rc == 0);
     reply = zstr_recv (client);
     assert (streq (reply, "World"));
-    free (reply);
+    FREE_AND_NULL (reply);
 
     //  Try ping-pong using sendx and recx
     rc = zstr_sendx (client, "Hello", NULL);
@@ -368,14 +368,14 @@ zstr_test (bool verbose)
     rc = zstr_recvx (server, &request, NULL);
     assert (rc >= 0);
     assert (streq (request, "Hello"));
-    free (request);
+    FREE_AND_NULL (request);
 
     rc = zstr_sendx (server, "World", NULL);
     assert (rc == 0);
     rc = zstr_recvx (client, &reply, NULL);
     assert (rc >= 0);
     assert (streq (reply, "World"));
-    free (reply);
+    FREE_AND_NULL (reply);
 
     //  Client and server disallow multipart
     rc = zstr_sendm (client, "Hello");

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -256,7 +256,7 @@ zsys_shutdown (void)
                     zsys_sockname (sockref->type),
                     sockref->filename, (int) sockref->line_nbr);
         zmq_close (sockref->handle);
-        free (sockref);
+        FREE_AND_NULL (sockref);
         sockref = (s_sockref_t *) zlist_pop (s_sockref_list);
         --s_open_sockets;
     }
@@ -285,14 +285,10 @@ zsys_shutdown (void)
     ZMUTEX_DESTROY (s_mutex);
 
     //  Free dynamically allocated properties
-    free (s_interface);
-    s_interface = NULL;
-    free (s_ipv6_address);
-    s_ipv6_address = NULL;
-    free (s_ipv6_mcast_address);
-    s_ipv6_mcast_address = NULL;
-    free (s_logident);
-    s_logident = NULL;
+    FREE_AND_NULL (s_interface);
+    FREE_AND_NULL (s_ipv6_address);
+    FREE_AND_NULL (s_ipv6_mcast_address);
+    FREE_AND_NULL (s_logident);
 
     zsys_interrupted = 0;
     zctx_interrupted = 0;
@@ -384,7 +380,7 @@ zsys_close (void *handle, const char *filename, size_t line_nbr)
         while (sockref) {
             if (sockref->handle == handle) {
                 zlist_remove (s_sockref_list, sockref);
-                free (sockref);
+                FREE_AND_NULL (sockref);
                 break;
             }
             sockref = (s_sockref_t *) zlist_next (s_sockref_list);
@@ -709,7 +705,7 @@ zsys_dir_create (const char *pathname, ...)
 #else
             if (mkdir (formatted, 0775)) {
 #endif
-                free (formatted);
+                FREE_AND_NULL (formatted);
                 return -1;      //  Failed
             }
         }
@@ -864,7 +860,7 @@ zsys_vprintf (const char *format, va_list argptr)
     //  larger buffer for it.
     if (required >= size) {
         size = required + 1;
-        free (string);
+        FREE_AND_NULL (string);
         string = (char *) malloc (size);
         if (string) {
             va_copy (my_argptr, argptr);
@@ -1462,7 +1458,7 @@ void
 zsys_set_interface (const char *value)
 {
     zsys_init ();
-    free (s_interface);
+    FREE_AND_NULL (s_interface);
     s_interface = strdup (value);
     assert (s_interface);
 }
@@ -1488,7 +1484,7 @@ void
 zsys_set_ipv6_address (const char *value)
 {
     zsys_init ();
-    free (s_ipv6_address);
+    FREE_AND_NULL (s_ipv6_address);
     s_ipv6_address = strdup (value);
     assert (s_ipv6_address);
 }
@@ -1514,7 +1510,7 @@ void
 zsys_set_ipv6_mcast_address (const char *value)
 {
     zsys_init ();
-    free (s_ipv6_mcast_address);
+    FREE_AND_NULL (s_ipv6_mcast_address);
     s_ipv6_mcast_address = strdup (value);
     assert (s_ipv6_mcast_address);
 }
@@ -1569,7 +1565,7 @@ void
 zsys_set_logident (const char *value)
 {
     zsys_init ();
-    free (s_logident);
+    FREE_AND_NULL (s_logident);
     s_logident = strdup (value);
 #if defined (__UNIX__)
     if (s_logsystem)
@@ -1809,7 +1805,7 @@ zsys_test (bool verbose)
     if (verbose) {
         char *hostname = zsys_hostname ();
         zsys_info ("host name is %s", hostname);
-        free (hostname);
+        FREE_AND_NULL (hostname);
         zsys_info ("system limit is %zu ZeroMQ sockets", zsys_socket_limit ());
     }
     zsys_set_linger (0);
@@ -1825,7 +1821,7 @@ zsys_test (bool verbose)
     zstr_send (pipe_front, "Hello");
     char *string = zstr_recv (pipe_back);
     assert (streq (string, "Hello"));
-    free (string);
+    FREE_AND_NULL (string);
     zsock_destroy (&pipe_back);
     zsock_destroy (&pipe_front);
 
@@ -1868,13 +1864,13 @@ zsys_test (bool verbose)
 
     string = zsys_sprintf ("%s %02x", "Hello", 16);
     assert (streq (string, "Hello 10"));
-    free (string);
+    FREE_AND_NULL (string);
 
     char *str64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890,.";
     int num10 = 1234567890;
     string = zsys_sprintf ("%s%s%s%s%d", str64, str64, str64, str64, num10);
     assert (strlen (string) == (4 * 64 + 10));
-    free (string);
+    FREE_AND_NULL (string);
 
     //  Test logging system
     zsys_set_logident ("czmq_selftest");

--- a/src/ztimerset.c
+++ b/src/ztimerset.c
@@ -58,7 +58,7 @@ ztimerset_destroy (ztimerset_t **self_p)
     if (*self_p) {
         ztimerset_t *self = *self_p;
         zmq_timers_destroy (&self->zmq_timers);
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 #endif

--- a/src/ztrie.c
+++ b/src/ztrie.c
@@ -170,12 +170,12 @@ s_ztrie_node_destroy (ztrie_node_t **self_p)
         if (self->parameter_count > 0) {
             size_t index;
             for (index = 0; index < self->parameter_count; index++) {
-                free (self->parameter_names [index]);
+                FREE_AND_NULL (self->parameter_names [index]);
                 if (self->parameter_values [index])
-                    free (self->parameter_values [index]);
+                    FREE_AND_NULL (self->parameter_values [index]);
             }
-            free (self->parameter_names);
-            free (self->parameter_values);
+            FREE_AND_NULL (self->parameter_names);
+            FREE_AND_NULL (self->parameter_values);
         }
         if (self->token_type == NODE_TYPE_REGEX || self->token_type == NODE_TYPE_PARAM)
             zrex_destroy (&self->regex);
@@ -184,7 +184,7 @@ s_ztrie_node_destroy (ztrie_node_t **self_p)
             (self->destroy_data_fn) (&self->data);
 
         //  Free object itself
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -251,7 +251,7 @@ ztrie_destroy (ztrie_t **self_p)
         zlistx_destroy (&self->params);
 
         //  Free object itself
-        free (self);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }
@@ -307,10 +307,10 @@ s_ztrie_matches_token (ztrie_node_t *parent, char *token, int len)
                             s_ztrie_node_update_param (child, index, zrex_hit (child->regex, index));
                     }
                 }
-                free (token_term);
+                FREE_AND_NULL (token_term);
                 return child;
             }
-            free (token_term);
+            FREE_AND_NULL (token_term);
         }
         child = (ztrie_node_t *) zlistx_next (parent->children);
     }

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -94,8 +94,8 @@ zuuid_destroy (zuuid_t **self_p)
     assert (self_p);
     if (*self_p) {
         zuuid_t *self = *self_p;
-        free (self->str_canonical);
-        free (self);
+        FREE_AND_NULL (self->str_canonical);
+        FREE_AND_NULL (self);
         *self_p = NULL;
     }
 }


### PR DESCRIPTION
Solution: unify free/nullify into a FREE_AND_NULL macro

whenever a pointer is free()'d but not nullifies, a double-free or user-after-free 
bug is at least potentially possible.
For example #1649 is in part a spot fix for this problem.  Everywhere in
zmq this is preempted almost as a matter of style. For example, the
destructor pattern in CLASS, and also in zstr_free().  There's little
reason not to replace the calls to free() with a macro that also
nullifies the pointer after free()ing it.  Many project do this and for
good reason, as it eliminates a whole class of bugs.

The only downside I can see is that a double-free no longer triggers a
SEGV, because what is still a logical error is turned into a silent
no-op instead, and it may be the case that the SEGV would have alerted
us to other logical errors. But the caveat also applies to callers of
CLASS destructors and zstr_free(), so it's a trade-off which has already
been adopted to an extent.