### PR TITLE
Fix autotools build on Cygwin

### DIFF
--- a/include/czmq_library.h
+++ b/include/czmq_library.h
@@ -52,7 +52,7 @@
 #   define CZMQ_PRIVATE
 #else
 #   define CZMQ_EXPORT
-#   if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
+#   if (defined __GNUC__ && __GNUC__ >= 4 && !defined __CYGWIN__) || defined __INTEL_COMPILER
 #       define CZMQ_PRIVATE __attribute__ ((visibility ("hidden")))
 #   else
 #       define CZMQ_PRIVATE

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -654,7 +654,9 @@ typedef int SOCKET;
 #   define closesocket      close
 #   define INVALID_SOCKET   -1
 #   define SOCKET_ERROR     -1
-#   define O_BINARY         0
+#   if !defined O_BINARY
+#       define O_BINARY      0
+#   endif
 #endif
 
 //- Include non-portable header files based on platform.h -------------------


### PR DESCRIPTION
Fix autotools build on Cygwin failing due to:

- O_BINARY symbol redefinition in include/czmq_prelude.h
- __attribute__ ((visibility ("hidden"))) not supported by Windows executables.
