### PR TITLE
changed description of 2 zhashx functions

### DIFF
--- a/api/zhashx.api
+++ b/api/zhashx.api
@@ -278,8 +278,8 @@
     </method>
 
     <method name = "set_key_hasher">
-        Set a user-defined comparator for keys; by default keys are
-        compared using strcmp.
+        Set a user-defined hash function for keys; by default keys are
+        hashed by a modified Bernstein hashing function.
         <argument name = "hasher" type = "zhashx_hash_fn" callback = "1"/>
     </method>
 

--- a/api/zhashx.api
+++ b/api/zhashx.api
@@ -273,7 +273,9 @@
 
     <method name = "set_key_comparator">
         Set a user-defined comparator for keys; by default keys are
-        compared using strcmp.
+        compared using strcmp. 
+        The callback function should return zero (0) on matching
+        items.
         <argument name = "comparator" type = "zhashx_comparator_fn" callback = "1"/>
     </method>
 


### PR DESCRIPTION
two corrections on descriptions in zhashx

one change is to correct an error in description for set_key_hasher.
bluca told me on IRC how it has to be right.

other is an addition to the description of set_key_comparator function
to eliminate possible confusion what the callback function has to return.