### PR TITLE
problem: no way to loop over all certs in a zcertstore

### DIFF
--- a/api/zcertstore.api
+++ b/api/zcertstore.api
@@ -65,6 +65,11 @@
         Print list of certificates in store to logging facility
     </method>
 
+    <method name = "certs" state = "draft">
+        Return a list of all the certificates in the store
+        <return type = "zlistx" fresh = "1" />
+    </method>
+
     <method name = "test" singleton = "1">
         Self test of this class
         <argument name = "verbose" type = "boolean" />

--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -78,6 +78,11 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zcertstore_empty (zcertstore_t *self);
 
+//  *** Draft method, for development use, may change without warning ***
+//  Return a list of all the certificates in the store
+CZMQ_EXPORT zlistx_t *
+    zcertstore_certs (zcertstore_t *self);
+
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end
 

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -236,6 +236,14 @@ zcertstore_empty (zcertstore_t *self)
     zhashx_purge (self->certs);
 }
 
+//  --------------------------------------------------------------------------
+//  Return a list of all the certificates in the store
+
+zlistx_t *
+zcertstore_certs (zcertstore_t *self)
+{
+    return zhashx_values(self->certs);
+}
 
 //  --------------------------------------------------------------------------
 //  Print list of certificates in store to stdout
@@ -325,6 +333,19 @@ zcertstore_test (bool verbose)
     cert = zcertstore_lookup (certstore, client_key);
     assert (cert);
     assert (streq (zcert_meta (cert, "name"), "John Doe"));
+
+#ifndef CZMQ_BUILD_DRAFT_API
+    // Iterate through certs
+    zlistx_t *certs = zcertstore_certs(certstore);
+    cert = (zcert_t *) zlistx_first(certs);
+    int cert_count = 0;
+    while (cert) {
+        assert (streq (zcert_meta (cert, "name"), "John Doe"));
+        cert = (zcert_t *) zlistx_next(certs);
+        cert_count++;
+    }
+    assert(cert_count==1);
+#endif
 
     //  Test custom loader
     test_loader_state *state = (test_loader_state *) zmalloc (sizeof (test_loader_state));


### PR DESCRIPTION
solution: add zcertstore_certs method that returns a zlistx of certs

This may not be 100% right yet - I'm not sure how to regenerate the bindings and documentation.  The goal is to be able to do something like this:

    zcert_t *cert;
    zlistx_t *certs = zcertstore_certs(certstore);
    cert = (zcert_t *) zlistx_first(certs);
    while (cert) {
        char *endpoint = zcert_meta (cert, "endpoint");
        if(endpoint) {
            fprintf(stderr, "Connect to %s using %s\n", endpoint, zcert_public_txt(cert));
        }
        cert = (zcert_t *) zlistx_next(certs);
    }
    zlistx_destroy(&certs);

That way an application won't require any configuration aside from a certstore path.  This could also be used to find the cert in a certstore that has the private key as well.