### PR TITLE
Problem: can't use zproto non-virtual API for zactor pipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,22 @@ IF (ENABLE_DRAFTS)
     )
 ENDIF (ENABLE_DRAFTS)
 
+
+add_custom_target(
+    copy-selftest-ro ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/selftest-ro ${CMAKE_BINARY_DIR}/src/selftest-ro
+)
+
+add_custom_target(
+    make-selftest-rw ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/src/selftest-rw
+)
+
+set_directory_properties(
+    PROPERTIES
+    ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/src/selftest-ro;${CMAKE_BINARY_DIR}/src/selftest-rw"
+)
+
 foreach(TEST_CLASS ${TEST_CLASSES})
     add_test(
         NAME ${TEST_CLASS}
@@ -415,6 +431,10 @@ foreach(TEST_CLASS ${TEST_CLASSES})
     set_tests_properties(
         ${TEST_CLASS}
         PROPERTIES TIMEOUT ${CLASSTEST_TIMEOUT}
+    )
+    set_tests_properties(
+        ${TEST_CLASS}
+        PROPERTIES DEPENDS "copy-selftest-ro;make-selftest-rw"
     )
 endforeach(TEST_CLASS)
 

--- a/api/zactor.api
+++ b/api/zactor.api
@@ -16,6 +16,16 @@
         <argument name = "args" type = "anything" />
     </callback_type>
 
+    <callback_type name = "destructor_fn">
+        Function to be called on zactor_destroy. Default behavior is to send zmsg_t with string "$TERM" in a first frame.
+
+        An example - to send $KTHXBAI string
+
+            if (zstr_send (self->pipe, "$KTHXBAI") == 0)
+                zsock_wait (self->pipe);
+        <argument name = "self" type = "zactor" />
+    </callback_type>
+
     <constructor>
         Create a new actor passing arbitrary arguments reference.
         <argument name = "task" type = "zactor_fn" callback = "1" />
@@ -58,5 +68,10 @@
         Return the actor's zsock handle. Use this when you absolutely need
         to work with the zsock instance rather than the actor.
         <return type = "zsock" />
+    </method>
+
+    <method name = "set destructor">
+        Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+        <argument name = "destructor" type = "zactor_destructor_fn" callback="1" />
     </method>
 </class>

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -57,6 +57,15 @@ typedef struct _zuuid_t zuuid_t;
 typedef void (zactor_fn) (
     zsock_t *pipe, void *args);
 
+// Function to be called on zactor_destroy. Default behavior is to send zmsg_t with string "$TERM" in a first frame.
+//                                                                                                                  
+// An example - to send $KTHXBAI string                                                                             
+//                                                                                                                  
+//     if (zstr_send (self->pipe, "$KTHXBAI") == 0)                                                                 
+//         zsock_wait (self->pipe);                                                                                 
+typedef void (zactor_destructor_fn) (
+    zactor_t *self);
+
 // Loaders retrieve certificates from an arbitrary source.
 typedef void (zcertstore_loader) (
     zcertstore_t *self);
@@ -181,6 +190,10 @@ void *
 // to work with the zsock instance rather than the actor.            
 zsock_t *
     zactor_sock (zactor_t *self);
+
+// Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+void
+    zactor_set_destructor (zactor_t *self, zactor_destructor_fn destructor);
 
 // Self test of this class.
 void

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -237,6 +237,7 @@ def coerce_py_file(obj):
 
 # zactor
 zactor_fn = CFUNCTYPE(None, zsock_p, c_void_p)
+zactor_destructor_fn = CFUNCTYPE(None, zactor_p)
 lib.zactor_new.restype = zactor_p
 lib.zactor_new.argtypes = [zactor_fn, c_void_p]
 lib.zactor_destroy.restype = None
@@ -251,6 +252,8 @@ lib.zactor_resolve.restype = c_void_p
 lib.zactor_resolve.argtypes = [c_void_p]
 lib.zactor_sock.restype = zsock_p
 lib.zactor_sock.argtypes = [zactor_p]
+lib.zactor_set_destructor.restype = None
+lib.zactor_set_destructor.argtypes = [zactor_p, zactor_destructor_fn]
 lib.zactor_test.restype = None
 lib.zactor_test.argtypes = [c_bool]
 
@@ -339,6 +342,12 @@ a libzmq actor handle, return the supplied value.
 to work with the zsock instance rather than the actor.
         """
         return Zsock(lib.zactor_sock(self._as_parameter_), False)
+
+    def set_destructor(self, destructor):
+        """
+        Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+        """
+        return lib.zactor_set_destructor(self._as_parameter_, destructor)
 
     @staticmethod
     def test(verbose):

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -62,6 +62,15 @@ typedef struct _zuuid_t zuuid_t;
 typedef void (zactor_fn) (
     zsock_t *pipe, void *args);
 
+// Function to be called on zactor_destroy. Default behavior is to send zmsg_t with string "$TERM" in a first frame.
+//                                                                                                                  
+// An example - to send $KTHXBAI string                                                                             
+//                                                                                                                  
+//     if (zstr_send (self->pipe, "$KTHXBAI") == 0)                                                                 
+//         zsock_wait (self->pipe);                                                                                 
+typedef void (zactor_destructor_fn) (
+    zactor_t *self);
+
 // Loaders retrieve certificates from an arbitrary source.
 typedef void (zcertstore_loader) (
     zcertstore_t *self);
@@ -186,6 +195,10 @@ void *
 // to work with the zsock instance rather than the actor.            
 zsock_t *
     zactor_sock (zactor_t *self);
+
+// Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+void
+    zactor_set_destructor (zactor_t *self, zactor_destructor_fn destructor);
 
 // Self test of this class.
 void
@@ -1487,11 +1500,13 @@ void
 
 // Set a user-defined comparator for keys; by default keys are
 // compared using strcmp.                                     
+// The callback function should return zero (0) on matching   
+// items.                                                     
 void
     zhashx_set_key_comparator (zhashx_t *self, zhashx_comparator_fn comparator);
 
-// Set a user-defined comparator for keys; by default keys are
-// compared using strcmp.                                     
+// Set a user-defined hash function for keys; by default keys are
+// hashed by a modified Bernstein hashing function.              
 void
     zhashx_set_key_hasher (zhashx_t *self, zhashx_hash_fn hasher);
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -64,6 +64,15 @@ typedef struct _zuuid_t zuuid_t;
 typedef void (zactor_fn) (
     zsock_t *pipe, void *args);
 
+// Function to be called on zactor_destroy. Default behavior is to send zmsg_t with string "$TERM" in a first frame.
+//                                                                                                                  
+// An example - to send $KTHXBAI string                                                                             
+//                                                                                                                  
+//     if (zstr_send (self->pipe, "$KTHXBAI") == 0)                                                                 
+//         zsock_wait (self->pipe);                                                                                 
+typedef void (zactor_destructor_fn) (
+    zactor_t *self);
+
 // Loaders retrieve certificates from an arbitrary source.
 typedef void (zcertstore_loader) (
     zcertstore_t *self);
@@ -188,6 +197,10 @@ void *
 // to work with the zsock instance rather than the actor.            
 zsock_t *
     zactor_sock (zactor_t *self);
+
+// Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+void
+    zactor_set_destructor (zactor_t *self, zactor_destructor_fn destructor);
 
 // Self test of this class.
 void

--- a/bindings/qml/src/QmlZactor.cpp
+++ b/bindings/qml/src/QmlZactor.cpp
@@ -34,6 +34,12 @@ QmlZsock *QmlZactor::sock () {
     return retQ_;
 };
 
+///
+//  Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+void QmlZactor::setDestructor (zactor_destructor_fn destructor) {
+    zactor_set_destructor (self, destructor);
+};
+
 
 QObject* QmlZactor::qmlAttachedProperties(QObject* object) {
     return new QmlZactorAttached(object);

--- a/bindings/qml/src/QmlZactor.h
+++ b/bindings/qml/src/QmlZactor.h
@@ -40,6 +40,9 @@ public slots:
     //  Return the actor's zsock handle. Use this when you absolutely need
     //  to work with the zsock instance rather than the actor.            
     QmlZsock *sock ();
+
+    //  Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+    void setDestructor (zactor_destructor_fn destructor);
 };
 
 class QmlZactorAttached : public QObject

--- a/bindings/qt/src/qzactor.cpp
+++ b/bindings/qt/src/qzactor.cpp
@@ -76,6 +76,14 @@ QZsock * QZactor::sock ()
 }
 
 ///
+//  Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+void QZactor::setDestructor (zactor_destructor_fn destructor)
+{
+    zactor_set_destructor (self, destructor);
+    
+}
+
+///
 //  Self test of this class.
 void QZactor::test (bool verbose)
 {

--- a/bindings/qt/src/qzactor.h
+++ b/bindings/qt/src/qzactor.h
@@ -44,6 +44,9 @@ public:
     //  to work with the zsock instance rather than the actor.            
     QZsock * sock ();
 
+    //  Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+    void setDestructor (zactor_destructor_fn destructor);
+
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -47,6 +47,7 @@ module CZMQ
       attach_function :zactor_is, [:pointer], :bool, **opts
       attach_function :zactor_resolve, [:pointer], :pointer, **opts
       attach_function :zactor_sock, [:pointer], :pointer, **opts
+      attach_function :zactor_set_destructor, [:pointer, :pointer], :void, **opts
       attach_function :zactor_test, [:bool], :void, **opts
 
       require_relative 'ffi/zactor'

--- a/include/zactor.h
+++ b/include/zactor.h
@@ -27,6 +27,15 @@ extern "C" {
 typedef void (zactor_fn) (
     zsock_t *pipe, void *args);
 
+// Function to be called on zactor_destroy. Default behavior is to send zmsg_t with string "$TERM" in a first frame.
+//                                                                                                                  
+// An example - to send $KTHXBAI string                                                                             
+//                                                                                                                  
+//     if (zstr_send (self->pipe, "$KTHXBAI") == 0)                                                                 
+//         zsock_wait (self->pipe);                                                                                 
+typedef void (zactor_destructor_fn) (
+    zactor_t *self);
+
 //  Create a new actor passing arbitrary arguments reference.
 CZMQ_EXPORT zactor_t *
     zactor_new (zactor_fn task, void *args);
@@ -61,6 +70,10 @@ CZMQ_EXPORT void *
 //  to work with the zsock instance rather than the actor.            
 CZMQ_EXPORT zsock_t *
     zactor_sock (zactor_t *self);
+
+//  Change default destructor by custom function. Actor MUST be able to handle new message instead of default $TERM.
+CZMQ_EXPORT void
+    zactor_set_destructor (zactor_t *self, zactor_destructor_fn destructor);
 
 //  Self test of this class.
 CZMQ_EXPORT void


### PR DESCRIPTION
Solution: add a custom destructor function callback, which overrrides default
zmsg_t with $TERM by own message format. With this patch it's possible to use
custom messages built by zproto_codec_c without converting them from/to zmsg_t.

Note the actor itself MUST handle new termination message, otherwise it won't be stopped