### PR TITLE
Problem: API compatibility broken for zsys_file_size

### DIFF
--- a/api/zsys.api
+++ b/api/zsys.api
@@ -91,12 +91,6 @@
         <return type = "boolean" />
     </method>
 
-    <method name = "file size" singleton = "1">
-        Return size of file, or -1 if not found
-        <argument name = "filename" type = "string" />
-        <return type = "file_size" />
-    </method>
-
     <method name = "file modified" singleton = "1">
         Return file modification time. Returns 0 if the file does not exist.
         <argument name = "filename" type = "string" />

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -90,10 +90,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT bool
     zsys_file_exists (const char *filename);
 
-//  Return size of file, or -1 if not found
-CZMQ_EXPORT off_t
-    zsys_file_size (const char *filename);
-
 //  Return file modification time. Returns 0 if the file does not exist.
 CZMQ_EXPORT time_t
     zsys_file_modified (const char *filename);
@@ -404,6 +400,10 @@ CZMQ_EXPORT void
     zsys_test (bool verbose);
 
 //  @end
+
+//  Return size of file, or -1 if not found
+CZMQ_EXPORT ssize_t
+    zsys_file_size (const char *filename);
 
 //  Global signal indicator, TRUE when user presses Ctrl-C or the process
 //  gets a SIGTERM signal.

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -592,7 +592,7 @@ zsys_file_exists (const char *filename)
 //  --------------------------------------------------------------------------
 //  Return size of file, or -1 if not found
 
-off_t
+ssize_t
 zsys_file_size (const char *filename)
 {
     struct stat


### PR DESCRIPTION
Solution: keep it off the zproject API definition for now, as it's
never been there in the first place, and define it manually with
ssize_t as the return value instead.