### PR TITLE
Problem: zsys_test can fail if old run artifacts are present

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1948,6 +1948,11 @@ zsys_test (bool verbose)
     zsys_file_mode_private ();
     if (verbose)
         printf ("zsys_test() at timestamp %" PRIi64 ": "
+            "Dropping .testsys/subdir (may be absent)\n",
+            zclock_time() );
+    rc = zsys_dir_delete ("%s/%s", ".", ".testsys");
+    if (verbose)
+        printf ("zsys_test() at timestamp %" PRIi64 ": "
             "Creating .testsys/subdir\n",
             zclock_time() );
     rc = zsys_dir_create ("%s/%s", ".", ".testsys/subdir");


### PR DESCRIPTION
Solution: Drop dir in zsys_test(). It seems safe to just do so, no extra checks on presence are needed.