### PR TITLE
Problem: zauth and zproxy tests do not set ZAP domain

### DIFF
--- a/src/zauth.c
+++ b/src/zauth.c
@@ -678,6 +678,7 @@ zauth_test (bool verbose)
     assert (success);
 
     //  Try PLAIN authentication
+    zsock_set_zap_domain (server, "global");
     zsock_set_plain_server (server, 1);
     zsock_set_plain_username (client, "admin");
     zsock_set_plain_password (client, "Password");
@@ -688,6 +689,7 @@ zauth_test (bool verbose)
     assert (password);
     fprintf (password, "admin=Password\n");
     fclose (password);
+    zsock_set_zap_domain (server, "global");
     zsock_set_plain_server (server, 1);
     zsock_set_plain_username (client, "admin");
     zsock_set_plain_password (client, "Password");
@@ -707,6 +709,7 @@ zauth_test (bool verbose)
 #endif
     s_renew_sockets(&server, &client);
 
+    zsock_set_zap_domain (server, "global");
     zsock_set_plain_server (server, 1);
     zsock_set_plain_username (client, "admin");
     zsock_set_plain_password (client, "Bogus");
@@ -729,6 +732,7 @@ zauth_test (bool verbose)
         zcert_apply (client_cert, client);
         zsock_set_curve_server (server, 1);
         zsock_set_curve_serverkey (client, server_key);
+        zsock_set_zap_domain (server, "global");
         success = s_can_connect (&server, &client, true);
         assert (!success);
 
@@ -751,6 +755,7 @@ zauth_test (bool verbose)
         zcert_save_public (client_cert, certfilepath);
         zstr_sendx (auth, "CURVE", basedirpath, NULL);
         zsock_wait (auth);
+        zsock_set_zap_domain (server, "global");
         success = s_can_connect (&server, &client, false);
         assert (success);
 

--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -680,6 +680,8 @@ zproxy_test (bool verbose)
     //  Test negative case (no server-side passwords defined)
     zstr_sendx (proxy, "PLAIN", "FRONTEND", NULL);
     zsock_wait (proxy);
+    zstr_sendx (proxy, "DOMAIN", "FRONTEND", "global", NULL);
+    zsock_wait (proxy);
     s_bind_test_sockets (proxy, &frontend, &backend);
     zsock_set_plain_username (faucet, "admin");
     zsock_set_plain_password (faucet, "Password");
@@ -694,7 +696,11 @@ zproxy_test (bool verbose)
     fclose (password);
     zstr_sendx (proxy, "PLAIN", "FRONTEND", NULL);
     zsock_wait (proxy);
+    zstr_sendx (proxy, "DOMAIN", "FRONTEND", "global", NULL);
+    zsock_wait (proxy);
     zstr_sendx (proxy, "PLAIN", "BACKEND", NULL);
+    zsock_wait (proxy);
+    zstr_sendx (proxy, "DOMAIN", "BACKEND", "global", NULL);
     zsock_wait (proxy);
     s_bind_test_sockets (proxy, &frontend, &backend);
     zsock_set_plain_username (faucet, "admin");
@@ -709,6 +715,8 @@ zproxy_test (bool verbose)
 
     //  Test negative case (bad client password)
     zstr_sendx (proxy, "PLAIN", "FRONTEND", NULL);
+    zsock_wait (proxy);
+    zstr_sendx (proxy, "DOMAIN", "FRONTEND", "global", NULL);
     zsock_wait (proxy);
     s_bind_test_sockets (proxy, &frontend, &backend);
     zsock_set_plain_username (faucet, "admin");
@@ -731,6 +739,8 @@ zproxy_test (bool verbose)
 
         //  Test without setting-up any authentication
         zstr_sendx (proxy, "CURVE", "FRONTEND", public_key, secret_key, NULL);
+        zsock_wait (proxy);
+        zstr_sendx (proxy, "DOMAIN", "FRONTEND", "global", NULL);
         zsock_wait (proxy);
         s_bind_test_sockets (proxy, &frontend, &backend);
         zcert_apply (client_cert, faucet);


### PR DESCRIPTION
Solution: always set it for all auth types. This is required by the
ZAP protocol, and previously libzmq let it slip, but not anymore.

More precisely, always set the domain for PLAIN auth and for the
negative CURVE test.