### PR TITLE
Problem: CZMQ master build fails in JNI binding

### DIFF
--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -380,9 +380,11 @@ public class Zsys {
     }
     /*
     Return network interface to use for broadcasts, or "" if none was set.
+    Note that "interface" is among reserved Java keywords, so it had to be
+    renamed here manually to "getInterface".
     */
     native static String __interface ();
-    public String interface () {
+    public String getInterface () {
         return __interface ();
     }
     /*


### PR DESCRIPTION
Solution: do not use a reserved Java keyword "interface" in Zsys.java; rename function to getInterface()

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: maybe there should be some place to document this modification and different behavior compared to other bindings. This change likely breaks no consumers because previous code never passed the build since introduction, per Travis build history (see `git diff f05c010 1042d8f` for change between green and red states). Probably the binding code is generated from the C code - if so, the parser script should also be amended to produce this exclusion and perhaps comment upon re-generations.