### PR TITLE
Problem: zsys_file_stable() check for (age>1000) is weak

### DIFF
--- a/api/zsys.api
+++ b/api/zsys.api
@@ -303,6 +303,22 @@
         <return type = "integer" />
     </method>
 
+    <method name = "set file stable age msec" singleton = "1">
+        Configure the threshold value of filesystem object age per st_mtime
+        that should elapse until we consider that object "stable" at the
+        current zclock_time() moment.
+        The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+        which generally depends on host OS, with fallback value of 3000.
+        <argument name = "file stable age msec" type = "msecs" />
+    </method>
+
+    <method name = "file stable age msec" singleton = "1">
+        Return current threshold value of file stable age in msec.
+        This can be used in code that chooses to wait for this timeout
+        before testing if a filesystem object is "stable" or not.
+        <return type = "msecs" />
+    </method>
+
     <method name = "set linger" singleton = "1">
         Configure the default linger timeout in msecs for new zsock instances.
         You can also set this separately on each zsock_t instance. The default

--- a/api/zsys.api
+++ b/api/zsys.api
@@ -303,7 +303,7 @@
         <return type = "integer" />
     </method>
 
-    <method name = "set file stable age msec" singleton = "1">
+    <method name = "set file stable age msec" singleton = "1" state = "draft">
         Configure the threshold value of filesystem object age per st_mtime
         that should elapse until we consider that object "stable" at the
         current zclock_time() moment.
@@ -312,7 +312,7 @@
         <argument name = "file stable age msec" type = "msecs" />
     </method>
 
