### PR TITLE
problem: zcertstore_certs was broken

### DIFF
--- a/api/zcertstore.api
+++ b/api/zcertstore.api
@@ -66,7 +66,10 @@
     </method>
 
     <method name = "certs" state = "draft">
-        Return a list of all the certificates in the store
+        Return a list of all the certificates in the store.
+        The caller takes ownership of the zlistx_t object and is responsible
+        for destroying it.  The caller does not take ownership of the zcert_t
+        objects.
         <return type = "zlistx" fresh = "1" />
     </method>
 

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zcertstore.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zcertstore.java
@@ -75,7 +75,10 @@ public class Zcertstore implements AutoCloseable{
         __print (self);
     }
     /*
-    Return a list of all the certificates in the store
+    Return a list of all the certificates in the store.                  
+    The caller takes ownership of the zlistx_t object and is responsible 
+    for destroying it.  The caller does not take ownership of the zcert_t
+    objects.                                                             
     */
     native static long __certs (long self);
     public Zlistx certs () {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -466,7 +466,10 @@ void
 void
     zcertstore_print (zcertstore_t *self);
 
-// Return a list of all the certificates in the store
+// Return a list of all the certificates in the store.                  
+// The caller takes ownership of the zlistx_t object and is responsible 
+// for destroying it.  The caller does not take ownership of the zcert_t
+// objects.                                                             
 zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -442,7 +442,10 @@ Print list of certificates in store to logging facility
 zlistx my_zcertstore.certs ()
 ```
 
-Return a list of all the certificates in the store
+Return a list of all the certificates in the store.
+The caller takes ownership of the zlistx_t object and is responsible
+for destroying it.  The caller does not take ownership of the zcert_t
+objects.
 
 ```
 nothing my_zcertstore.test (Boolean)

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -1049,7 +1049,10 @@ which don't usually have access to struct internals.
 
     def certs(self):
         """
-        Return a list of all the certificates in the store
+        Return a list of all the certificates in the store.
+The caller takes ownership of the zlistx_t object and is responsible
+for destroying it.  The caller does not take ownership of the zcert_t
+objects.
         """
         return Zlistx(lib.zcertstore_certs(self._as_parameter_), True)
 

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -471,7 +471,10 @@ void
 void
     zcertstore_print (zcertstore_t *self);
 
-// Return a list of all the certificates in the store
+// Return a list of all the certificates in the store.                  
+// The caller takes ownership of the zlistx_t object and is responsible 
+// for destroying it.  The caller does not take ownership of the zcert_t
+// objects.                                                             
 zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -473,7 +473,10 @@ void
 void
     zcertstore_print (zcertstore_t *self);
 
-// Return a list of all the certificates in the store
+// Return a list of all the certificates in the store.                  
+// The caller takes ownership of the zlistx_t object and is responsible 
+// for destroying it.  The caller does not take ownership of the zcert_t
+// objects.                                                             
 zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 

--- a/bindings/qml/src/QmlZcertstore.cpp
+++ b/bindings/qml/src/QmlZcertstore.cpp
@@ -45,7 +45,10 @@ void QmlZcertstore::print () {
 };
 
 ///
-//  Return a list of all the certificates in the store
+//  Return a list of all the certificates in the store.                  
+//  The caller takes ownership of the zlistx_t object and is responsible 
+//  for destroying it.  The caller does not take ownership of the zcert_t
+//  objects.                                                             
 QmlZlistx *QmlZcertstore::certs () {
     QmlZlistx *retQ_ = new QmlZlistx ();
     retQ_->self = zcertstore_certs (self);

--- a/bindings/qml/src/QmlZcertstore.h
+++ b/bindings/qml/src/QmlZcertstore.h
@@ -47,7 +47,10 @@ public slots:
     //  Print list of certificates in store to logging facility
     void print ();
 
-    //  Return a list of all the certificates in the store
+    //  Return a list of all the certificates in the store.                  
+    //  The caller takes ownership of the zlistx_t object and is responsible 
+    //  for destroying it.  The caller does not take ownership of the zcert_t
+    //  objects.                                                             
     QmlZlistx *certs ();
 };
 

--- a/bindings/qt/src/qzcertstore.cpp
+++ b/bindings/qt/src/qzcertstore.cpp
@@ -80,7 +80,10 @@ void QZcertstore::print ()
 }
 
 ///
