### PR TITLE
problem: zframe_meta documentation is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2463,7 +2463,8 @@ This is the class interface:
         zframe_data (zframe_t *self);
     
     //  Return meta data property for frame           
-    //  Caller must free string when finished with it.
+    //  The caller shall not modify or free the returned value, which shall be
+    //  owned by the message.
     CZMQ_EXPORT const char *
         zframe_meta (zframe_t *self, const char *property);
     

--- a/api/zframe.api
+++ b/api/zframe.api
@@ -63,7 +63,8 @@
 
     <method name = "meta">
         Return meta data property for frame
-        Caller must free string when finished with it.
+        The caller shall not modify or free the returned value, which shall be
+        owned by the message.
         <argument name = "property" type = "string" />
         <return type = "string" fresh = "0" />
     </method>

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1092,7 +1092,8 @@ byte *
     zframe_data (zframe_t *self);
 
 // Return meta data property for frame           
-// Caller must free string when finished with it.
+// The caller shall not modify or free the returned value, which shall be
+// owned by the message.
 const char *
     zframe_meta (zframe_t *self, const char *property);
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -2539,7 +2539,8 @@ Return -1 on error, 0 on success.
     def meta(self, property):
         """
         Return meta data property for frame
-Caller must free string when finished with it.
+        The caller shall not modify or free the returned value, which shall be
+        owned by the message.
         """
         return lib.zframe_meta(self._as_parameter_, property)
 

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -1097,7 +1097,8 @@ byte *
     zframe_data (zframe_t *self);
 
 // Return meta data property for frame           
-// Caller must free string when finished with it.
+// The caller shall not modify or free the returned value, which shall be
+// owned by the message.
 const char *
     zframe_meta (zframe_t *self, const char *property);
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -1099,7 +1099,8 @@ byte *
     zframe_data (zframe_t *self);
 
 // Return meta data property for frame           
-// Caller must free string when finished with it.
+// The caller shall not modify or free the returned value, which shall be
+// owned by the message.
 const char *
     zframe_meta (zframe_t *self, const char *property);
 

--- a/bindings/qml/src/QmlZframe.cpp
+++ b/bindings/qml/src/QmlZframe.cpp
@@ -22,7 +22,8 @@ byte *QmlZframe::data () {
 
 ///
 //  Return meta data property for frame           
-//  Caller must free string when finished with it.
+//  The caller shall not modify or free the returned value, which shall be
+//  owned by the message.
 const QString QmlZframe::meta (const QString &property) {
     return QString (zframe_meta (self, property.toUtf8().data()));
 };

--- a/bindings/qt/src/qzframe.cpp
+++ b/bindings/qt/src/qzframe.cpp
@@ -81,7 +81,8 @@ byte * QZframe::data ()
 
 ///
 //  Return meta data property for frame           
-//  Caller must free string when finished with it.
+//  The caller shall not modify or free the returned value, which shall be
+//  owned by the message.
 const QString QZframe::meta (const QString &property)
 {
     const QString rv = QString (zframe_meta (self, property.toUtf8().data()));

--- a/bindings/ruby/lib/czmq/ffi/zframe.rb
+++ b/bindings/ruby/lib/czmq/ffi/zframe.rb
@@ -164,7 +164,8 @@ module CZMQ
       end
 
       # Return meta data property for frame           
-      # Caller must free string when finished with it.
+      # The caller shall not modify or free the returned value, which shall be
+      # owned by the message.
       #
       # @param property [String, #to_s, nil]
       # @return [String]

--- a/include/zframe.h
+++ b/include/zframe.h
@@ -67,7 +67,8 @@ CZMQ_EXPORT byte *
     zframe_data (zframe_t *self);
 
 //  Return meta data property for frame           
-//  Caller must free string when finished with it.
+//  The caller shall not modify or free the returned value, which shall be
+//  owned by the message.
 CZMQ_EXPORT const char *
     zframe_meta (zframe_t *self, const char *property);
 

--- a/src/zframe.c
+++ b/src/zframe.c
@@ -226,7 +226,8 @@ zframe_data (zframe_t *self)
 
 //  --------------------------------------------------------------------------
 //  Return meta data property for frame.
-//  Caller must free string when finished with it.
+//  The caller shall not modify or free the returned value, which shall be
+//  owned by the message.
 
 const char *
 zframe_meta (zframe_t *self, const char *property)


### PR DESCRIPTION
zframe_meta returns the value from zmq_msg_gets directly and according
to http://api.zeromq.org/4-2:zmq-msg-gets

The zmq_msg_gets() function shall return the string value for the
property if successful. Otherwise it shall return NULL and set errno to
one of the values defined below. The caller shall not modify or free the
returned value, which shall be owned by the message. The encoding of the
property and value shall be UTF8.