### PR TITLE
Problems: zmsg/zframe_recv_nowait out of date with vanilla versions

### DIFF
--- a/src/zframe.c
+++ b/src/zframe.c
@@ -521,6 +521,16 @@ zframe_recv_nowait (void *source)
         return NULL;            //  Interrupted or terminated
     }
     self->more = zsock_rcvmore (source);
+#if defined (ZMQ_SERVER)
+    //  Grab routing ID if we're reading from a SERVER socket (ZMQ 4.2 and later)
+    if (zsock_type (source) == ZMQ_SERVER)
+        self->routing_id = zmq_msg_routing_id (&self->zmsg);
+#endif
+#if defined (ZMQ_DISH)
+    //  Grab group if we're reading from a DISH Socket (ZMQ 4.2 and later)
+    if (zsock_type (source) == ZMQ_DISH)
+        strcpy (self->group, zmq_msg_group (&self->zmsg));
+#endif
     return self;
 }
 

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -858,8 +858,12 @@ zmsg_recv_nowait (void *source)
     while (true) {
         zframe_t *frame = zframe_recv_nowait (source);
         if (!frame) {
-            zmsg_destroy (&self);
-            break;              //  Interrupted or terminated
+            if (errno == EINTR && zlist_head (self->frames))
+                continue;
+            else {
+                zmsg_destroy (&self);
+                break;              //  Interrupted or terminated
+            }
         }
         if (zmsg_append (self, &frame)) {
             zmsg_destroy (&self);

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -865,6 +865,11 @@ zmsg_recv_nowait (void *source)
                 break;              //  Interrupted or terminated
             }
         }
+#if defined (ZMQ_SERVER)
+        //  Grab routing ID if we're reading from a SERVER socket (ZMQ 4.2 and later)
+        if (zsock_type (source) == ZMQ_SERVER)
+            self->routing_id = zframe_routing_id (frame);
+#endif
         if (zmsg_append (self, &frame)) {
             zmsg_destroy (&self);
             break;


### PR DESCRIPTION
Solution: implement additional checks to bring them up to speed

They are marked as deprecated, but until they are provided they should be fully supported