### PR TITLE
Problem: uuid header not correctly included on OpenBSD

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -684,7 +684,7 @@ char *if_indextoname (unsigned int ifindex, char *ifname);
 #   define HAVE_UUID 1
 #endif
 #if defined (HAVE_UUID)
-#   if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD)
+#   if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD) || defined(__UTYPE_OPENBSD)
 #       include <uuid.h>
 #   elif defined __UTYPE_HPUX
 #       include <dce/uuid.h>


### PR DESCRIPTION
Solution: Add OpenBSD to existing list of BSDs for correct
header inclusion
