### PR TITLE
Problem: zhashx_purge() seems to leak when shrinking

### DIFF
--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -395,6 +395,7 @@ zhashx_purge (zhashx_t *self)
         size_t limit = primes [INITIAL_PRIME];
         item_t **items = (item_t **) zmalloc (sizeof (item_t *) * limit);
         assert (items);
+        freen (self->items);
         self->prime_index = INITIAL_PRIME;
         self->chain_limit = INITIAL_CHAIN;
         self->items = items;


### PR DESCRIPTION
Solution: freen() the old self->items before reassigning to the newly allocated smaller one

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>