### PR TITLE
Problem: zproc_test() still can not find its zsp helper

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -1025,7 +1025,7 @@ zdir_test (bool verbose)
 
     // wait for initial file to become 'stable'
 #ifdef CZMQ_BUILD_DRAFT_API
-    zclock_sleep (zsys_file_stable_age_msec() + 50);
+    zclock_sleep ((int)zsys_file_stable_age_msec() + 50);
 #else
     zclock_sleep (5050);
 #endif
@@ -1056,7 +1056,7 @@ zdir_test (bool verbose)
     // poll for a certain timeout before giving up and failing the test
     void* polled = NULL;
 #ifdef CZMQ_BUILD_DRAFT_API
-    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 150);
+    polled = zpoller_wait(watch_poll, (int)zsys_file_stable_age_msec() + 150);
 #else
     polled = zpoller_wait(watch_poll, 5150);
 #endif
@@ -1096,7 +1096,7 @@ zdir_test (bool verbose)
 
     // poll for a certain timeout before giving up and failing the test.
 #ifdef CZMQ_BUILD_DRAFT_API
-    polled = zpoller_wait(watch_poll, zsys_file_stable_age_msec() + 150);
+    polled = zpoller_wait(watch_poll, (int)zsys_file_stable_age_msec() + 150);
 #else
     polled = zpoller_wait(watch_poll, 5150);
 #endif

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -712,7 +712,7 @@ zfile_test (bool verbose)
     close (handle);
     assert (zfile_has_changed (file));
 #ifdef CZMQ_BUILD_DRAFT_API
-    zclock_sleep (zsys_file_stable_age_msec() + 50);
+    zclock_sleep ((int)zsys_file_stable_age_msec() + 50);
 #else
     zclock_sleep (5050);
 #endif

--- a/src/zgossip_msg.c
+++ b/src/zgossip_msg.c
@@ -592,7 +592,7 @@ zgossip_msg_set_ttl (zgossip_msg_t *self, uint32_t ttl)
 void
 zgossip_msg_test (bool verbose)
 {
-    printf (" * zgossip_msg:");
+    printf (" * zgossip_msg: ");
 
     if (verbose)
         printf ("\n");

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -985,6 +985,11 @@ zproc_test (bool verbose)
     if (zsys_file_exists ("src/zsp") || zsys_file_exists ("./src/zsp"))
         file = "./src/zsp";
     else
+    if (zsys_file_exists ("../zsp"))
+    //  WHOA: zproc: zproc_test() : current working directory is
+    //      /home/travis/build/username/czmq/czmq-4.0.3/_build/src/selftest-rw
+        file = "../zsp";
+    else
     if (zsys_file_exists ("_build/../src/zsp"))
         file = "_build/../src/zsp";
     else

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -981,24 +981,6 @@ zproc_test (bool verbose)
         printf("\n");
     }
 
-#if (defined (PATH_MAX))
-    char cwd[PATH_MAX];
-#else
-# if (defined (_MAX_PATH))
-    char cwd[_MAX_PATH];
-# else
-    char cwd[1024];
-# endif
-#endif
-    memset (cwd, 0, sizeof (cwd));
-#if (defined (WIN32))
-    if (_getcwd(cwd, sizeof(cwd)) != NULL) {
-#else
-    if (getcwd(cwd, sizeof(cwd)) != NULL) {
-#endif
-        printf ("zproc_test() : current working directory is %s\n", cwd);
-    }
-
     //  find the right binary for current build (in-tree, distcheck, etc.)
     char *file = NULL;
     if (zsys_file_exists ("src/zsp") || zsys_file_exists ("./src/zsp"))
@@ -1038,11 +1020,30 @@ zproc_test (bool verbose)
 
     if (file == NULL || !zsys_file_exists (file)) {
         zsys_warning ("cannot detect zsp binary, %s does not exist", file ? file : "<null>");
+
         printf ("SKIPPED (zsp helper not found)\n");
+
+#if (defined (PATH_MAX))
+        char cwd[PATH_MAX];
+#else
+# if (defined (_MAX_PATH))
+        char cwd[_MAX_PATH];
+# else
+        char cwd[1024];
+# endif
+#endif
+        memset (cwd, 0, sizeof (cwd));
+#if (defined (WIN32))
+        if (_getcwd(cwd, sizeof(cwd)) != NULL)
+#else
+        if (getcwd(cwd, sizeof(cwd)) != NULL)
+#endif
+            printf ("zproc_test() : current working directory is %s\n", cwd);
+
         return;
     }
     if (verbose) {
-        printf ("zproc_test() : detected a zsp binary at %s\n", file);
+        zsys_info ("zproc_test() : detected a zsp binary at %s\n", file);
     }
 
     //  Create new subproc instance

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -57,7 +57,13 @@ content of the messages in any way. See test example on how to use it.
 */
 
 #include "czmq_classes.h"
-#include <unistd.h>
+
+// For getcwd() variants
+#if (defined (WIN32))
+# include <direct.h>
+#else
+# include <unistd.h>
+#endif
 
 #define ZPROC_RUNNING -42
 
@@ -975,10 +981,23 @@ zproc_test (bool verbose)
         printf("\n");
     }
 
