### PR TITLE
Problem: can't handle temp files in tests easily

### DIFF
--- a/api/zfile.api
+++ b/api/zfile.api
@@ -20,6 +20,11 @@
         <argument name = "name" type = "string" />
     </constructor>
 
+    <constructor name="tmp">
+        Create new temporary file for writing via tmpfile. File is automaticaly
+        deleted on destroy
+    </constructor>
+
     <destructor>
         Destroy a file item
     </destructor>

--- a/api/zfile.api
+++ b/api/zfile.api
@@ -20,7 +20,7 @@
         <argument name = "name" type = "string" />
     </constructor>
 
-    <constructor name="tmp">
+    <constructor name="tmp" state="draft">
         Create new temporary file for writing via tmpfile. File is automaticaly
         deleted on destroy
     </constructor>

--- a/include/zfile.h
+++ b/include/zfile.h
@@ -31,6 +31,11 @@ extern "C" {
 CZMQ_EXPORT zfile_t *
     zfile_new (const char *path, const char *name);
 
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+CZMQ_EXPORT zfile_t *
+    zfile_tmp (void);
+
 //  Destroy a file item
 CZMQ_EXPORT void
     zfile_destroy (zfile_t **self_p);

--- a/include/zfile.h
+++ b/include/zfile.h
@@ -31,11 +31,6 @@ extern "C" {
 CZMQ_EXPORT zfile_t *
     zfile_new (const char *path, const char *name);
 
-//  Create new temporary file for writing via tmpfile. File is automaticaly
-//  deleted on destroy
-CZMQ_EXPORT zfile_t *
-    zfile_tmp (void);
-
 //  Destroy a file item
 CZMQ_EXPORT void
     zfile_destroy (zfile_t **self_p);
@@ -149,6 +144,14 @@ CZMQ_EXPORT const char *
 CZMQ_EXPORT void
     zfile_test (bool verbose);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+CZMQ_EXPORT zfile_t *
+    zfile_tmp (void);
+
+#endif // CZMQ_BUILD_DRAFT_API
 //  @end
 
 

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -94,6 +94,13 @@ CZMQ_PRIVATE zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+//  Caller owns return value and must destroy it when done.
+CZMQ_PRIVATE zfile_t *
+    zfile_tmp (void);
+
+//  *** Draft method, defined for internal use only ***
 //  Return frame routing ID, if the frame came from a ZMQ_SERVER socket.
 //  Else returns zero.
 CZMQ_PRIVATE uint32_t

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -122,7 +122,6 @@ zfile_tmp (void)
 {
     zfile_t *self = (zfile_t *) zmalloc (sizeof (zfile_t));
     assert (self);
-    self->remove_on_destroy = true;
 
     char buffer [PATH_MAX];
     strcpy (buffer, "/tmp/czmq_zfile.XXXXXX");
@@ -138,6 +137,7 @@ zfile_tmp (void)
         return NULL;
     }
 
+    self->remove_on_destroy = true;
     self->close_fd = true;
     self->fullname = strdup (buffer);
     zfile_restat (self);

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -123,6 +123,8 @@ zfile_tmp (void)
     zfile_t *self = (zfile_t *) zmalloc (sizeof (zfile_t));
     assert (self);
 
+#if defined (__WINDOWS__)
+#else
     char buffer [PATH_MAX];
     strcpy (buffer, "/tmp/czmq_zfile.XXXXXX");
     self->fd = mkstemp (buffer);
@@ -136,10 +138,11 @@ zfile_tmp (void)
         self->fd = -1;
         return NULL;
     }
-
-    self->remove_on_destroy = true;
     self->close_fd = true;
     self->fullname = strdup (buffer);
+#endif
+
+    self->remove_on_destroy = true;
     zfile_restat (self);
     return self;
 }

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -44,6 +44,12 @@ struct _zfile_t {
     zdigest_t *digest;      //  File digest, if known
     char *curline;          //  Last read line, if any
     size_t linemax;         //  Size of allocated buffer
+    bool remove_on_destroy; //  Whenever delete file on destroy
+                            //  Typically for tempfiles
+    int fd;                 //  File descriptor - set up by zfile_tmp
+    bool close_fd;          //  XXX: for some reason self->fd == 0 in
+                            //  zdir and zdir_patch tests, this is a
+                            //  workaround for the problem
 
     //  Properties from files that exist on file system
     time_t modified;        //  Modification time
@@ -101,9 +107,59 @@ zfile_new (const char *path, const char *name)
     }
     self->handle = 0;
     zfile_restat (self);
+    self->fd = -1;
+    self->close_fd = false;
     return self;
 }
 
