### PR TITLE
problem: User-Id field in zap response is not populated

### DIFF
--- a/src/zauth.c
+++ b/src/zauth.c
@@ -657,6 +657,7 @@ zauth_test (bool verbose)
     success = s_can_connect (&server, &client, false);
     assert (success);
 
+#if (ZMQ_VERSION >= ZMQ_MAKE_VERSION (4, 1, 0))
     // Test that the User-Id metadata is present
     zframe_t *frame = zframe_recv (server);
     assert (frame != NULL);
@@ -664,6 +665,7 @@ zauth_test (bool verbose)
     assert (user_id != NULL);
     assert (streq (user_id, "admin"));
     zframe_destroy (&frame);
+#endif
     s_renew_sockets(&server, &client);
 
     zsock_set_plain_server (server, 1);


### PR DESCRIPTION
problem: zauth tests do not check User-Id metadata

Solution: update the PLAIN and CURVE tests to fetch and verify the
User-Id metadata set by ZAP

problem: User-Id field in zap response is not populated.

According to ZAP spec:

user id: this MAY provide the user identity in case of a 200 status, for
use by applications. For other statuses, it SHALL be empty.

Solution:  This adds a char pointer in the zap request struct that can
point to the the username, client_key, or principal fields.

With this change zframe_meta(frame, "User-Id") returns the public key
for a connection.  This enables a use case where you have a long lived
connection authenticated by a key or password and want to verify that the
user/key still exists.

    zframe_t *frame = zframe_recv(server);
    const char *user_id = zframe_meta(frame, "User-Id");
    if(user_id!=NULL) {
        zcert_t *c = zcertstore_lookup(store, user_id);
        if(!c)
            //Certificate no longer exists in store!
    }