### PR TITLE
Problem: RAND_MAX can get used when ZSYS_RANDOF_FUNC==random()

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -443,30 +443,40 @@ typedef struct {
 #   define  ZSYS_RANDOF_FLT float
 #endif // ZSYS_RANDOF_FLT is defined by caller... trust them or explode later
 
+// Implementations vary...
+#if !defined (ZSYS_RANDOF_FUNC)
+# if defined (ZSYS_RANDOF_FUNC_BITS)
+#  undef ZSYS_RANDOF_FUNC_BITS
+# endif
+# if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
+ || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
+#   define  ZSYS_RANDOF_FUNC    rand
+#   define  ZSYS_RANDOF_FUNC_BITS 15
+# else
+#   define  ZSYS_RANDOF_FUNC    random
+#   define  ZSYS_RANDOF_FUNC_BITS 32
+# endif
+#endif // ZSYS_RANDOF_FUNC is defined by caller... trust them or explode later
+
 //  Limits below were experimented for 32-bit floats on x86 with test-randof
 //  Due to discrete rounding, greater values caused collisions with the
 //  fraction s_randof_factor() defined below returning 1.0.
 #if !defined (ZSYS_RANDOF_MAX)
-# if defined (RAND_MAX)
-#  if (RAND_MAX > (UINT32_MAX>>6))
-#   define  ZSYS_RANDOF_MAX (UINT32_MAX>>6)
-#  else // RAND_MAX is small enough to not overflow our calculations
-#   define  ZSYS_RANDOF_MAX RAND_MAX
-#  endif
-# else // No RAND_MAX - use a smaller safer limit, but with values too discrete
-#   define  ZSYS_RANDOF_MAX INT16_MAX
-# endif
-#endif // ZSYS_RANDOF_MAX is defined by caller... trust them or explode later
-
-// Implementations vary...
-#if !defined (ZSYS_RANDOF_FUNC)
-# if (defined (__WINDOWS__)) || (defined (__UTYPE_IBMAIX)) \
- || (defined (__UTYPE_HPUX)) || (defined (__UTYPE_SUNOS)) || (defined (__UTYPE_SOLARIS))
-#   define  ZSYS_RANDOF_FUNC    rand
+# if (ZSYS_RANDOF_FUNC_BITS >= 26)
+    // Assume that random() is at least 32-bit as it is on most platforms
+#       define  ZSYS_RANDOF_MAX (UINT32_MAX>>6)
 # else
-#   define  ZSYS_RANDOF_FUNC    random
-# endif
-#endif // ZSYS_RANDOF_FUNC is defined by caller... trust them or explode later
+#  if defined (RAND_MAX)
+#   if (RAND_MAX > (UINT32_MAX>>6))
+#       define  ZSYS_RANDOF_MAX (UINT32_MAX>>6)
+#   else // RAND_MAX is small enough to not overflow our calculations
+#       define  ZSYS_RANDOF_MAX RAND_MAX
+#   endif
+#  else // No RAND_MAX - use a smaller safer limit, but with values too discrete
+#       define  ZSYS_RANDOF_MAX INT16_MAX
+#  endif
+# endif // not random()
+#endif // ZSYS_RANDOF_MAX is defined by caller... trust them or explode later
 
 #define s_randof_factor()   (ZSYS_RANDOF_FLT)( (ZSYS_RANDOF_FLT)(ZSYS_RANDOF_FUNC() % (ZSYS_RANDOF_MAX - 1)) / ( (ZSYS_RANDOF_FLT)(ZSYS_RANDOF_MAX) ) )
 

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -17,7 +17,8 @@
 //- Establish the compiler and computer system ------------------------------
 /*
  *  Defines zero or more of these symbols, for use in any non-portable
- *  code:
+ *  code (for pre-defined values see e.g. build-system headers as well
+ *  as output of GNU C preprocessor via `cpp -dM < /dev/null`):
  *
  *  __WINDOWS__         Microsoft C/C++ with Windows calls
  *  __MSDOS__           System is MS-DOS (set if __WINDOWS__ set)
@@ -193,10 +194,12 @@
 #elif (defined (sinix))
 #   define __UTYPE_SINIX
 #   define __UNIX__
-#elif (defined (SOLARIS) || defined (__SVR4)) || defined (SVR4)
+#elif (defined (SOLARIS) || defined (__SVR4) || defined (SVR4) || defined (__SVR4__) || defined (__svr4) || defined (svr4) || defined (__svr4__))
+    // Note: this rule and below should match legacy SunOS and Solaris
+    // on builds without the GNU toolchain; with one you get __UTYPE_GNU
 #   define __UTYPE_SUNSOLARIS
 #   define __UNIX__
-#elif (defined (SUNOS) || defined (SUN) || defined (sun))
+#elif (defined (SUNOS) || defined (SUN) || defined (sun) || defined (__sun) || defined (__sun__))
 #   define __UTYPE_SUNOS
 #   define __UNIX__
 #elif (defined (__USLC__) || defined (UnixWare))
@@ -443,7 +446,7 @@ typedef struct {
 #   define  ZSYS_RANDOF_FLT float
 #endif // ZSYS_RANDOF_FLT is defined by caller... trust them or explode later
 
-// Implementations vary...
+// Implementations vary... Note that many will get __UTYPE_GNU nowadays.
 #if !defined (ZSYS_RANDOF_FUNC)
 # if defined (ZSYS_RANDOF_FUNC_BITS)
 #  undef ZSYS_RANDOF_FUNC_BITS

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -489,15 +489,15 @@ typedef struct {
 // Fuzziness added below (division by slightly more than a whole number) solves
 // this wonderfully even for "num" ranges twice as big as the ZSYS_RANDOF_MAX.
 #if (ZSYS_RANDOF_MAX > UINT16_MAX)
-#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * s_randof_factor() / ( 1.0 + s_randof_factor()/100 ) )
+#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * s_randof_factor() / ( 1.0 + s_randof_factor() / 100.0 ) )
 #else // boost dispersion
 # if (ZSYS_RANDOF_MAX > INT16_MAX)
-#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() ) / ( 2.0 + s_randof_factor() / 2 ) )
+#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() ) / ( 2.0 + s_randof_factor() / 2.0 ) )
 # else
 #  if (ZSYS_RANDOF_MAX > UINT8_MAX)
-#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() ) / ( 4.0 + s_randof_factor() * 10 ) )
+#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() ) / ( 4.0 + s_randof_factor() * 10.0 ) )
 #  else
-#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() ) / ( 6.0 + s_randof_factor() * 100 ) )
+#   define randof(num)  (int) ( (ZSYS_RANDOF_FLT)(num) * ( s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() + s_randof_factor() ) / ( 6.0 + s_randof_factor() * 100.0 ) )
 #  endif
 # endif
 #endif


### PR DESCRIPTION
Solution: refer to the chosen random() vs. rand() function to use the limiting value (RAND_MAX applies to rand(), and random() usually returns a 32-bit value from HW or kernel).

Also some other fixes of mostly cosmetic value.
    
Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>