+//  --------------------------------------------------------------------------
+//  Constructor
+//  Create new temporary file for writing via tmpfile. File is automaticaly
+//  deleted on destroy
+
+zfile_t *
+zfile_tmp (void)
+{
+    zfile_t *self = (zfile_t *) zmalloc (sizeof (zfile_t));
+    assert (self);
+    self->remove_on_destroy = true;
+
+    // I know tmpnam is considered insecure, however I did not find a way
+    // how to get fullname from FILE *, or fd, which would be
+    // portable. If someone knows the way, feel free to rewrite it.
+    // ... on non Windows platforms there is O_CREAT | O_EXCL for open,
+    // which prevents the temp file name attacks
+    char name [L_tmpnam];
+    char *r = tmpnam (name);
+    if (!r) {
+        free (self);
+        return NULL;
+    }
+    self->fullname = strdup (name);
+#if defined __WINDOWS__
+    //some Windows expert should review and improve :)
+    self->handle = fopen (self->fullname, "wb+");
+#else
+    self->fd = open (self->fullname, O_WRONLY | O_CREAT | O_EXCL);
+    self->close_fd = true;
+    if (self->fd < 0) {
+        free (self->fullname);
+        free (self);
+        return NULL;
+    }
+    self->handle = fdopen (self->fd, "w");
+#endif
+    if (!self->handle) {
+        if (self->close_fd)
+            close (self->fd);
+        free (self->fullname);
+        free (self);
+        return NULL;
+    }
+
+    zfile_restat (self);
+    return self;
+}
 
 //  --------------------------------------------------------------------------
 //  Destroy a file item
@@ -115,8 +171,9 @@ zfile_destroy (zfile_t **self_p)
     if (*self_p) {
         zfile_t *self = *self_p;
         zdigest_destroy (&self->digest);
-        if (self->handle)
-            fclose (self->handle);
+        if (self->remove_on_destroy)
+            zfile_remove (self);
+        zfile_close (self);
         freen (self->fullname);
         freen (self->curline);
         freen (self->link);
@@ -506,6 +563,8 @@ zfile_close (zfile_t *self)
         zfile_restat (self);
         self->eof = false;
     }
+    if (self->close_fd)
+        close (self->fd);
 }
 
 
@@ -829,6 +888,19 @@ zfile_test (bool verbose)
     zfile_remove (file);
     zfile_close (file);
     zfile_destroy (&file);
+
+    zfile_t *tempfile = zfile_tmp ();
+    assert (tempfile);
+    assert (zfile_filename (tempfile, NULL));
+    assert (zsys_file_exists (zfile_filename (tempfile, NULL)));
+    zchunk_t *tchunk = zchunk_new ("HELLO", 6);
+    assert (zfile_write (tempfile, tchunk, 0) == 0);
+    zchunk_destroy (&tchunk);
+
+    char *filename = strdup (zfile_filename (tempfile, NULL));
+    zfile_destroy (&tempfile);
+    assert (!zsys_file_exists (filename));
+    zstr_free (&filename);
 
 #if defined (__WINDOWS__)
     zsys_shutdown();

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -124,6 +124,9 @@ zfile_tmp (void)
     assert (self);
 
 #if defined (__WINDOWS__)
+    zsys_info ("zfile_tmp is not yet implemented for Windows");
+    free (self);
+    return NULL;
 #else
     char buffer [PATH_MAX];
     strcpy (buffer, "/tmp/czmq_zfile.XXXXXX");
@@ -876,6 +879,7 @@ zfile_test (bool verbose)
     zfile_destroy (&file);
 
 #ifdef CZMQ_BUILD_DRAFT_API
+#   if ! defined(__WINDOWS__)
     zfile_t *tempfile = zfile_tmp ();
     assert (tempfile);
     assert (zfile_filename (tempfile, NULL));
@@ -888,6 +892,7 @@ zfile_test (bool verbose)
     zfile_destroy (&tempfile);
     assert (!zsys_file_exists (filename));
     zstr_free (&filename);
+#   endif // ! defined(__WINDOWS__)
 #endif // CZMQ_BUILD_DRAFT_API
 
 #if defined (__WINDOWS__)

--- a/src/zfile.c
+++ b/src/zfile.c
@@ -889,6 +889,7 @@ zfile_test (bool verbose)
     zfile_close (file);
     zfile_destroy (&file);
 
+#ifdef CZMQ_BUILD_DRAFT_API
     zfile_t *tempfile = zfile_tmp ();
     assert (tempfile);
     assert (zfile_filename (tempfile, NULL));
@@ -901,6 +902,7 @@ zfile_test (bool verbose)
     zfile_destroy (&tempfile);
     assert (!zsys_file_exists (filename));
     zstr_free (&filename);
+#endif // CZMQ_BUILD_DRAFT_API
 
 #if defined (__WINDOWS__)
     zsys_shutdown();


### PR DESCRIPTION
Solution: fixed implementation of zfile_tmp to use mkstemp. Now it hall be secure.