### PR TITLE
Problem: singleton JNI methods aren't static

### DIFF
--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
@@ -31,14 +31,14 @@ public class Zcert implements AutoCloseable{
     Accepts public/secret key pair from caller
     */
     native static long __newFrom (byte [] publicKey, byte [] secretKey);
-    public Zcert newFrom (byte [] publicKey, byte [] secretKey) {
+    public static Zcert newFrom (byte [] publicKey, byte [] secretKey) {
         return new Zcert (__newFrom (publicKey, secretKey));
     }
     /*
     Load certificate from file
     */
     native static long __load (String filename);
-    public Zcert load (String filename) {
+    public static Zcert load (String filename) {
         return new Zcert (__load (filename));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zconfig.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zconfig.java
@@ -33,7 +33,7 @@ public class Zconfig implements AutoCloseable{
     if the file does not exist.                                             
     */
     native static long __load (String filename);
-    public Zconfig load (String filename) {
+    public static Zconfig load (String filename) {
         return new Zconfig (__load (filename));
     }
     /*
@@ -41,7 +41,7 @@ public class Zconfig implements AutoCloseable{
     filename.                                                            
     */
     native static long __loadf (String format);
-    public Zconfig loadf (String format) {
+    public static Zconfig loadf (String format) {
         return new Zconfig (__loadf (format));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zframe.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zframe.java
@@ -33,14 +33,14 @@ public class Zframe implements AutoCloseable{
     Create an empty (zero-sized) frame
     */
     native static long __newEmpty ();
-    public Zframe newEmpty () {
+    public static Zframe newEmpty () {
         return new Zframe (__newEmpty ());
     }
     /*
     Create a frame with a specified string content.
     */
     native static long __from (String string);
-    public Zframe from (String string) {
+    public static Zframe from (String string) {
         return new Zframe (__from (string));
     }
     /*
@@ -49,7 +49,7 @@ public class Zframe implements AutoCloseable{
     zpoller or zloop.                                                       
     */
     native static long __recv (long source);
-    public Zframe recv (long source) {
+    public static Zframe recv (long source) {
         return new Zframe (__recv (source));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zhash.java
@@ -33,7 +33,7 @@ public class Zhash implements AutoCloseable{
     unpacks to an empty hash table.                                          
     */
     native static long __unpack (long frame);
-    public Zhash unpack (Zframe frame) {
+    public static Zhash unpack (Zframe frame) {
         return new Zhash (__unpack (frame.self));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zhashx.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zhashx.java
@@ -33,7 +33,7 @@ public class Zhashx implements AutoCloseable{
     unpacks to an empty hash table.                                          
     */
     native static long __unpack (long frame);
-    public Zhashx unpack (Zframe frame) {
+    public static Zhashx unpack (Zframe frame) {
         return new Zhashx (__unpack (frame.self));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zmsg.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zmsg.java
@@ -34,7 +34,7 @@ public class Zmsg implements AutoCloseable{
     before receiving.                                                        
     */
     native static long __recv (long source);
-    public Zmsg recv (long source) {
+    public static Zmsg recv (long source) {
         return new Zmsg (__recv (source));
     }
     /*
@@ -43,7 +43,7 @@ public class Zmsg implements AutoCloseable{
     there was insufficient memory to work.                                  
     */
     native static long __decode (long frame);
-    public Zmsg decode (Zframe frame) {
+    public static Zmsg decode (Zframe frame) {
         return new Zmsg (__decode (frame.self));
     }
     /*
@@ -52,7 +52,7 @@ public class Zmsg implements AutoCloseable{
     OK). Signals are encoded to be distinguishable from "normal" messages.  
     */
     native static long __newSignal (byte status);
-    public Zmsg newSignal (byte status) {
+    public static Zmsg newSignal (byte status) {
         return new Zmsg (__newSignal (status));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -36,7 +36,7 @@ public class Zsock implements AutoCloseable{
     Create a PUB socket. Default action is bind.
     */
     native static long __newPub (String endpoint);
-    public Zsock newPub (String endpoint) {
+    public static Zsock newPub (String endpoint) {
         return new Zsock (__newPub (endpoint));
     }
     /*
@@ -44,119 +44,119 @@ public class Zsock implements AutoCloseable{
     action is connect.                                                          
     */
     native static long __newSub (String endpoint, String subscribe);
-    public Zsock newSub (String endpoint, String subscribe) {
+    public static Zsock newSub (String endpoint, String subscribe) {
         return new Zsock (__newSub (endpoint, subscribe));
     }
     /*
     Create a REQ socket. Default action is connect.
     */
     native static long __newReq (String endpoint);
-    public Zsock newReq (String endpoint) {
+    public static Zsock newReq (String endpoint) {
         return new Zsock (__newReq (endpoint));
     }
     /*
     Create a REP socket. Default action is bind.
     */
     native static long __newRep (String endpoint);
-    public Zsock newRep (String endpoint) {
+    public static Zsock newRep (String endpoint) {
         return new Zsock (__newRep (endpoint));
     }
     /*
     Create a DEALER socket. Default action is connect.
     */
     native static long __newDealer (String endpoint);
-    public Zsock newDealer (String endpoint) {
+    public static Zsock newDealer (String endpoint) {
         return new Zsock (__newDealer (endpoint));
     }
     /*
     Create a ROUTER socket. Default action is bind.
     */
     native static long __newRouter (String endpoint);
-    public Zsock newRouter (String endpoint) {
+    public static Zsock newRouter (String endpoint) {
         return new Zsock (__newRouter (endpoint));
     }
     /*
     Create a PUSH socket. Default action is connect.
     */
     native static long __newPush (String endpoint);
-    public Zsock newPush (String endpoint) {
+    public static Zsock newPush (String endpoint) {
         return new Zsock (__newPush (endpoint));
     }
     /*
     Create a PULL socket. Default action is bind.
     */
     native static long __newPull (String endpoint);
-    public Zsock newPull (String endpoint) {
+    public static Zsock newPull (String endpoint) {
         return new Zsock (__newPull (endpoint));
     }
     /*
     Create an XPUB socket. Default action is bind.
     */
     native static long __newXpub (String endpoint);
-    public Zsock newXpub (String endpoint) {
+    public static Zsock newXpub (String endpoint) {
         return new Zsock (__newXpub (endpoint));
     }
     /*
     Create an XSUB socket. Default action is connect.
     */
     native static long __newXsub (String endpoint);
-    public Zsock newXsub (String endpoint) {
+    public static Zsock newXsub (String endpoint) {
         return new Zsock (__newXsub (endpoint));
     }
     /*
     Create a PAIR socket. Default action is connect.
     */
     native static long __newPair (String endpoint);
-    public Zsock newPair (String endpoint) {
+    public static Zsock newPair (String endpoint) {
         return new Zsock (__newPair (endpoint));
     }
     /*
     Create a STREAM socket. Default action is connect.
     */
     native static long __newStream (String endpoint);
-    public Zsock newStream (String endpoint) {
+    public static Zsock newStream (String endpoint) {
         return new Zsock (__newStream (endpoint));
     }
     /*
     Create a SERVER socket. Default action is bind.
     */
     native static long __newServer (String endpoint);
-    public Zsock newServer (String endpoint) {
+    public static Zsock newServer (String endpoint) {
         return new Zsock (__newServer (endpoint));
     }
     /*
     Create a CLIENT socket. Default action is connect.
     */
     native static long __newClient (String endpoint);
-    public Zsock newClient (String endpoint) {
+    public static Zsock newClient (String endpoint) {
         return new Zsock (__newClient (endpoint));
     }
     /*
     Create a RADIO socket. Default action is bind.
     */
     native static long __newRadio (String endpoint);
-    public Zsock newRadio (String endpoint) {
+    public static Zsock newRadio (String endpoint) {
         return new Zsock (__newRadio (endpoint));
     }
     /*
     Create a DISH socket. Default action is connect.
     */
     native static long __newDish (String endpoint);
-    public Zsock newDish (String endpoint) {
+    public static Zsock newDish (String endpoint) {
         return new Zsock (__newDish (endpoint));
     }
     /*
     Create a GATHER socket. Default action is bind.
     */
     native static long __newGather (String endpoint);
-    public Zsock newGather (String endpoint) {
+    public static Zsock newGather (String endpoint) {
         return new Zsock (__newGather (endpoint));
     }
     /*
     Create a SCATTER socket. Default action is connect.
     */
     native static long __newScatter (String endpoint);
-    public Zsock newScatter (String endpoint) {
+    public static Zsock newScatter (String endpoint) {
         return new Zsock (__newScatter (endpoint));
     }
     /*

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zuuid.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zuuid.java
@@ -31,7 +31,7 @@ public class Zuuid implements AutoCloseable{
     Create UUID object from supplied ZUUID_LEN-octet value.
     */
     native static long __newFrom (byte [] source);
-    public Zuuid newFrom (byte [] source) {
+    public static Zuuid newFrom (byte [] source) {
         return new Zuuid (__newFrom (source));
     }
     /*


### PR DESCRIPTION
Solution: Regenerate from a patched zproject that makes them so

This is the change created by https://github.com/zeromq/zproject/pull/910
as a fix for https://github.com/zeromq/zproject/issues/909