+#if (defined (PATH_MAX))
     char cwd[PATH_MAX];
+#else
+# if (defined (_MAX_PATH))
+    char cwd[_MAX_PATH];
+# else
+    char cwd[1024];
+# endif
+#endif
     memset (cwd, 0, sizeof (cwd));
-    if (getcwd(cwd, sizeof(cwd)) != NULL)
+#if (defined (WIN32))
+    if (_getcwd(cwd, sizeof(cwd)) != NULL) {
+#else
+    if (getcwd(cwd, sizeof(cwd)) != NULL) {
+#endif
         printf ("zproc_test() : current working directory is %s\n", cwd);
+    }
 
     //  find the right binary for current build (in-tree, distcheck, etc.)
     char *file = NULL;

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -77,7 +77,7 @@ static int s_thread_sched_policy = -1; //  ZSYS_THREAD_SCHED_POLICY=-1
 static int s_thread_priority = -1;  //  ZSYS_THREAD_PRIORITY=-1
 static size_t s_max_sockets = 1024; //  ZSYS_MAX_SOCKETS=1024
 static int s_max_msgsz = INT_MAX;   //  ZSYS_MAX_MSGSZ=INT_MAX
-static int s_file_stable_age_msec = S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC;
+static int64_t s_file_stable_age_msec = S_DEFAULT_ZSYS_FILE_STABLE_AGE_MSEC;
                                     //  ZSYS_FILE_STABLE_AGE_MSEC=5000
 static size_t s_linger = 0;         //  ZSYS_LINGER=0
 static size_t s_sndhwm = 1000;      //  ZSYS_SNDHWM=1000

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -21,7 +21,13 @@
 */
 
 #include "czmq_classes.h"
-#include <unistd.h>
+
+// For getcwd() variants
+#if (defined (WIN32))
+# include <direct.h>
+#else
+# include <unistd.h>
+#endif
 
 //  --------------------------------------------------------------------------
 //  Signal handling
@@ -2121,9 +2127,21 @@ zsys_test (bool verbose)
     assert (rc == 0);
     zsys_file_mode_default ();
 
+#if (defined (PATH_MAX))
     char cwd[PATH_MAX];
+#else
+# if (defined (_MAX_PATH))
+    char cwd[_MAX_PATH];
+# else
+    char cwd[1024];
+# endif
+#endif
     memset (cwd, 0, sizeof(cwd));
+#if (defined (WIN32))
+    if (_getcwd(cwd, sizeof(cwd)) != NULL) {
+#else
     if (getcwd(cwd, sizeof(cwd)) != NULL) {
+#endif
         if (verbose)
             printf ("zsys_test() at timestamp %" PRIi64 ": "
                 "current working directory is %s\n",


### PR DESCRIPTION
Solution:
* figure out and unravel the draft :)
* fix a side effect of zsys tests (changed CWD)
* make this fix compile on Windows too

Continuation of #1736

Note: this only pops up in builds with `--enable-drafts=yes` as `zproc` is still experimental, and only against ZMQ4+.

Merge criteria: the issue is fixed if such errors are not seen in a run:
````
 * zproc: W: (czmq_selftest) 17-08-03 17:13:56 cannot detect zsp binary, src/zsp does not exist
SKIPPED (zsp helper not found)
````

but rather success is logged:
````
 * zproc: OK
````