-//  Return a list of all the certificates in the store
+//  Return a list of all the certificates in the store.                  
+//  The caller takes ownership of the zlistx_t object and is responsible 
+//  for destroying it.  The caller does not take ownership of the zcert_t
+//  objects.                                                             
 QZlistx * QZcertstore::certs ()
 {
     QZlistx *rv = new QZlistx (zcertstore_certs (self));

--- a/bindings/qt/src/qzcertstore.h
+++ b/bindings/qt/src/qzcertstore.h
@@ -48,7 +48,10 @@ public:
     //  Print list of certificates in store to logging facility
     void print ();
 
-    //  Return a list of all the certificates in the store
+    //  Return a list of all the certificates in the store.                  
+    //  The caller takes ownership of the zlistx_t object and is responsible 
+    //  for destroying it.  The caller does not take ownership of the zcert_t
+    //  objects.                                                             
     QZlistx * certs ();
 
     //  Self test of this class

--- a/bindings/ruby/lib/czmq/ffi/zcertstore.rb
+++ b/bindings/ruby/lib/czmq/ffi/zcertstore.rb
@@ -191,7 +191,10 @@ module CZMQ
         result
       end
 
-      # Return a list of all the certificates in the store
+      # Return a list of all the certificates in the store.                  
+      # The caller takes ownership of the zlistx_t object and is responsible 
+      # for destroying it.  The caller does not take ownership of the zcert_t
+      # objects.                                                             
       #
       # @return [Zlistx]
       def certs()

--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -79,7 +79,10 @@ CZMQ_EXPORT void
     zcertstore_empty (zcertstore_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Return a list of all the certificates in the store
+//  Return a list of all the certificates in the store.                  
+//  The caller takes ownership of the zlistx_t object and is responsible 
+//  for destroying it.  The caller does not take ownership of the zcert_t
+//  objects.                                                             
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT zlistx_t *
     zcertstore_certs (zcertstore_t *self);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -79,7 +79,10 @@ CZMQ_PRIVATE void
     zcertstore_empty (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
-//  Return a list of all the certificates in the store
+//  Return a list of all the certificates in the store.                  
+//  The caller takes ownership of the zlistx_t object and is responsible 
+//  for destroying it.  The caller does not take ownership of the zcert_t
+//  objects.                                                             
 //  Caller owns return value and must destroy it when done.
 CZMQ_PRIVATE zlistx_t *
     zcertstore_certs (zcertstore_t *self);

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -242,7 +242,11 @@ zcertstore_empty (zcertstore_t *self)
 zlistx_t *
 zcertstore_certs (zcertstore_t *self)
 {
-    return zhashx_values(self->certs);
+    if (self->loader)
+        self->loader (self);
+    zlistx_t *certs = zhashx_values(self->certs);
+    zlistx_set_destructor (certs, NULL);
+    return certs;
 }
 
 //  --------------------------------------------------------------------------
@@ -334,7 +338,7 @@ zcertstore_test (bool verbose)
     assert (cert);
     assert (streq (zcert_meta (cert, "name"), "John Doe"));
 
-#ifndef CZMQ_BUILD_DRAFT_API
+#ifdef CZMQ_BUILD_DRAFT_API
     // Iterate through certs
     zlistx_t *certs = zcertstore_certs(certstore);
     cert = (zcert_t *) zlistx_first(certs);
@@ -345,6 +349,7 @@ zcertstore_test (bool verbose)
         cert_count++;
     }
     assert(cert_count==1);
+    zlistx_destroy(&certs);
 #endif
 
     //  Test custom loader


### PR DESCRIPTION
solution:

zcertstore configures itself with a destructor that calls
zcert_destroy.  zhashx_values copies this destructor by default, causing
zlistx_destroy on the returned list to incorrectly destroy the
certificates.  To fix this the destructor must be disabled on the
zlist_x before it can be destroyed.