### PR TITLE
problem: zap domain not being set in gossip

### DIFF
--- a/src/zgossip.c
+++ b/src/zgossip.c
@@ -29,6 +29,7 @@
     * CONNECT endpoint -- connect the gossip service to the specified peer
     * PUBLISH key value -- publish a key/value pair to the gossip cluster
     * STATUS -- return number of key/value pairs held by gossip service
+    * ZAP DOMAIN domain -- set the ZAP DOMAIN domain = value
 
     Returns these messages:
 
@@ -90,6 +91,11 @@
 
 #include "czmq_classes.h"
 
+// TODO- project.xml?
+#ifdef CZMQ_BUILD_DRAFT_API
+#define CZMQ_ZGOSSIP_ZAP_DOMAIN "global"
+#endif
+
 
 //  ---------------------------------------------------------------------
 //  Forward declarations for the two main classes we use here
@@ -117,6 +123,9 @@ struct _server_t {
 
     char *public_key;
     char *secret_key;
+#ifdef CZMQ_BUILD_DRAFT_API
+    char *zap_domain;
+#endif
 };
 
 //  ---------------------------------------------------------------------
@@ -177,6 +186,10 @@ server_initialize (server_t *self)
 
     self->tuples = zhashx_new ();
     assert (self->tuples);
+
+#ifdef CZMQ_BUILD_DRAFT_API
+    self->zap_domain = strdup(CZMQ_ZGOSSIP_ZAP_DOMAIN);
+#endif
     return 0;
 }
 
@@ -190,6 +203,9 @@ server_terminate (server_t *self)
     zhashx_destroy (&self->tuples);
     zstr_free (&self->public_key);
     zstr_free (&self->secret_key);
+#ifdef CZMQ_BUILD_DRAFT_API
+    zstr_free (&self->zap_domain);
+#endif
 }
 
 //  Connect to a remote server
@@ -339,6 +355,16 @@ server_method (server_t *self, const char *method, zmsg_t *msg)
         self->secret_key = strdup(key);
         assert (self->secret_key);
         zstr_free (&key);
+    }
+    else
+    if (streq (method, "ZAP DOMAIN")) {
+        char *value = zmsg_popstr (msg);
+        zstr_free(&self->zap_domain);
+        self->zap_domain = strdup(value);
+        assert (self->zap_domain);
+        zstr_free (&value);
+
+        zsys_info ("auth zap domain: %s", self->zap_domain);
     }
 #endif
     else
@@ -604,7 +630,7 @@ zgossip_test (bool verbose)
 
         zstr_sendx (server, "SET PUBLICKEY", zcert_public_txt (server_cert), NULL);
         zstr_sendx (server, "SET SECRETKEY", zcert_secret_txt (server_cert), NULL);
-        zstr_sendx (server, "AUTH ZAP DOMAIN", "global", NULL);
+        zstr_sendx (server, "ZAP DOMAIN", "TEST", NULL);
 
         zstr_sendx (server, "BIND", "tcp://127.0.0.1:*", NULL);
         zstr_sendx (server, "PORT", NULL);
@@ -623,6 +649,7 @@ zgossip_test (bool verbose)
 
         zstr_sendx (client1, "SET PUBLICKEY", zcert_public_txt (client1_cert), NULL);
         zstr_sendx (client1, "SET SECRETKEY", zcert_secret_txt (client1_cert), NULL);
+        zstr_sendx (client1, "ZAP DOMAIN", "TEST", NULL);
 
         const char *public_txt = zcert_public_txt (server_cert);
         zstr_sendx (client1, "CONNECT", endpoint, public_txt, NULL);

--- a/src/zgossip.c
+++ b/src/zgossip.c
@@ -363,8 +363,6 @@ server_method (server_t *self, const char *method, zmsg_t *msg)
         self->zap_domain = strdup(value);
         assert (self->zap_domain);
         zstr_free (&value);
-
-        zsys_info ("auth zap domain: %s", self->zap_domain);
     }
 #endif
     else

--- a/src/zgossip_engine.inc
+++ b/src/zgossip_engine.inc
@@ -89,10 +89,6 @@ typedef struct {
     size_t timeout;             //  Default client expiry timeout
     bool verbose;               //  Verbose logging enabled?
     char *log_prefix;           //  Default log prefix
-
-#ifdef CZMQ_BUILD_DRAFT_API
-    char *auth_zap_domain; // Zap Auth Domain (curve)
-#endif
 } s_server_t;
 
 
@@ -405,9 +401,6 @@ s_client_destroy (s_client_t **self_p)
         engine_set_log_prefix (&self->client, "*** TERMINATED ***");
         client_terminate (&self->client);
         free (self->hashkey);
-#ifdef CZMQ_BUILD_DRAFT_API
-        zstr_free (&self->server->auth_zap_domain);
-#endif
         free (self);
         *self_p = NULL;
     }
@@ -795,6 +788,8 @@ s_server_config_service (s_server_t *self)
                 zsock_set_plain_server (self->router, 1);
             }
 #ifdef CZMQ_BUILD_DRAFT_API
+            // TODO- zproto
+            // https://github.com/zeromq/zproto/blob/master/src/zproto_server_c.gsl#L883
             else
             if (streq (mechanism, "curve")) {
                 zsys_notice ("using CURVE security");
@@ -848,17 +843,17 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
         char *endpoint = zmsg_popstr (msg);
 
 #ifdef CZMQ_BUILD_DRAFT_API
+        // TODO- expose self->router to application context ?
+        // Add secret|public|zap to gsl(?)
+        // move this block to custom server function when both keys are present
         if (self->server.secret_key) {
+            zsock_set_zap_domain (self->router, self->server.zap_domain);
             zcert_t *cert = zcert_new_from_txt(self->server.public_key, self->server.secret_key);
             zcert_apply(cert, self->router);
             zsock_set_curve_server (self->router, 1);
-
-            if (self->auth_zap_domain) {
-                zsys_info (self->auth_zap_domain);
-                zsock_set_zap_domain (self->router, self->auth_zap_domain);
-            }
             zcert_destroy(&cert);
         }
+        // TODO- add this test in zproto_server_c.gsl
 #ifndef ZMQ_CURVE
         // zmq legacy
         bool ZMQ_CURVE = false;
@@ -913,17 +908,6 @@ s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
             zsys_warning ("cannot save config file '%s'", filename);
         zstr_free (&filename);
     }
-#ifdef CZMQ_BUILD_DRAFT_API
-    else
-    if (streq (method, "AUTH ZAP DOMAIN")) {
-        char *value = zmsg_popstr (msg);
-        self->auth_zap_domain = strdup(value);
-        assert (self->auth_zap_domain);
-        zstr_free (&value);
-
-        zsys_info ("auth zap domain: %s", self->auth_zap_domain);
-    }
-#endif
     else {
         //  Execute custom method
         zmsg_t *reply = server_method (&self->server, method, msg);


### PR DESCRIPTION
solution: re-factor how zap domains are set, (less in _engine.inc), set a default "global" context if none is set when BIND is called.