### PR TITLE
problem: ipc proxy tests fail when using vagrant/virtual box

### DIFF
--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -589,14 +589,22 @@ zproxy_test (bool verbose)
 #ifdef  WIN32
 	sink = zsock_new_sub(">inproc://backend", "whatever");
 #else
-	sink = zsock_new_sub (">ipc://backend", "whatever");
+    // vagrant vms don't like using shared storage for ipc pipes..
+    if (streq(getenv("USER"), "vagrant"))
+        sink = zsock_new_sub (">ipc:///tmp/backend", "whatever");
+    else
+	    sink = zsock_new_sub (">ipc://backend", "whatever");
 #endif //  WIN32
 	assert (sink);
 
 #ifdef WIN32
 	zstr_sendx (proxy, "BACKEND", "XPUB", "inproc://backend", NULL);
 #else
-	zstr_sendx(proxy, "BACKEND", "XPUB", "ipc://backend", NULL);
+    // vagrant vms don't like using shared storage for ipc pipes..
+    if (streq(getenv("USER"), "vagrant"))
+        zstr_sendx(proxy, "BACKEND", "XPUB", "ipc:///tmp/backend", NULL);
+    else
+        zstr_sendx(proxy, "BACKEND", "XPUB", "ipc://backend", NULL);
 #endif
     zsock_wait (proxy);
 


### PR DESCRIPTION
when developing using vagrant and virtualbox- it maps your checked out directory to /vagrant so you can test within the vm (virtualbox shared folder effectively). for whatever reason, ipc pipes get funny when trying to run/link within this shared directory.

solution: check to see if we're running the test as the `vagrant` user- if so use /tmp as the ipc backend for proxy tests instead of the `pwd` which is typically a shared folder and vbox tends to disallow by default.. this fix is very specific to vagrant unix systems, but vagrant + vbox very much aid in czmq development imo.

(this has been bugging me for a while...)