-    <method name = "file stable age msec" singleton = "1">
+    <method name = "file stable age msec" singleton = "1" state = "draft">
         Return current threshold value of file stable age in msec.
         This can be used in code that chooses to wait for this timeout
         before testing if a filesystem object is "stable" or not.

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zsys.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zsys.c
@@ -258,6 +258,19 @@ Java_org_zeromq_czmq_Zsys__1_1maxMsgsz (JNIEnv *env, jclass c)
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsys__1_1setFileStableAgeMsec (JNIEnv *env, jclass c, jlong file_stable_age_msec)
+{
+    zsys_set_file_stable_age_msec ((int64_t) file_stable_age_msec);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zsys__1_1fileStableAgeMsec (JNIEnv *env, jclass c)
+{
+    jlong file_stable_age_msec_ = (jlong) zsys_file_stable_age_msec ();
+    return file_stable_age_msec_;
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zsys__1_1setLinger (JNIEnv *env, jclass c, jlong linger)
 {
     zsys_set_linger ((size_t) linger);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -297,6 +297,26 @@ public class Zsys {
         return __maxMsgsz ();
     }
     /*
+    Configure the threshold value of filesystem object age per st_mtime
+    that should elapse until we consider that object "stable" at the
+    current zclock_time() moment.
+    The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+    which generally depends on host OS, with fallback value of 3000.
+    */
+    native static void __setFileStableAgeMsec (long fileStableAgeMsec);
+    public void setFileStableAgeMsec (long fileStableAgeMsec) {
+        __setFileStableAgeMsec (fileStableAgeMsec);
+    }
+    /*
+    Return current threshold value of file stable age in msec.
+    This can be used in code that chooses to wait for this timeout
+    before testing if a filesystem object is "stable" or not.
+    */
+    native static long __fileStableAgeMsec ();
+    public long fileStableAgeMsec () {
+        return __fileStableAgeMsec ();
+    }
+    /*
     Configure the default linger timeout in msecs for new zsock instances.
     You can also set this separately on each zsock_t instance. The default
     linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -3718,6 +3718,20 @@ void
 int
     zsys_max_msgsz (void);
 
+// Configure the threshold value of filesystem object age per st_mtime
+// that should elapse until we consider that object "stable" at the
+// current zclock_time() moment.
+// The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+// which generally depends on host OS, with fallback value of 3000.
+void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+// Return current threshold value of file stable age in msec.
+// This can be used in code that chooses to wait for this timeout
+// before testing if a filesystem object is "stable" or not.
+int64_t
+    zsys_file_stable_age_msec (void);
+
 // Configure the default linger timeout in msecs for new zsock instances.
 // You can also set this separately on each zsock_t instance. The default
 // linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -3915,6 +3915,24 @@ integer my_zsys.maxMsgsz ()
 Return maximum message size.
 
 ```
+nothing my_zsys.setFileStableAgeMsec (Number)
+```
+
+Configure the threshold value of filesystem object age per st_mtime
+that should elapse until we consider that object "stable" at the
+current zclock_time() moment.
+The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+which generally depends on host OS, with fallback value of 3000.
+
+```
+msecs my_zsys.fileStableAgeMsec ()
+```
+
+Return current threshold value of file stable age in msec.
+This can be used in code that chooses to wait for this timeout
+before testing if a filesystem object is "stable" or not.
+
+```
 nothing my_zsys.setLinger ()
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -6487,6 +6487,8 @@ NAN_MODULE_INIT (Zsys::Init) {
     Nan::SetPrototypeMethod (tpl, "socketLimit", _socket_limit);
     Nan::SetPrototypeMethod (tpl, "setMaxMsgsz", _set_max_msgsz);
     Nan::SetPrototypeMethod (tpl, "maxMsgsz", _max_msgsz);
+    Nan::SetPrototypeMethod (tpl, "setFileStableAgeMsec", _set_file_stable_age_msec);
+    Nan::SetPrototypeMethod (tpl, "fileStableAgeMsec", _file_stable_age_msec);
     Nan::SetPrototypeMethod (tpl, "setLinger", _set_linger);
     Nan::SetPrototypeMethod (tpl, "setSndhwm", _set_sndhwm);
     Nan::SetPrototypeMethod (tpl, "setRcvhwm", _set_rcvhwm);
@@ -6877,6 +6879,23 @@ NAN_METHOD (Zsys::_set_max_msgsz) {
 
 NAN_METHOD (Zsys::_max_msgsz) {
     int result = zsys_max_msgsz ();
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zsys::_set_file_stable_age_msec) {
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `file stable age msec`");
+
+    int64_t file_stable_age_msec;
+    if (info [0]->IsNumber ())
+        file_stable_age_msec = Nan::To<int64_t>(info [0]).FromJust ();
+    else
+        return Nan::ThrowTypeError ("`file stable age msec` must be a number");
+    zsys_set_file_stable_age_msec ((int64_t) file_stable_age_msec);
+}
+
+NAN_METHOD (Zsys::_file_stable_age_msec) {
+    int64_t result = zsys_file_stable_age_msec ();
     info.GetReturnValue ().Set (Nan::New<Number>(result));
 }
 

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -847,6 +847,8 @@ class Zsys: public Nan::ObjectWrap {
     static NAN_METHOD (_socket_limit);
     static NAN_METHOD (_set_max_msgsz);
     static NAN_METHOD (_max_msgsz);
+    static NAN_METHOD (_set_file_stable_age_msec);
+    static NAN_METHOD (_file_stable_age_msec);
     static NAN_METHOD (_set_linger);
     static NAN_METHOD (_set_sndhwm);
     static NAN_METHOD (_set_rcvhwm);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -7200,6 +7200,10 @@ lib.zsys_set_max_msgsz.restype = None
 lib.zsys_set_max_msgsz.argtypes = [c_int]
 lib.zsys_max_msgsz.restype = c_int
 lib.zsys_max_msgsz.argtypes = []
+lib.zsys_set_file_stable_age_msec.restype = None
+lib.zsys_set_file_stable_age_msec.argtypes = [msecs_p]
+lib.zsys_file_stable_age_msec.restype = msecs_p
+lib.zsys_file_stable_age_msec.argtypes = []
 lib.zsys_set_linger.restype = None
 lib.zsys_set_linger.argtypes = [c_size_t]
 lib.zsys_set_sndhwm.restype = None
@@ -7612,6 +7616,26 @@ The default is INT_MAX.
         Return maximum message size.
         """
         return lib.zsys_max_msgsz()
+
+    @staticmethod
+    def set_file_stable_age_msec(file_stable_age_msec):
+        """
+        Configure the threshold value of filesystem object age per st_mtime
+that should elapse until we consider that object "stable" at the
+current zclock_time() moment.
+The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+which generally depends on host OS, with fallback value of 3000.
+        """
+        return lib.zsys_set_file_stable_age_msec(file_stable_age_msec)
+
+    @staticmethod
+    def file_stable_age_msec():
+        """
+        Return current threshold value of file stable age in msec.
+This can be used in code that chooses to wait for this timeout
+before testing if a filesystem object is "stable" or not.
+        """
+        return lib.zsys_file_stable_age_msec()
 
     @staticmethod
     def set_linger(linger):

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -56,7 +56,11 @@ class TestCZMQ(unittest.TestCase):
             initfile.handle().write(b"initial file\n")
         initfile.close()
 
-        time.sleep(1.001) # wait for initial file to become 'stable'
+        try:
+            stable_age = file_stable_age_msec()
+        except Exception:
+            stable_age = 3.001
+        time.sleep(stable_age) # wait for initial file to become 'stable'
 
         watch.sock().send(b"si", b"TIMEOUT", 100)
         self.assertEqual(watch.sock().wait(), 0)
@@ -185,9 +189,14 @@ class TestCZMQ(unittest.TestCase):
         f.close()
         del f
 
+        try:
+            stable_age = file_stable_age_msec()
+        except Exception:
+            stable_age = 3.001
+
         self.assertTrue(file.has_changed())
         self.assertFalse(file.is_stable())
-        time.sleep(1.001) # just over a second passes...
+        time.sleep(stable_age) # just over a threshold value passes...
         self.assertTrue(file.has_changed())
         self.assertFalse(file.is_stable())
 

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -57,7 +57,7 @@ class TestCZMQ(unittest.TestCase):
         initfile.close()
 
         try:
-            stable_age = file_stable_age_msec()
+            stable_age = float(file_stable_age_msec()) / 1000.0
         except Exception:
             stable_age = 3.001
         time.sleep(stable_age) # wait for initial file to become 'stable'
@@ -190,7 +190,7 @@ class TestCZMQ(unittest.TestCase):
         del f
 
         try:
-            stable_age = file_stable_age_msec()
+            stable_age = float(file_stable_age_msec()) / 1000.0
         except Exception:
             stable_age = 3.001
 

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -3723,6 +3723,20 @@ void
 int
     zsys_max_msgsz (void);
 
+// Configure the threshold value of filesystem object age per st_mtime
+// that should elapse until we consider that object "stable" at the
+// current zclock_time() moment.
+// The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+// which generally depends on host OS, with fallback value of 3000.
+void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+// Return current threshold value of file stable age in msec.
+// This can be used in code that chooses to wait for this timeout
+// before testing if a filesystem object is "stable" or not.
+int64_t
+    zsys_file_stable_age_msec (void);
+
 // Configure the default linger timeout in msecs for new zsock instances.
 // You can also set this separately on each zsock_t instance. The default
 // linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -3725,6 +3725,20 @@ void
 int
     zsys_max_msgsz (void);
 
+// Configure the threshold value of filesystem object age per st_mtime
+// that should elapse until we consider that object "stable" at the
+// current zclock_time() moment.
+// The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+// which generally depends on host OS, with fallback value of 3000.
+void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+// Return current threshold value of file stable age in msec.
+// This can be used in code that chooses to wait for this timeout
+// before testing if a filesystem object is "stable" or not.
+int64_t
+    zsys_file_stable_age_msec (void);
+
 // Configure the default linger timeout in msecs for new zsock instances.
 // You can also set this separately on each zsock_t instance. The default
 // linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -317,6 +317,24 @@ int QmlZsysAttached::maxMsgsz () {
 };
 
 ///
+//  Configure the threshold value of filesystem object age per st_mtime
+//  that should elapse until we consider that object "stable" at the
+//  current zclock_time() moment.
+//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+//  which generally depends on host OS, with fallback value of 3000.
+void QmlZsysAttached::setFileStableAgeMsec (int64_t fileStableAgeMsec) {
+    zsys_set_file_stable_age_msec (fileStableAgeMsec);
+};
+
+///
+//  Return current threshold value of file stable age in msec.
+//  This can be used in code that chooses to wait for this timeout
+//  before testing if a filesystem object is "stable" or not.
+int64_t QmlZsysAttached::fileStableAgeMsec () {
+    return zsys_file_stable_age_msec ();
+};
+
+///
 //  Configure the default linger timeout in msecs for new zsock instances.
 //  You can also set this separately on each zsock_t instance. The default
 //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -224,6 +224,18 @@ public slots:
     //  Return maximum message size.
     int maxMsgsz ();
 
+    //  Configure the threshold value of filesystem object age per st_mtime
+    //  that should elapse until we consider that object "stable" at the
+    //  current zclock_time() moment.
+    //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+    //  which generally depends on host OS, with fallback value of 3000.
+    void setFileStableAgeMsec (int64_t fileStableAgeMsec);
+
+    //  Return current threshold value of file stable age in msec.
+    //  This can be used in code that chooses to wait for this timeout
+    //  before testing if a filesystem object is "stable" or not.
+    int64_t fileStableAgeMsec ();
+
     //  Configure the default linger timeout in msecs for new zsock instances.
     //  You can also set this separately on each zsock_t instance. The default
     //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -363,6 +363,28 @@ int QZsys::maxMsgsz ()
 }
 
 ///
+//  Configure the threshold value of filesystem object age per st_mtime
+//  that should elapse until we consider that object "stable" at the
+//  current zclock_time() moment.
+//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+//  which generally depends on host OS, with fallback value of 3000.
+void QZsys::setFileStableAgeMsec (int64_t fileStableAgeMsec)
+{
+    zsys_set_file_stable_age_msec (fileStableAgeMsec);
+
+}
+
+///
+//  Return current threshold value of file stable age in msec.
+//  This can be used in code that chooses to wait for this timeout
+//  before testing if a filesystem object is "stable" or not.
+int64_t QZsys::fileStableAgeMsec ()
+{
+    int64_t rv = zsys_file_stable_age_msec ();
+    return rv;
+}
+
+///
 //  Configure the default linger timeout in msecs for new zsock instances.
 //  You can also set this separately on each zsock_t instance. The default
 //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -189,6 +189,18 @@ public:
     //  Return maximum message size.
     static int maxMsgsz ();
 
+    //  Configure the threshold value of filesystem object age per st_mtime
+    //  that should elapse until we consider that object "stable" at the
+    //  current zclock_time() moment.
+    //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+    //  which generally depends on host OS, with fallback value of 3000.
+    static void setFileStableAgeMsec (int64_t fileStableAgeMsec);
+
+    //  Return current threshold value of file stable age in msec.
+    //  This can be used in code that chooses to wait for this timeout
+    //  before testing if a filesystem object is "stable" or not.
+    static int64_t fileStableAgeMsec ();
+
     //  Configure the default linger timeout in msecs for new zsock instances.
     //  You can also set this separately on each zsock_t instance. The default
     //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -1574,6 +1574,8 @@ module CZMQ
       attach_function :zsys_socket_limit, [], :size_t, **opts
       attach_function :zsys_set_max_msgsz, [:int], :void, **opts
       attach_function :zsys_max_msgsz, [], :int, **opts
+      attach_function :zsys_set_file_stable_age_msec, [:pointer], :void, **opts
+      attach_function :zsys_file_stable_age_msec, [], :pointer, **opts
       attach_function :zsys_set_linger, [:size_t], :void, **opts
       attach_function :zsys_set_sndhwm, [:size_t], :void, **opts
       attach_function :zsys_set_rcvhwm, [:size_t], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -1574,8 +1574,28 @@ module CZMQ
       attach_function :zsys_socket_limit, [], :size_t, **opts
       attach_function :zsys_set_max_msgsz, [:int], :void, **opts
       attach_function :zsys_max_msgsz, [], :int, **opts
-      attach_function :zsys_set_file_stable_age_msec, [:pointer], :void, **opts
-      attach_function :zsys_file_stable_age_msec, [], :pointer, **opts
+      begin # DRAFT method
+        attach_function :zsys_set_file_stable_age_msec, [:pointer], :void, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zsys_set_file_stable_age_msec()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zsys_set_file_stable_age_msec(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
+      begin # DRAFT method
+        attach_function :zsys_file_stable_age_msec, [], :pointer, **opts
+      rescue ::FFI::NotFoundError
+        if $VERBOSE || $DEBUG
+          warn "The DRAFT function zsys_file_stable_age_msec()" +
+            " is not provided by the installed CZMQ library."
+        end
+        def self.zsys_file_stable_age_msec(*)
+          raise NotImplementedError, "compile CZMQ with --enable-drafts"
+        end
+      end
       attach_function :zsys_set_linger, [:size_t], :void, **opts
       attach_function :zsys_set_sndhwm, [:size_t], :void, **opts
       attach_function :zsys_set_rcvhwm, [:size_t], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zsys.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsys.rb
@@ -523,6 +523,29 @@ module CZMQ
         result
       end
 
+      # Configure the threshold value of filesystem object age per st_mtime
+      # that should elapse until we consider that object "stable" at the
+      # current zclock_time() moment.
+      # The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+      # which generally depends on host OS, with fallback value of 3000.
+      #
+      # @param file_stable_age_msec [::FFI::Pointer, #to_ptr]
+      # @return [void]
+      def self.set_file_stable_age_msec(file_stable_age_msec)
+        result = ::CZMQ::FFI.zsys_set_file_stable_age_msec(file_stable_age_msec)
+        result
+      end
+
+      # Return current threshold value of file stable age in msec.
+      # This can be used in code that chooses to wait for this timeout
+      # before testing if a filesystem object is "stable" or not.
+      #
+      # @return [::FFI::Pointer]
+      def self.file_stable_age_msec()
+        result = ::CZMQ::FFI.zsys_file_stable_age_msec()
+        result
+      end
+
       # Configure the default linger timeout in msecs for new zsock instances.
       # You can also set this separately on each zsock_t instance. The default
       # linger time is zero, i.e. any pending messages will be dropped. If the

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -25,6 +25,8 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
+//  This class has draft methods, which may change over time. They are not
+//  in stable releases, by default. Use --enable-drafts to enable.
 // Callback for interrupt signal handler
 typedef void (zsys_handler_fn) (
     int signal_value);
@@ -251,20 +253,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int
     zsys_max_msgsz (void);
 
-//  Configure the threshold value of filesystem object age per st_mtime
-//  that should elapse until we consider that object "stable" at the
-//  current zclock_time() moment.
-//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
-CZMQ_EXPORT void
-    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
-
-//  Return current threshold value of file stable age in msec.
-//  This can be used in code that chooses to wait for this timeout
-//  before testing if a filesystem object is "stable" or not.
-CZMQ_EXPORT int64_t
-    zsys_file_stable_age_msec (void);
-
 //  Configure the default linger timeout in msecs for new zsock instances.
 //  You can also set this separately on each zsock_t instance. The default
 //  linger time is zero, i.e. any pending messages will be dropped. If the
@@ -414,6 +402,24 @@ CZMQ_EXPORT void
 CZMQ_EXPORT void
     zsys_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Configure the threshold value of filesystem object age per st_mtime
+//  that should elapse until we consider that object "stable" at the
+//  current zclock_time() moment.
+//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+//  which generally depends on host OS, with fallback value of 3000.
+CZMQ_EXPORT void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Return current threshold value of file stable age in msec.
+//  This can be used in code that chooses to wait for this timeout
+//  before testing if a filesystem object is "stable" or not.
+CZMQ_EXPORT int64_t
+    zsys_file_stable_age_msec (void);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @end
 
 //  Return size of file, or -1 if not found

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -251,6 +251,20 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int
     zsys_max_msgsz (void);
 
+//  Configure the threshold value of filesystem object age per st_mtime
+//  that should elapse until we consider that object "stable" at the
+//  current zclock_time() moment.
+//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+//  which generally depends on host OS, with fallback value of 3000.
+CZMQ_EXPORT void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+//  Return current threshold value of file stable age in msec.
+//  This can be used in code that chooses to wait for this timeout
+//  before testing if a filesystem object is "stable" or not.
+CZMQ_EXPORT int64_t
+    zsys_file_stable_age_msec (void);
+
 //  Configure the default linger timeout in msecs for new zsock instances.
 //  You can also set this separately on each zsock_t instance. The default
 //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -227,6 +227,22 @@ CZMQ_PRIVATE int
 CZMQ_PRIVATE char *
     zstr_str (void *source);
 
+//  *** Draft method, defined for internal use only ***
+//  Configure the threshold value of filesystem object age per st_mtime
+//  that should elapse until we consider that object "stable" at the
+//  current zclock_time() moment.
+//  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
+//  which generally depends on host OS, with fallback value of 3000.
+CZMQ_PRIVATE void
+    zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
+
+//  *** Draft method, defined for internal use only ***
+//  Return current threshold value of file stable age in msec.
+//  This can be used in code that chooses to wait for this timeout
+//  before testing if a filesystem object is "stable" or not.
+CZMQ_PRIVATE int64_t
+    zsys_file_stable_age_msec (void);
+
 //  *** Draft constants, defined for internal use only ***
 #define ZGOSSIP_MSG_HELLO 1                 //
 #define ZGOSSIP_MSG_PUBLISH 2               //

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -971,7 +971,7 @@ zdir_test (bool verbose)
         assert ( synced == 0);
     }
 
-    zclock_sleep (1001); // wait for initial file to become 'stable'
+    zclock_sleep (zsys_file_stable_age_msec() + 1); // wait for initial file to become 'stable'
 
     zsock_send (watch, "si", "TIMEOUT", 100);
     synced = zsock_wait(watch);
@@ -997,7 +997,7 @@ zdir_test (bool verbose)
     zpoller_t *watch_poll = zpoller_new (watch, NULL);
 
     // poll for a certain timeout before giving up and failing the test.
-    void* polled = zpoller_wait(watch_poll, 1001);
+    void* polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
     assert (polled == watch);
 
     // wait for notification of the file being added
@@ -1024,7 +1024,7 @@ zdir_test (bool verbose)
     zfile_destroy (&newfile);
 
     // poll for a certain timeout before giving up and failing the test.
-    polled = zpoller_wait(watch_poll, 1001);
+    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
     assert (polled == watch);
 
     // wait for notification of the file being removed

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -971,7 +971,12 @@ zdir_test (bool verbose)
         assert ( synced == 0);
     }
 
-    zclock_sleep (zsys_file_stable_age_msec() + 1); // wait for initial file to become 'stable'
+    // wait for initial file to become 'stable'
+#ifdef CZMQ_BUILD_DRAFT_API
+    zclock_sleep (zsys_file_stable_age_msec() + 1);
+#else
+    zclock_sleep (3001);
+#endif
 
     zsock_send (watch, "si", "TIMEOUT", 100);
     synced = zsock_wait(watch);
@@ -996,8 +1001,13 @@ zdir_test (bool verbose)
 
     zpoller_t *watch_poll = zpoller_new (watch, NULL);
 
-    // poll for a certain timeout before giving up and failing the test.
-    void* polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
+    // poll for a certain timeout before giving up and failing the test
+    void* polled = NULL;
+#ifdef CZMQ_BUILD_DRAFT_API
+    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
+#else
+    polled = zpoller_wait(watch_poll, 3001);
+#endif
     assert (polled == watch);
 
     // wait for notification of the file being added
@@ -1024,7 +1034,11 @@ zdir_test (bool verbose)
     zfile_destroy (&newfile);
 
     // poll for a certain timeout before giving up and failing the test.
+#ifdef CZMQ_BUILD_DRAFT_API
     polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
+#else
+    polled = zpoller_wait(watch_poll, 3001);
+#endif
     assert (polled == watch);
 
     // wait for notification of the file being removed

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -711,7 +711,7 @@ zfile_test (bool verbose)
     assert (rc == 13);
     close (handle);
     assert (zfile_has_changed (file));
-    zclock_sleep (1001);
+    zclock_sleep (zsys_file_stable_age_msec() + 1);
     assert (zfile_has_changed (file));
 
     assert (!zfile_is_stable (file));

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -711,7 +711,11 @@ zfile_test (bool verbose)
     assert (rc == 13);
     close (handle);
     assert (zfile_has_changed (file));
+#ifdef CZMQ_BUILD_DRAFT_API
     zclock_sleep (zsys_file_stable_age_msec() + 1);
+#else
+    zclock_sleep (3001);
+#endif
     assert (zfile_has_changed (file));
 
     assert (!zfile_is_stable (file));

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -610,6 +610,13 @@ zsys_file_size (const char *filename)
 //  Return file modification time (accounted in seconds usually since
 //  UNIX Epoch, with granularity dependent on underlying filesystem,
 //  and starting point dependent on host OS and maybe its bitness).
+//  Per https://msdn.microsoft.com/en-us/library/w4ddyt9h(vs.71).aspx :
+//      Note   In all versions of Microsoft C/C++ except Microsoft C/C++
+//      version 7.0, and in all versions of Microsoft Visual C++, the time
+//      function returns the current time as the number of seconds elapsed
+//      since midnight on January 1, 1970. In Microsoft C/C++ version 7.0,
+//      time() returned the current time as the number of seconds elapsed
+//      since midnight on December 31, 1899.
 //  This value is "arithmetic" with no big guarantees in the standards, and
 //  normally it should be manipulated with host's datetime suite of routines,
 //  including difftime(), or converted to "struct tm" for any predictable use.


### PR DESCRIPTION
Solution: Document the analysis of why checking for (age>1000) when we account in values rounded to thousands is misleading, propose better solutions and an improvement for current implementation.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

This takes off from discussion in IRC.