### PR TITLE
Problem: File stable timeout tests still fail

### DIFF
--- a/api/zsys.api
+++ b/api/zsys.api
@@ -308,7 +308,7 @@
         that should elapse until we consider that object "stable" at the
         current zclock_time() moment.
         The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-        which generally depends on host OS, with fallback value of 3000.
+        which generally depends on host OS, with fallback value of 5000.
         <argument name = "file stable age msec" type = "msecs" />
     </method>
 

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -301,7 +301,7 @@ public class Zsys {
     that should elapse until we consider that object "stable" at the
     current zclock_time() moment.
     The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-    which generally depends on host OS, with fallback value of 3000.
+    which generally depends on host OS, with fallback value of 5000.
     */
     native static void __setFileStableAgeMsec (long fileStableAgeMsec);
     public void setFileStableAgeMsec (long fileStableAgeMsec) {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -3722,7 +3722,7 @@ int
 // that should elapse until we consider that object "stable" at the
 // current zclock_time() moment.
 // The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-// which generally depends on host OS, with fallback value of 3000.
+// which generally depends on host OS, with fallback value of 5000.
 void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -3922,7 +3922,7 @@ Configure the threshold value of filesystem object age per st_mtime
 that should elapse until we consider that object "stable" at the
 current zclock_time() moment.
 The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-which generally depends on host OS, with fallback value of 3000.
+which generally depends on host OS, with fallback value of 5000.
 
 ```
 msecs my_zsys.fileStableAgeMsec ()

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -7624,7 +7624,7 @@ The default is INT_MAX.
 that should elapse until we consider that object "stable" at the
 current zclock_time() moment.
 The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-which generally depends on host OS, with fallback value of 3000.
+which generally depends on host OS, with fallback value of 5000.
         """
         return lib.zsys_set_file_stable_age_msec(file_stable_age_msec)
 

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -57,7 +57,7 @@ class TestCZMQ(unittest.TestCase):
         initfile.close()
 
         try:
-            stable_age = float(file_stable_age_msec()) / 1000.0
+            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.001
         except Exception:
             stable_age = 3.001
         time.sleep(stable_age) # wait for initial file to become 'stable'
@@ -190,7 +190,7 @@ class TestCZMQ(unittest.TestCase):
         del f
 
         try:
-            stable_age = float(file_stable_age_msec()) / 1000.0
+            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.001
         except Exception:
             stable_age = 3.001
 

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -57,9 +57,9 @@ class TestCZMQ(unittest.TestCase):
         initfile.close()
 
         try:
-            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.001
+            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.050
         except Exception:
-            stable_age = 3.001
+            stable_age = 5.050
         time.sleep(stable_age) # wait for initial file to become 'stable'
 
         watch.sock().send(b"si", b"TIMEOUT", 100)
@@ -190,9 +190,9 @@ class TestCZMQ(unittest.TestCase):
         del f
 
         try:
-            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.001
+            stable_age = float(file_stable_age_msec()) / 1000.0 + 0.050
         except Exception:
-            stable_age = 3.001
+            stable_age = 5.050
 
         self.assertTrue(file.has_changed())
         self.assertFalse(file.is_stable())

--- a/bindings/python_cffi/czmq_cffi/_cdefs.inc
+++ b/bindings/python_cffi/czmq_cffi/_cdefs.inc
@@ -3727,7 +3727,7 @@ int
 // that should elapse until we consider that object "stable" at the
 // current zclock_time() moment.
 // The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-// which generally depends on host OS, with fallback value of 3000.
+// which generally depends on host OS, with fallback value of 5000.
 void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -3729,7 +3729,7 @@ int
 // that should elapse until we consider that object "stable" at the
 // current zclock_time() moment.
 // The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-// which generally depends on host OS, with fallback value of 3000.
+// which generally depends on host OS, with fallback value of 5000.
 void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
 

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -321,7 +321,7 @@ int QmlZsysAttached::maxMsgsz () {
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.
 //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
+//  which generally depends on host OS, with fallback value of 5000.
 void QmlZsysAttached::setFileStableAgeMsec (int64_t fileStableAgeMsec) {
     zsys_set_file_stable_age_msec (fileStableAgeMsec);
 };

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -228,7 +228,7 @@ public slots:
     //  that should elapse until we consider that object "stable" at the
     //  current zclock_time() moment.
     //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-    //  which generally depends on host OS, with fallback value of 3000.
+    //  which generally depends on host OS, with fallback value of 5000.
     void setFileStableAgeMsec (int64_t fileStableAgeMsec);
 
     //  Return current threshold value of file stable age in msec.

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -367,7 +367,7 @@ int QZsys::maxMsgsz ()
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.
 //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
+//  which generally depends on host OS, with fallback value of 5000.
 void QZsys::setFileStableAgeMsec (int64_t fileStableAgeMsec)
 {
     zsys_set_file_stable_age_msec (fileStableAgeMsec);

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -193,7 +193,7 @@ public:
     //  that should elapse until we consider that object "stable" at the
     //  current zclock_time() moment.
     //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-    //  which generally depends on host OS, with fallback value of 3000.
+    //  which generally depends on host OS, with fallback value of 5000.
     static void setFileStableAgeMsec (int64_t fileStableAgeMsec);
 
     //  Return current threshold value of file stable age in msec.

--- a/bindings/ruby/lib/czmq/ffi/zsys.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsys.rb
@@ -527,7 +527,7 @@ module CZMQ
       # that should elapse until we consider that object "stable" at the
       # current zclock_time() moment.
       # The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-      # which generally depends on host OS, with fallback value of 3000.
+      # which generally depends on host OS, with fallback value of 5000.
       #
       # @param file_stable_age_msec [::FFI::Pointer, #to_ptr]
       # @return [void]

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -408,7 +408,7 @@ CZMQ_EXPORT void
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.
 //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
+//  which generally depends on host OS, with fallback value of 5000.
 CZMQ_EXPORT void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
 

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -232,7 +232,7 @@ CZMQ_PRIVATE char *
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.
 //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
+//  which generally depends on host OS, with fallback value of 5000.
 CZMQ_PRIVATE void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec);
 

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -973,9 +973,9 @@ zdir_test (bool verbose)
 
     // wait for initial file to become 'stable'
 #ifdef CZMQ_BUILD_DRAFT_API
-    zclock_sleep (zsys_file_stable_age_msec() + 1);
+    zclock_sleep (zsys_file_stable_age_msec() + 50);
 #else
-    zclock_sleep (3001);
+    zclock_sleep (5050);
 #endif
 
     zsock_send (watch, "si", "TIMEOUT", 100);
@@ -1004,9 +1004,9 @@ zdir_test (bool verbose)
     // poll for a certain timeout before giving up and failing the test
     void* polled = NULL;
 #ifdef CZMQ_BUILD_DRAFT_API
-    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
+    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 150);
 #else
-    polled = zpoller_wait(watch_poll, 3001);
+    polled = zpoller_wait(watch_poll, 5150);
 #endif
     assert (polled == watch);
 
@@ -1035,9 +1035,9 @@ zdir_test (bool verbose)
 
     // poll for a certain timeout before giving up and failing the test.
 #ifdef CZMQ_BUILD_DRAFT_API
-    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 1);
+    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 150);
 #else
-    polled = zpoller_wait(watch_poll, 3001);
+    polled = zpoller_wait(watch_poll, 5150);
 #endif
     assert (polled == watch);
 

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -712,9 +712,9 @@ zfile_test (bool verbose)
     close (handle);
     assert (zfile_has_changed (file));
 #ifdef CZMQ_BUILD_DRAFT_API
-    zclock_sleep (zsys_file_stable_age_msec() + 1);
+    zclock_sleep (zsys_file_stable_age_msec() + 50);
 #else
-    zclock_sleep (3001);
+    zclock_sleep (5050);
 #endif
     assert (zfile_has_changed (file));
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -67,7 +67,7 @@ static bool s_initialized = false;
 // This is a private tunable that is likely to be replaced or tweaked later
 // per comment block at s_zsys_file_stable() implementation, to reflect
 // the best stat data granularity available on host OS *and* used by czmq.
-#define S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC 3000
+#define S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC 5000
 #endif
 
 //  Default globals for new sockets and other joys; these can all be set
@@ -78,7 +78,7 @@ static int s_thread_priority = -1;  //  ZSYS_THREAD_PRIORITY=-1
 static size_t s_max_sockets = 1024; //  ZSYS_MAX_SOCKETS=1024
 static int s_max_msgsz = INT_MAX;   //  ZSYS_MAX_MSGSZ=INT_MAX
 static int s_file_stable_age_msec = S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC;
-                                    //  ZSYS_FILE_STABLE_AGE_MSEC=3000
+                                    //  ZSYS_FILE_STABLE_AGE_MSEC=5000
 static size_t s_linger = 0;         //  ZSYS_LINGER=0
 static size_t s_sndhwm = 1000;      //  ZSYS_SNDHWM=1000
 static size_t s_rcvhwm = 1000;      //  ZSYS_RCVHWM=1000
@@ -720,7 +720,7 @@ s_zsys_file_stable (const char *filename, bool verbose)
         //  removable media, and only account even seconds in stat data.
         //  Solutions are two-fold: when using stat fields that are precise
         //  to a second (or inpredictably two), we should actually check for
-        //  (age > 3000) in rounded-microsecond accounting. Also, for some
+        //  (age > 3000+) in rounded-microsecond accounting. Also, for some
         //  systems we can have `configure`-time checks on presence of more
         //  precise (and less standardized) stat timestamp fields, where we
         //  can presumably avoid rounding to thousands and use (age > 2000).
@@ -1491,7 +1491,7 @@ zsys_max_msgsz (void)
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.
 //  The default is S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC defined in zsys.c
-//  which generally depends on host OS, with fallback value of 3000.
+//  which generally depends on host OS, with fallback value of 5000.
 
 void
     zsys_set_file_stable_age_msec (int64_t file_stable_age_msec)

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1511,6 +1511,13 @@ void
 //  This can be used in code that chooses to wait for this timeout
 //  before testing if a filesystem object is "stable" or not.
 
+//  Note that the OS timer quantization can bite you, so it may be
+//  reasonably safe to sleep/wait/poll for a larger timeout before
+//  assuming a fault, e.g. the default timer resolution on Windows
+//  is 15.6 ms (per timer interrupt 64 times a second), graphed here:
+//    https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408(v=vs.85).aspx
+//  and Unix/Linux OSes also have different-resolution timers.
+
 int64_t
     zsys_file_stable_age_msec (void)
 {


### PR DESCRIPTION
Solutions:
* use longer default timeout that should suffice for laggy hosts and OSes (note: so perhaps also more incentive to tune it via `configure` for host OSes with better known characteristics and/or extended stat-struct fields with better timestamp resolution); 
* use even longer poll-timeouts in zdir_test() waiting for FS changes to be detected