### PR TITLE
Problem: zproject's selftest-rw does not allways work

### DIFF
--- a/api/zfile.api
+++ b/api/zfile.api
@@ -20,6 +20,11 @@
         <argument name = "name" type = "string" />
     </constructor>
 
+    <constructor name="tmp">
+        Create new temporary file for writing via tmpfile. File is automaticaly
+        deleted on destroy
+    </constructor>
+
     <destructor>
         Destroy a file item
     </destructor>

--- a/api/zfile.api
+++ b/api/zfile.api
@@ -20,7 +20,7 @@
         <argument name = "name" type = "string" />
     </constructor>
 
-    <constructor name="tmp">
+    <constructor name="tmp" state="draft">
         Create new temporary file for writing via tmpfile. File is automaticaly
         deleted on destroy
     </constructor>

--- a/include/zfile.h
+++ b/include/zfile.h
@@ -31,6 +31,11 @@ extern "C" {
 CZMQ_EXPORT zfile_t *
     zfile_new (const char *path, const char *name);
 
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+CZMQ_EXPORT zfile_t *
+    zfile_tmp (void);
+
 //  Destroy a file item
 CZMQ_EXPORT void
     zfile_destroy (zfile_t **self_p);

--- a/include/zfile.h
+++ b/include/zfile.h
@@ -31,11 +31,6 @@ extern "C" {
 CZMQ_EXPORT zfile_t *
     zfile_new (const char *path, const char *name);
 
-//  Create new temporary file for writing via tmpfile. File is automaticaly
-//  deleted on destroy
-CZMQ_EXPORT zfile_t *
-    zfile_tmp (void);
-
 //  Destroy a file item
 CZMQ_EXPORT void
     zfile_destroy (zfile_t **self_p);
@@ -149,6 +144,14 @@ CZMQ_EXPORT const char *
 CZMQ_EXPORT void
     zfile_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+CZMQ_EXPORT zfile_t *
+    zfile_tmp (void);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @end
 
 

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -94,6 +94,13 @@ CZMQ_PRIVATE zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+//  Caller owns return value and must destroy it when done.
+CZMQ_PRIVATE zfile_t *
+    zfile_tmp (void);
+
+//  *** Draft method, defined for internal use only ***
 //  Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
 //  Else returns zero.
 CZMQ_PRIVATE uint32_t

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -890,6 +890,7 @@ zfile_test (bool verbose)
     zfile_close (file);
     zfile_destroy (&file);
 
+#ifdef CZMQ_BUILD_DRAFT_API
     zfile_t *tempfile = zfile_tmp ();
     assert (tempfile);
     assert (zfile_filename (tempfile, NULL));
@@ -902,6 +903,7 @@ zfile_test (bool verbose)
     zfile_destroy (&tempfile);
     assert (!zsys_file_exists (filename));
     zstr_free (&filename);
+#endif // CZMQ_BUILD_DRAFT_API
 
 #if defined (__WINDOWS__)
     zsys_shutdown();

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -44,6 +44,12 @@ struct _zfile_t {
     zdigest_t *digest;      //  File digest, if known
     char *curline;          //  Last read line, if any
     size_t linemax;         //  Size of allocated buffer
+    bool remove_on_destroy; //  Whenever delete file on destroy
+                            //  Typically for tempfiles
+    int fd;                 //  File descriptor - set up by zfile_tmp
+    bool close_fd;          //  XXX: for some reason self->fd == 0 in
+                            //  zdir and zdir_patch tests, this is a
+                            //  workaround for the problem
 
     //  Properties from files that exist on file system
     time_t modified;        //  Modification time
@@ -100,9 +106,59 @@ zfile_new (const char *path, const char *name)
         }
     }
     zfile_restat (self);
+    self->fd = -1;
+    self->close_fd = false;
     return self;
 }
 
+//  --------------------------------------------------------------------------
+//  Constructor
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+
+zfile_t *
+zfile_tmp (void)
+{
+    zfile_t *self = (zfile_t *) zmalloc (sizeof (zfile_t));
+    assert (self);
+    self->remove_on_destroy = true;
+
+    // I know tmpnam is considered insecure, however I did not find a way
+    // how to get fullname from FILE *, or fd, which would be
+    // portable. If someone knows the way, feel free to rewrite it.
+    // ... on non Windows platforms there is O_CREAT | O_EXCL for open,
+    // which prevents the temp file name attacks
+    char name [L_tmpnam];
+    char *r = tmpnam (name);
+    if (!r) {
+        free (self);
+        return NULL;
+    }
+    self->fullname = strdup (name);
+#if defined __WINDOWS__
+    //some Windows expert should review and improve :)
+    self->handle = fopen (self->fullname, "wb+");
+#else
+    self->fd = open (self->fullname, O_WRONLY | O_CREAT | O_EXCL);
+    self->close_fd = true;
+    if (self->fd < 0) {
+        free (self->fullname);
+        free (self);
+        return NULL;
+    }
+    self->handle = fdopen (self->fd, "w");
+#endif
+    if (!self->handle) {
+        if (self->close_fd)
+            close (self->fd);
+        free (self->fullname);
+        free (self);
+        return NULL;
+    }
+
+    zfile_restat (self);
+    return self;
+}
 
 //  --------------------------------------------------------------------------
 //  Destroy a file item
@@ -114,8 +170,9 @@ zfile_destroy (zfile_t **self_p)
     if (*self_p) {
         zfile_t *self = *self_p;
         zdigest_destroy (&self->digest);
-        if (self->handle)
-            fclose (self->handle);
+        if (self->remove_on_destroy)
+            zfile_remove (self);
+        zfile_close (self);
         freen (self->fullname);
         freen (self->curline);
         freen (self->link);
@@ -494,6 +551,8 @@ zfile_close (zfile_t *self)
         self->handle = 0;
         self->eof = false;
     }
+    if (self->close_fd)
+        close (self->fd);
 }
 
 
@@ -830,6 +889,19 @@ zfile_test (bool verbose)
     zfile_remove (file);
     zfile_close (file);
     zfile_destroy (&file);
+
+    zfile_t *tempfile = zfile_tmp ();
+    assert (tempfile);
+    assert (zfile_filename (tempfile, NULL));
+    assert (zsys_file_exists (zfile_filename (tempfile, NULL)));
+    zchunk_t *tchunk = zchunk_new ("HELLO", 6);
+    assert (zfile_write (tempfile, tchunk, 0) == 0);
+    zchunk_destroy (&tchunk);
+
+    char *filename = strdup (zfile_filename (tempfile, NULL));
+    zfile_destroy (&tempfile);
+    assert (!zsys_file_exists (filename));
+    zstr_free (&filename);
 
 #if defined (__WINDOWS__)
     zsys_shutdown();


### PR DESCRIPTION
... we run our tests inside complicated Docker containers setup, where is no
guarantee user running test can access files in src/selftest-rw.

Solution: Add a constructor to create temporary file, which is automatically
removed on destroy. This will leads to nicer API for tests + it'd be hard to
find a platform without writable temporary directory. So this concept can work
better than src/selftest-rw + it leads to nicer code and simpler Makefiles generated by zproject.

XXX: it does use tmpnam, because I did not find a portable way how to obtain filename from FILE* or fd. On non-Windows the problem is mitigated by O_CREAT|O_EXCL flags for open, which will fail if file exists.