### PR TITLE
fixed Werror messages building on mingw32 mingw64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -477,6 +477,8 @@ case "${host_os}" in
         AC_DEFINE(CZMQ_HAVE_HPUX, 1, [Have HPUX OS])
         ;;
     *mingw32*)
+	CFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CFLAGS"
+        CPPFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(CZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(CZMQ_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)
@@ -486,7 +488,8 @@ case "${host_os}" in
     *mingw64*)
         # Define on MINGW64 to enable all libeary features
         # Disable format error due to incomplete ANSI C
-        CPPFLAGS="-Wno-error=format -D_XOPEN_SOURCE $CPPFLAGS"
+	CFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CFLAGS"
+        CPPFLAGS="-Wno-error=format -Wno-unused-function -Wno-unused-variable -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(CZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(CZMQ_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)


### PR DESCRIPTION
Hi,

I've fixed the wanings errors which i got during the compilation of czmq on mingw64 ... it seems like the check for mingw64 did not worked very well ... because of the host_os switch condition .. it searches for mingw64 in the host_os variable but it is in my case x86_64-w64-mingw32. That has the side effect that it runs the mingw32 settings ... I'm not sure if it should be changed or added a new case so i decided to just set the same FLAGS to mingw32 and mingw64 as a more generic solution.

BR Frank :-)