### PR TITLE
[WIP] Problem: zproc selftests sometimes fail

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1081,18 +1081,18 @@ zproc_test (bool verbose)
 
         if (!which) {
             if (zproc_timeout_msec > zproc_test_elapsed_msec) {
-                zsys_debug("zproc_test : did not get stdout from helper, %" PRIi64 " msec remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
+                zsys_debug("zproc_test() : did not get stdout from helper, %" PRIi64 " msec remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
                 continue;
             }
             // ...else : we've slept a lot and got no response; kill the helper
-            zsys_debug("zproc_test : did not get stdout from helper, patience expired (%" PRIi64 " msec remaining to retry)", (zproc_timeout_msec - zproc_test_elapsed_msec) );
+            zsys_debug("zproc_test() : did not get stdout from helper, patience expired (%" PRIi64 " msec remaining to retry)", (zproc_timeout_msec - zproc_test_elapsed_msec) );
             zproc_kill (self, SIGTERM);
             zproc_wait (self, true);
             break;
         }
 
         if (which == zproc_stdout (self)) {
-            zsys_debug("zproc_test : got stdout from helper, %" PRIi64 " msec was remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
+            zsys_debug("zproc_test() : got stdout from helper, %" PRIi64 " msec was remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
             stdout_read = true;
             zframe_t *frame;
             zsock_brecv (zproc_stdout (self), "f", &frame);
@@ -1113,7 +1113,7 @@ zproc_test (bool verbose)
         }
 
         // should not get there
-        zsys_debug("zproc_test : reached the unreachable point (unexpected zpoller result), %" PRIi64 " msec was remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
+        zsys_debug("zproc_test() : reached the unreachable point (unexpected zpoller result), %" PRIi64 " msec was remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
         assert (false);
     }
 

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1065,6 +1065,7 @@ zproc_test (bool verbose)
 
     // execute the binary. It runs in own actor, which monitor the process and
     // pass data accross pipes and zeromq sockets
+    zsys_debug("zproc_test() : launching helper '%s'", file );
     zproc_run (self);
     zpoller_t *poller = zpoller_new (zproc_stdout (self), NULL);
 

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1071,7 +1071,7 @@ zproc_test (bool verbose)
     // read the content from zproc_stdout - use zpoller and a loop
     bool stdout_read = false;
     // kill the binary, it never ends, but the test must
-    int64_t zproc_timeout_msec = 4000;
+    int64_t zproc_timeout_msec = 10000;
     int64_t zproc_test_start_msec = zclock_mono();
     int64_t zproc_test_elapsed_msec = 0;
 

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1089,6 +1089,10 @@ zproc_test (bool verbose)
         zproc_test_elapsed_msec = zclock_mono() - zproc_test_start_msec;
 
         if (!which) {
+            if (stdout_read) {
+                zsys_debug("zproc_test() : did not get stdout from helper, but we already have some (%" PRIi64 " msec remaining to retry)", (zproc_timeout_msec - zproc_test_elapsed_msec) );
+                break;
+            }
             if (zproc_timeout_msec > zproc_test_elapsed_msec) {
                 zsys_debug("zproc_test() : did not get stdout from helper, %" PRIi64 " msec remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
                 continue;

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1079,9 +1079,11 @@ zproc_test (bool verbose)
         if (!which) {
             if (zproc_timeout_msec > 0) {
                 zproc_timeout_msec -= 800;
+                zsys_debug("zproc_test : did not get stdout from helper, %i msec remaining to retry", zproc_timeout_msec);
                 continue;
             }
             // ...else : we've slept a lot and got no response; kill the helper
+            zsys_debug("zproc_test : did not get stdout from helper, patience expired (%i msec remaining to retry)", zproc_timeout_msec);
             zproc_kill (self, SIGTERM);
             zproc_wait (self, true);
             break;

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -1081,7 +1081,6 @@ zproc_test (bool verbose)
 
         if (!which) {
             if (zproc_timeout_msec > zproc_test_elapsed_msec) {
-                zproc_timeout_msec -= 800;
                 zsys_debug("zproc_test : did not get stdout from helper, %" PRIi64 " msec remaining to retry", (zproc_timeout_msec - zproc_test_elapsed_msec) );
                 continue;
             }


### PR DESCRIPTION
Solution: guessing that the randomly chosen and hardcoded timeout (800msec) was too short in some cases, allow a longer one overall and check if it expired in 800-msec increments.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Please do review the changeset - to weed out logical mistakes and my misconceptions, if any ;)