### PR TITLE
Problem: zpoller checks for ETIMEDOUT instead of EAGAIN in zmq_poller

### DIFF
--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -230,7 +230,7 @@ zpoller_wait (zpoller_t *self, int timeout)
     if (!zmq_poller_wait (self->zmq_poller, &event, timeout * ZMQ_POLL_MSEC))
         return event.user_data;
     else
-    if (errno == ETIMEDOUT)
+    if (errno == ETIMEDOUT || errno == EAGAIN)
         self->expired = true;
     else
     if (zsys_interrupted && !self->nonstop)


### PR DESCRIPTION
Solution: to support the change in the DRAFT zmq_poller API, check for
EAGAIN too.
See: https://github.com/zeromq/libzmq/issues/2713

Note that I've kept the ETIMEDOUT as well for now, to help users with older versions, even if it's a DRAFT api the cost is very low.