### PR TITLE
Problem: zproc_test() can not find its zsp helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
+
 # disables auto CRLF conversion for all files; create the file correctly and it will be allright
 * -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# This is a skeleton created by zproject.
+# You can add hand-written code here.
+
 save.xml
 # Object files
 *.o
@@ -21,6 +24,7 @@ save.xml
 # Executables
 src/czmq_selftest
 src/zmakecert
+src/zsp
 src/czmq_selftest
 *.exe
 *.out
@@ -28,9 +32,9 @@ src/czmq_selftest
 core
 
  # Distcheck workspace and archives
-czmq-4.0.2/
-czmq-4.0.2.tar.gz
-czmq-4.0.2.zip
+czmq-4.0.3/
+czmq-4.0.3.tar.gz
+czmq-4.0.3.zip
 
 # Man pages
 doc/*.1
@@ -51,6 +55,7 @@ config.log
 config.status
 config/
 configure
+configure.lineno
 libtool
 src/platform.h
 src/platform.h.in
@@ -70,6 +75,7 @@ install_manifest.txt
 Testing/
 
 # Repositories downloaded by CI integration scripts
+libzmq/
 *.git/
 
 # Travis build area
@@ -78,6 +84,12 @@ tmp/
 # Valgrind files
 callgrind*
 vgcore*
+
+# Vagrant files
+.vagrant
+
+# CLion / PyCharm
+.idea
 
 # GYP files
 project.Makefile

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -981,38 +981,39 @@ zproc_test (bool verbose)
         printf ("zproc_test() : current working directory is %s\n", cwd);
 
     //  find the right binary for current build (in-tree, distcheck, etc.)
-    char *file = "src/zsp";
-    if (!zsys_file_exists (file)) {
-        if (zsys_file_exists ("_build/../src/zsp"))
-            file = "_build/../src/zsp";
-        else
-        if (zsys_file_exists ("_build/src/zsp"))
-            file = "_build/src/zsp";
-        else
-        if (zsys_file_exists ("../_build/src/zsp"))
-            file = "../_build/src/zsp";
-        else
-        if (zsys_file_exists ("../../_build/src/zsp"))
-            file = "../../_build/src/zsp";
-        else
-        if (zsys_file_exists ("_build/sub/src/zsp"))
-            file = "_build/sub/src/zsp";
-        else
-        if (zsys_file_exists ("../_build/sub/src/zsp"))
-            file = "../_build/sub/src/zsp";
-        else
-        if (zsys_file_exists ("../../_build/sub/src/zsp"))
-            file = "../../_build/sub/src/zsp";
-        else
-        if (zsys_file_exists ("zsp"))
-            file = "./zsp";
-        else
-        if (zsys_file_exists ("../src/zsp"))
-            file = "../src/zsp";
-    }
+    char *file = NULL;
+    if (zsys_file_exists ("src/zsp") || zsys_file_exists ("./src/zsp"))
+        file = "./src/zsp";
+    else
+    if (zsys_file_exists ("_build/../src/zsp"))
+        file = "_build/../src/zsp";
+    else
+    if (zsys_file_exists ("_build/src/zsp"))
+        file = "_build/src/zsp";
+    else
+    if (zsys_file_exists ("../_build/src/zsp"))
+        file = "../_build/src/zsp";
+    else
+    if (zsys_file_exists ("../../_build/src/zsp"))
+        file = "../../_build/src/zsp";
+    else
+    if (zsys_file_exists ("_build/sub/src/zsp"))
+        file = "_build/sub/src/zsp";
+    else
+    if (zsys_file_exists ("../_build/sub/src/zsp"))
+        file = "../_build/sub/src/zsp";
+    else
+    if (zsys_file_exists ("../../_build/sub/src/zsp"))
+        file = "../../_build/sub/src/zsp";
+    else
+    if (zsys_file_exists ("zsp") || zsys_file_exists ("./zsp"))
+        file = "./zsp";
+    else
+    if (zsys_file_exists ("../src/zsp"))
+        file = "../src/zsp";
 
-    if (!zsys_file_exists (file)) {
-        zsys_warning ("cannot detect zsp binary, %s does not exist", file);
+    if (file == NULL || !zsys_file_exists (file)) {
+        zsys_warning ("cannot detect zsp binary, %s does not exist", file ? file : "<null>");
         printf ("SKIPPED (zsp helper not found)\n");
         return;
     }

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -973,12 +973,12 @@ zproc_test (bool verbose)
 
     if (verbose) {
         printf("\n");
-
-        char cwd[PATH_MAX];
-        memset (cwd, 0, sizeof (cwd));
-        if (getcwd(cwd, sizeof(cwd)) != NULL)
-            printf ("zproc_test() : current working directory is %s\n", cwd);
     }
+
+    char cwd[PATH_MAX];
+    memset (cwd, 0, sizeof (cwd));
+    if (getcwd(cwd, sizeof(cwd)) != NULL)
+        printf ("zproc_test() : current working directory is %s\n", cwd);
 
     //  find the right binary for current build (in-tree, distcheck, etc.)
     char *file = "src/zsp";

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -978,7 +978,7 @@ zproc_test (bool verbose)
         file = "./zsp";
 
     if (!zsys_file_exists (file)) {
-        zsys_warning ("cannot detect zsp binary, %s does not exists", file);
+        zsys_warning ("cannot detect zsp binary, %s does not exist", file);
         printf ("SKIPPED (zsp not found");
         return;
     }

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -57,6 +57,7 @@ content of the messages in any way. See test example on how to use it.
 */
 
 #include "czmq_classes.h"
