### PR TITLE
Problem: MSVS does not have PRIi64

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -497,6 +497,18 @@ typedef intptr_t ssize_t;
 #   if (!defined (PRId64))
 #       define PRId64   "I64d"
 #   endif
+#   if (!defined (PRIi8))
+#       define PRIi8    "i"
+#   endif
+#   if (!defined (PRIi16))
+#       define PRIi16   "i"
+#   endif
+#   if (!defined (PRIi32))
+#       define PRIi32   "i"
+#   endif
+#   if (!defined (PRIi64))
+#       define PRIi64   "I64i"
+#   endif
 #   if (!defined (PRIu8))
 #       define PRIu8    "u"
 #   endif


### PR DESCRIPTION
Solution: add the PRIi* to czmq_prelude.h

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

NOTE: Before merging, wait for AppVeyor Windows tests to pass
