### PR TITLE
Problem: once in a few million runs, randof() still lies

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -421,21 +421,22 @@ typedef struct {
 #define strneq(s1,s2)   (strcmp ((s1), (s2)))
 #define freen(x) do {free(x); x = NULL;} while(0)
 
-//  Provide random number from 0..(num-1)
+//  randof(num) : Provide random number from 0..(num-1)
 //  Note that (at least in Solaris) while rand() returns an int limited by
 //  RAND_MAX, random() returns a 32-bit value all filled with random bits.
 //  The math libraries on different platforms and capabilities in HW are a
 //  nightmare. Seems we have to drown the code in casts to have reasonable
-//  results...
+//  results... Also note that the 32-bit float has a hard time representing
+//  values close to UINT32_MAX that we had before, so now limit to UINT16_MAX.
 #if defined(RAND_MAX)
 # if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
  || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(rand () % RAND_MAX) / ((float)RAND_MAX + 1.0)) ) ) )
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(rand () % (RAND_MAX - 1)) / ((float)RAND_MAX)) ) ) )
 # else  // other platforms
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(random () % RAND_MAX) / ((float)RAND_MAX + 1.0)) ) ) )
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(random () % (RAND_MAX - 1)) / ((float)RAND_MAX)) ) ) )
 # endif // ifdef RAND_MAX
 #else
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(uint32_t)(random () % UINT32_MAX) / ((float)UINT32_MAX + 1.0)) ) ) )
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)( (uint16_t)(random ()) % (UINT16_MAX - 1) ) / ((float)UINT16_MAX)) ) ) )
 #endif
 
 // Windows MSVS doesn't have stdbool

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -424,15 +424,18 @@ typedef struct {
 //  Provide random number from 0..(num-1)
 //  Note that (at least in Solaris) while rand() returns an int limited by
 //  RAND_MAX, random() returns a 32-bit value all filled with random bits.
-#if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
+//  The math libraries on different platforms and capabilities in HW are a
+//  nightmare. Seems we have to drown the code in casts to have reasonable
+//  results...
+#if defined(RAND_MAX)
+# if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
  || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * (float)(rand ()) / ((float)RAND_MAX + 1.0)) ) )
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(rand () % RAND_MAX) / ((float)RAND_MAX + 1.0)) ) ) )
+# else  // other platforms
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(random () % RAND_MAX) / ((float)RAND_MAX + 1.0)) ) ) )
+# endif // ifdef RAND_MAX
 #else