+#include <unistd.h>
 
 #define ZPROC_RUNNING -42
 
@@ -969,18 +970,54 @@ zproc_test (bool verbose)
 
     //  @selftest
     //  0. initialization
-    //  find the right binary
+
+    if (verbose) {
+        printf("\n");
+
+        char cwd[PATH_MAX];
+        memset (cwd, 0, sizeof (cwd));
+        if (getcwd(cwd, sizeof(cwd)) != NULL)
+            printf ("zproc_test() : current working directory is %s\n", cwd);
+    }
+
+    //  find the right binary for current build (in-tree, distcheck, etc.)
     char *file = "src/zsp";
-    if (zsys_file_exists ("_build/../src/zsp"))
-        file = "_build/../src/zsp";
-    else
-    if (zsys_file_exists ("zsp"))
-        file = "./zsp";
+    if (!zsys_file_exists (file)) {
+        if (zsys_file_exists ("_build/../src/zsp"))
+            file = "_build/../src/zsp";
+        else
+        if (zsys_file_exists ("_build/src/zsp"))
+            file = "_build/src/zsp";
+        else
+        if (zsys_file_exists ("../_build/src/zsp"))
+            file = "../_build/src/zsp";
+        else
+        if (zsys_file_exists ("../../_build/src/zsp"))
+            file = "../../_build/src/zsp";
+        else
+        if (zsys_file_exists ("_build/sub/src/zsp"))
+            file = "_build/sub/src/zsp";
+        else
+        if (zsys_file_exists ("../_build/sub/src/zsp"))
+            file = "../_build/sub/src/zsp";
+        else
+        if (zsys_file_exists ("../../_build/sub/src/zsp"))
+            file = "../../_build/sub/src/zsp";
+        else
+        if (zsys_file_exists ("zsp"))
+            file = "./zsp";
+        else
+        if (zsys_file_exists ("../src/zsp"))
+            file = "../src/zsp";
+    }
 
     if (!zsys_file_exists (file)) {
         zsys_warning ("cannot detect zsp binary, %s does not exist", file);
-        printf ("SKIPPED (zsp not found");
+        printf ("SKIPPED (zsp helper not found)\n");
         return;
+    }
+    if (verbose) {
+        printf ("zproc_test() : detected a zsp binary at %s\n", file);
     }
 
     //  Create new subproc instance

--- a/src/zsp.c
+++ b/src/zsp.c
@@ -80,7 +80,7 @@ int main (int argc, char *argv [])
         message = getenv ("ZSP_MESSAGE");
 
     zfile_t *stdinf = NULL;
-    
+
     if (use_stdin) {
         stdinf = zfile_new ("/dev", "stdin");
         int r = zfile_input (stdinf);
@@ -111,7 +111,7 @@ int main (int argc, char *argv [])
 
         zclock_sleep (50);
     }
-    
+
     zfile_destroy (&stdinf);
 
     return 0;


### PR DESCRIPTION
Solution: figure out and unravel the draft :)

Note: this only pops up in builds with `--enable-drafts=yes` as `zproc` is still experimental.

Merge criteria: the issue is fixed if such errors are not seen in a run:
````
 * zproc: W: (czmq_selftest) 17-08-03 17:13:56 cannot detect zsp binary, src/zsp does not exist
SKIPPED (zsp helper not found)
````

but rather success is logged:
````
 * zproc: OK
````