### PR TITLE
problem: missing zcert_new_from_txt function 

### DIFF
--- a/api/zcert.api
+++ b/api/zcert.api
@@ -20,6 +20,12 @@
         <argument name = "secret key" type = "buffer" />
     </constructor>
 
+    <constructor name = "new from txt" state = "draft">
+        Accepts public/secret key text pair from caller
+        <argument name = "public txt" type = "string" />
+        <argument name = "secret txt" type = "string" />
+    </constructor>
+
     <constructor name = "load">
         Load certificate from file
         <argument name = "filename" type = "string" />

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zcert.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zcert.c
@@ -31,6 +31,17 @@ Java_org_zeromq_czmq_Zcert__1_1newFrom (JNIEnv *env, jclass c, jbyteArray public
 }
 
 JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zcert__1_1newFromTxt (JNIEnv *env, jclass c, jstring public_txt, jstring secret_txt)
+{
+    char *public_txt_ = (char *) (*env)->GetStringUTFChars (env, public_txt, NULL);
+    char *secret_txt_ = (char *) (*env)->GetStringUTFChars (env, secret_txt, NULL);
+    jlong new_from_txt_ = (jlong) (intptr_t) zcert_new_from_txt (public_txt_, secret_txt_);
+    (*env)->ReleaseStringUTFChars (env, public_txt, public_txt_);
+    (*env)->ReleaseStringUTFChars (env, secret_txt, secret_txt_);
+    return new_from_txt_;
+}
+
+JNIEXPORT jlong JNICALL
 Java_org_zeromq_czmq_Zcert__1_1load (JNIEnv *env, jclass c, jstring filename)
 {
     char *filename_ = (char *) (*env)->GetStringUTFChars (env, filename, NULL);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zcert.java
@@ -35,6 +35,13 @@ public class Zcert implements AutoCloseable{
         return new Zcert (__newFrom (publicKey, secretKey));
     }
     /*
+    Accepts public/secret key text pair from caller
+    */
+    native static long __newFromTxt (String publicTxt, String secretTxt);
+    public static Zcert newFromTxt (String publicTxt, String secretTxt) {
+        return new Zcert (__newFromTxt (publicTxt, secretTxt));
+    }
+    /*
     Load certificate from file
     */
     native static long __load (String filename);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -349,6 +349,10 @@ zcert_t *
 zcert_t *
     zcert_new_from (const byte *public_key, const byte *secret_key);
 
+// Accepts public/secret key text pair from caller
+zcert_t *
+    zcert_new_from_txt (const char *public_txt, const char *secret_txt);
+
 // Load certificate from file
 zcert_t *
     zcert_load (const char *filename);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -736,6 +736,8 @@ lib.zcert_destroy.restype = None
 lib.zcert_destroy.argtypes = [POINTER(zcert_p)]
 lib.zcert_new_from.restype = zcert_p
 lib.zcert_new_from.argtypes = [c_void_p, c_void_p]
+lib.zcert_new_from_txt.restype = zcert_p
+lib.zcert_new_from_txt.argtypes = [c_char_p, c_char_p]
 lib.zcert_load.restype = zcert_p
 lib.zcert_load.argtypes = [c_char_p]
 lib.zcert_public_key.restype = c_void_p
@@ -825,6 +827,13 @@ class Zcert(object):
         Accepts public/secret key pair from caller
         """
         return Zcert(lib.zcert_new_from(public_key, secret_key), True)
+
+    @staticmethod
+    def new_from_txt(public_txt, secret_txt):
+        """
+        Accepts public/secret key text pair from caller
+        """
+        return Zcert(lib.zcert_new_from_txt(public_txt, secret_txt), True)
 
     @staticmethod
     def load(filename):

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -354,6 +354,10 @@ zcert_t *
 zcert_t *
     zcert_new_from (const byte *public_key, const byte *secret_key);
 
+// Accepts public/secret key text pair from caller
+zcert_t *
+    zcert_new_from_txt (const char *public_txt, const char *secret_txt);
+
 // Load certificate from file
 zcert_t *
     zcert_load (const char *filename);

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -356,6 +356,10 @@ zcert_t *
 zcert_t *
     zcert_new_from (const byte *public_key, const byte *secret_key);
 
+// Accepts public/secret key text pair from caller
+zcert_t *
+    zcert_new_from_txt (const char *public_txt, const char *secret_txt);
+
 // Load certificate from file
 zcert_t *
     zcert_load (const char *filename);

--- a/bindings/qml/src/QmlZcert.cpp
+++ b/bindings/qml/src/QmlZcert.cpp
@@ -137,6 +137,14 @@ QmlZcert *QmlZcertAttached::constructFrom (const byte *publicKey, const byte *se
 };
 
 ///
+//  Accepts public/secret key text pair from caller
+QmlZcert *QmlZcertAttached::constructFromTxt (const QString &publicTxt, const QString &secretTxt) {
+    QmlZcert *qmlSelf = new QmlZcert ();
+    qmlSelf->self = zcert_new_from_txt (publicTxt.toUtf8().data(), secretTxt.toUtf8().data());
+    return qmlSelf;
+};
+
+///
 //  Load certificate from file
 QmlZcert *QmlZcertAttached::load (const QString &filename) {
     QmlZcert *qmlSelf = new QmlZcert ();

--- a/bindings/qml/src/QmlZcert.h
+++ b/bindings/qml/src/QmlZcert.h
@@ -100,6 +100,9 @@ public slots:
     //  Accepts public/secret key pair from caller
     QmlZcert *constructFrom (const byte *publicKey, const byte *secretKey);
 
+    //  Accepts public/secret key text pair from caller
+    QmlZcert *constructFromTxt (const QString &publicTxt, const QString &secretTxt);
+
     //  Load certificate from file
     QmlZcert *load (const QString &filename);
 

--- a/bindings/qt/src/qzcert.cpp
+++ b/bindings/qt/src/qzcert.cpp
@@ -30,6 +30,13 @@ QZcert* QZcert::newFrom (const byte *publicKey, const byte *secretKey, QObject *
 }
 
 ///
+//  Accepts public/secret key text pair from caller
+QZcert* QZcert::newFromTxt (const QString &publicTxt, const QString &secretTxt, QObject *qObjParent)
+{
+    return new QZcert (zcert_new_from_txt (publicTxt.toUtf8().data(), secretTxt.toUtf8().data()), qObjParent);
+}
+
+///
 //  Load certificate from file
 QZcert* QZcert::load (const QString &filename, QObject *qObjParent)
 {

--- a/bindings/qt/src/qzcert.h
+++ b/bindings/qt/src/qzcert.h
@@ -23,6 +23,9 @@ public:
     //  Accepts public/secret key pair from caller
     static QZcert* newFrom (const byte *publicKey, const byte *secretKey, QObject *qObjParent = 0);
 
+    //  Accepts public/secret key text pair from caller
+    static QZcert* newFromTxt (const QString &publicTxt, const QString &secretTxt, QObject *qObjParent = 0);
+
     //  Load certificate from file
     static QZcert* load (const QString &filename, QObject *qObjParent = 0);
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -252,6 +252,17 @@ module CZMQ
 
       attach_function :zcert_new, [], :pointer, **opts
       attach_function :zcert_new_from, [:pointer, :pointer], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zcert_new_from_txt, [:string, :string], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zcert_new_from_txt()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zcert_new_from_txt(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
       attach_function :zcert_load, [:string], :pointer, **opts
       attach_function :zcert_destroy, [:pointer], :void, **opts
       attach_function :zcert_public_key, [:pointer], :pointer, **opts

--- a/bindings/ruby/lib/czmq/ffi/zcert.rb
+++ b/bindings/ruby/lib/czmq/ffi/zcert.rb
@@ -89,6 +89,15 @@ module CZMQ
         __new ptr
       end
 
+      # Accepts public/secret key text pair from caller
+      # @param public_txt [String, #to_s, nil]
+      # @param secret_txt [String, #to_s, nil]
+      # @return [CZMQ::Zcert]
+      def self.new_from_txt(public_txt, secret_txt)
+        ptr = ::CZMQ::FFI.zcert_new_from_txt(public_txt, secret_txt)
+        __new ptr
+      end
+
       # Load certificate from file
       # @param filename [String, #to_s, nil]
       # @return [CZMQ::Zcert]

--- a/include/zcert.h
+++ b/include/zcert.h
@@ -110,6 +110,11 @@ CZMQ_EXPORT void
 
 #ifdef CZMQ_BUILD_DRAFT_API
 //  *** Draft method, for development use, may change without warning ***
+//  Accepts public/secret key text pair from caller
+CZMQ_EXPORT zcert_t *
+    zcert_new_from_txt (const char *public_txt, const char *secret_txt);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Unset certificate metadata.
 CZMQ_EXPORT void
     zcert_unset_meta (zcert_t *self, const char *name);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -55,6 +55,12 @@ CZMQ_PRIVATE void
     zactor_set_destructor (zactor_t *self, zactor_destructor_fn destructor);
 
 //  *** Draft method, defined for internal use only ***
+//  Accepts public/secret key text pair from caller
+//  Caller owns return value and must destroy it when done.
+CZMQ_PRIVATE zcert_t *
+    zcert_new_from_txt (const char *public_txt, const char *secret_txt);
+
+//  *** Draft method, defined for internal use only ***
 //  Unset certificate metadata.
 CZMQ_PRIVATE void
     zcert_unset_meta (zcert_t *self, const char *name);

--- a/src/zcert.c
+++ b/src/zcert.c
@@ -98,7 +98,6 @@ zcert_new_from (const byte *public_key, const byte *secret_key)
     return self;
 }
 
-#ifdef CZMQ_BUILD_DRAFT_API
 //  --------------------------------------------------------------------------
 //  Constructor, accepts public/secret text key pair from caller
 
@@ -124,7 +123,6 @@ zcert_new_from_txt (const char *public_txt, const char *secret_txt)
 #endif
     return self;
 }
-#endif
 
 
 //  --------------------------------------------------------------------------


### PR DESCRIPTION
solution: create zcert_new_from_txt function that takes in keys as text and generates a cert (instead of just from binary or disk)

added as a DRAFT function for now... thought about modifying new_from but wasn't sure if that would potentially break things for others...