### PR TITLE
PROBLEM: Need to remove any node and subtree

### DIFF
--- a/api/zconfig.api
+++ b/api/zconfig.api
@@ -180,8 +180,13 @@
         <return type = "boolean" />
     </method>
 
-    <method name = "remove" state = "draft">
-        Destroy subtree (child)
+    <method name = "remove_subtree" state = "draft">
+        Destroy subtree (all children)
+    </method>
+
+    <method name = "remove" singleton = "1" state = "draft">
+        Destroy node and subtree (all children)
+        <argument name = "self_p" type = "zconfig" by_reference = "1" />
     </method>
 
     <method name = "fprint">

--- a/api/zconfig.api
+++ b/api/zconfig.api
@@ -189,7 +189,7 @@
         <argument name = "file" type = "FILE" />
     </method>
 
-    <method name = "print">
+    <method name = "print" state = "draft">
         Print properties of object
     </method>
 

--- a/api/zconfig.api
+++ b/api/zconfig.api
@@ -189,7 +189,7 @@
         <argument name = "file" type = "FILE" />
     </method>
 
-    <method name = "print" state = "draft">
+    <method name = "print">
         Print properties of object
     </method>
 

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -155,17 +155,13 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT bool
     zconfig_has_changed (zconfig_t *self);
 
-#ifdef CZMQ_BUILD_DRAFT_API
-//  *** Draft method, for development use, may change without warning ***
-//  Destroy subtree (child)
-CZMQ_EXPORT void
-    zconfig_remove (zconfig_t *self);
-
-#endif // CZMQ_BUILD_DRAFT_API
-
 //  Print the config file to open stream
 CZMQ_EXPORT void
     zconfig_fprint (zconfig_t *self, FILE *file);
+
+//  Print properties of object
+CZMQ_EXPORT void
+    zconfig_print (zconfig_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT void
@@ -176,10 +172,6 @@ CZMQ_EXPORT void
 //  Destroy subtree (child)
 CZMQ_EXPORT void
     zconfig_remove (zconfig_t *self);
-
-//  Print properties of object
-CZMQ_EXPORT void
-    zconfig_print (zconfig_t *self);
 
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -169,9 +169,14 @@ CZMQ_EXPORT void
 
 #ifdef CZMQ_BUILD_DRAFT_API
 //  *** Draft method, for development use, may change without warning ***
-//  Destroy subtree (child)
+//  Destroy subtree (all children)
 CZMQ_EXPORT void
-    zconfig_remove (zconfig_t *self);
+    zconfig_remove_subtree (zconfig_t *self);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Destroy node and subtree (all children)
+CZMQ_EXPORT void
+    zconfig_remove (zconfig_t **self_p);
 
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -155,17 +155,17 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT bool
     zconfig_has_changed (zconfig_t *self);
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
 //  Destroy subtree (child)
 CZMQ_EXPORT void
     zconfig_remove (zconfig_t *self);
 
+#endif // CZMQ_BUILD_DRAFT_API
+
 //  Print the config file to open stream
 CZMQ_EXPORT void
     zconfig_fprint (zconfig_t *self, FILE *file);
-
-//  Print properties of object
-CZMQ_EXPORT void
-    zconfig_print (zconfig_t *self);
 
 //  Self test of this class
 CZMQ_EXPORT void
@@ -176,6 +176,10 @@ CZMQ_EXPORT void
 //  Destroy subtree (child)
 CZMQ_EXPORT void
     zconfig_remove (zconfig_t *self);
+
+//  Print properties of object
+CZMQ_EXPORT void
+    zconfig_print (zconfig_t *self);
 
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -155,6 +155,10 @@ CZMQ_EXPORT char *
 CZMQ_EXPORT bool
     zconfig_has_changed (zconfig_t *self);
 
+//  Destroy subtree (child)
+CZMQ_EXPORT void
+    zconfig_remove (zconfig_t *self);
+
 //  Print the config file to open stream
 CZMQ_EXPORT void
     zconfig_fprint (zconfig_t *self, FILE *file);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -94,9 +94,14 @@ CZMQ_PRIVATE zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
-//  Destroy subtree (child)
+//  Destroy subtree (all children)
 CZMQ_PRIVATE void
-    zconfig_remove (zconfig_t *self);
+    zconfig_remove_subtree (zconfig_t *self);
+
+//  *** Draft method, defined for internal use only ***
+//  Destroy node and subtree (all children)
+CZMQ_PRIVATE void
+    zconfig_remove (zconfig_t **self_p);
 
 //  *** Draft method, defined for internal use only ***
 //  Create new temporary file for writing via tmpfile. File is automaticaly

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -97,6 +97,9 @@ CZMQ_PRIVATE zlistx_t *
 //  Destroy subtree (child)
 CZMQ_PRIVATE void
     zconfig_remove (zconfig_t *self);
+//  Print properties of object
+CZMQ_PRIVATE void
+    zconfig_print (zconfig_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Create new temporary file for writing via tmpfile. File is automaticaly

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -97,9 +97,6 @@ CZMQ_PRIVATE zlistx_t *
 //  Destroy subtree (child)
 CZMQ_PRIVATE void
     zconfig_remove (zconfig_t *self);
-//  Print properties of object
-CZMQ_PRIVATE void
-    zconfig_print (zconfig_t *self);
 
 //  *** Draft method, defined for internal use only ***
 //  Create new temporary file for writing via tmpfile. File is automaticaly


### PR DESCRIPTION
not just root.
    
Previously a method `zconfig_remove` had been created that removes just
the subtree (all children) of the selected node, which is confusing.
    
SOLUTION:

* Rename `zconfig_remove ()` -> `zconfig_remove_subtree ()`
* Use name `zconfig_remove` for the _new_ method
* Implement `zconfig_remove ()`
* Write test for `zconfig_remove ()`; Extend test for `zconfig_remove_subtree ()`