-# if defined(RAND_MAX)
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * (float)(random () % RAND_MAX) / ((float)RAND_MAX + 1.0)) ) )
-# else
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * (float)(uint32_t)random () / ((float)UINT32_MAX + 1.0)) ) )
-# endif
+#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(uint32_t)(random () % UINT32_MAX) / ((float)UINT32_MAX + 1.0)) ) ) )
 #endif
 
 // Windows MSVS doesn't have stdbool

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -439,12 +439,13 @@ typedef struct {
 # if defined (RAND_MAX)
 #  if (RAND_MAX > UINT16_MAX)
 #   define  ZSYS_RANDOF_MAX UINT16_MAX
-#  else
+#  else // RAND_MAX is small enough to not overflow our calculations
 #   define  ZSYS_RANDOF_MAX RAND_MAX
 #  endif
-# else
+# else // No RAND_MAX - use a smaller safer limit
 #   define  ZSYS_RANDOF_MAX INT16_MAX
 # endif
+#endif // ZSYS_RANDOF_MAX is defined by caller... trust them or explode later
 
 # if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
  || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -432,12 +432,25 @@ typedef struct {
 //  rigged with problems here: even if the code used double-precision, the
 //  corner-case factors (divident close to INT32_MAX and close to divisor)
 //  were too close to 1.0, so the final product was "num" rather than "num-1".
+//  Finally note that on some platforms RAND_MAX can be smallish, like 32767,
+//  so we should use it if small enough.
+
+#if !defined (ZSYS_RANDOF_MAX)
+# if defined (RAND_MAX)
+#  if (RAND_MAX > UINT16_MAX)
+#   define  ZSYS_RANDOF_MAX UINT16_MAX
+#  else
+#   define  ZSYS_RANDOF_MAX RAND_MAX
+#  endif
+# else
+#   define  ZSYS_RANDOF_MAX INT16_MAX
+# endif
 
 # if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
  || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
-#   define randof(num)  (int) ( (float)(num) * ( (float)( (rand   () % (UINT16_MAX - 1) ) / ( (float)(UINT16_MAX) ) ) ) )
+#   define randof(num)  (int) ( (float)(num) * ( (float)( (rand   () % (ZSYS_RANDOF_MAX - 1) ) / ( (float)(ZSYS_RANDOF_MAX) ) ) ) )
 # else
-#   define randof(num)  (int) ( (float)(num) * ( (float)( (random () % (UINT16_MAX - 1) ) / ( (float)(UINT16_MAX) ) ) ) )
+#   define randof(num)  (int) ( (float)(num) * ( (float)( (random () % (ZSYS_RANDOF_MAX - 1) ) / ( (float)(ZSYS_RANDOF_MAX) ) ) ) )
 #endif
 
 

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -422,22 +422,24 @@ typedef struct {
 #define freen(x) do {free(x); x = NULL;} while(0)
 
 //  randof(num) : Provide random number from 0..(num-1)
-//  Note that (at least in Solaris) while rand() returns an int limited by
-//  RAND_MAX, random() returns a 32-bit value all filled with random bits.
+//  ASSUMES that "num" itself is at most an int (bit size no more than float
+//  on the host platform), and non-negative; may be a "function()" token.
 //  The math libraries on different platforms and capabilities in HW are a
 //  nightmare. Seems we have to drown the code in casts to have reasonable
 //  results... Also note that the 32-bit float has a hard time representing
 //  values close to UINT32_MAX that we had before, so now limit to UINT16_MAX.
-#if defined(RAND_MAX)
+//  Platforms where RAND_MAX is comparable to even signed INT32_MAX were
+//  rigged with problems here: even if the code used double-precision, the
+//  corner-case factors (divident close to INT32_MAX and close to divisor)
+//  were too close to 1.0, so the final product was "num" rather than "num-1".
+
 # if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
  || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(rand () % (RAND_MAX - 1)) / ((float)RAND_MAX)) ) ) )
-# else  // other platforms
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)(random () % (RAND_MAX - 1)) / ((float)RAND_MAX)) ) ) )
-# endif // ifdef RAND_MAX
-#else
-#   define randof(num)  (int) ( floorf( (float) ( (float)(num) * ( (float)( (uint16_t)(random ()) % (UINT16_MAX - 1) ) / ((float)UINT16_MAX)) ) ) )
+#   define randof(num)  (int) ( (float)(num) * ( (float)( (rand   () % (UINT16_MAX - 1) ) / ( (float)(UINT16_MAX) ) ) ) )
+# else
+#   define randof(num)  (int) ( (float)(num) * ( (float)( (random () % (UINT16_MAX - 1) ) / ( (float)(UINT16_MAX) ) ) ) )
 #endif
+
 
 // Windows MSVS doesn't have stdbool
 #if (defined (_MSC_VER))


### PR DESCRIPTION
Solutions: in czmq_prelude.h randof() :
* make sure to use RAND_MAX only where available;
* make more effort to multiply NUM by a factor of less than 1.0 - limit the chosen random function result by chosen maximum minus one (remainder of...) in all cases, and parenthesize calculation of the "0...<1" factor to avoid overflows etc.
* do not calculate the random-factor with large numbers like UINT32_MAX or RAND_MAX (big on e.g. Linux-64bit), because either `float` can not discern these values plus-minus several discrete levels at all, or (in experiment with `double`) the resulting factor has too many nines and multiplication yields "num.0000000" anyway. Constrain this to smaller numbers, use UINT16_MAX which passed the artificial tests ok.

Details:
During builds of previous PR and master branches, which added a loop of 10 million executions of `randof()` asserting the results, about 5-6 of 18 jobs executed failed right in this test with:
````
lt-czmq_selftest: ../src/zhashx.c:1300: zhashx_test: Assertion `testnbr != testmax' failed.
```

This means that due to some hardware (including VM) floating point magic, casts, libc/libmath or whatever other reasons, the macro sometimes ends up multiplying `num` by `1.0` or some factor close enough that casting back to `int` produces the `num` argument value rather than expected maximum of `num-1`.

Given that generally the `num` token can be some `function()` call, so we can not refer to it twice in the macro to doctor the outputs, e.g. adding a `% num` to limit the value. Using `num - 1` can yield unexpected negative outputs. So short of converting to function, there is not much more refinement in macro that I can think of at the moment...