### PR TITLE
Problem: can not see why zsys_test fails

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -261,7 +261,12 @@ memcheck: src/czmq_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_bui
 	$(LIBTOOL) --mode=execute valgrind --tool=memcheck \
 		--leak-check=full --show-reachable=yes --error-exitcode=1 \
 		--suppressions=$(srcdir)/src/.valgrind.supp \
-		$(builddir)/src/czmq_selftest
+		$(builddir)/src/czmq_selftest || \
+	{ echo "Re-running failed ($$?) $@ with greater verbosity"; \
+	  $(LIBTOOL) --mode=execute valgrind --tool=memcheck \
+		--leak-check=full --show-reachable=yes --error-exitcode=1 \
+		--suppressions=$(srcdir)/src/.valgrind.supp \
+		$(builddir)/src/czmq_selftest -v ; }
 
 # Run the selftest binary under valgrind to check for performance leaks
 callcheck: src/czmq_selftest $(abs_top_builddir)/$(SELFTEST_DIR_RW) $(abs_top_builddir)/$(SELFTEST_DIR_RO)


### PR DESCRIPTION
Solution: augment the timing-dependent portion of code and test with optional verbosity (requested privately from tests, invisible for ordinary consumers)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Context:

As discussed on IRC, I have this test failing in valgrind of czmq-master built as part of a larger project on Travis. I could not reproduce the issue isolated from that build, nor in local rebuilds, so its heaviness and/or Travis virtualization may be a contributing factor (this test relies on speed that a recently created file is "young", so lags are fatal). Curiously, non-memcheck builds against czmq-master, as well as any sort of builds against our legacy baseline fork of czmq-v3.0.2 (where these routines seem to be same as in master) do not fail the same tests in Travis.

In order to debug this better, I added some optional tracing to this part of the code, as agreed with @bluca .