### PR TITLE
Fix zuuid.c build error on FreeBSD

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -683,6 +683,9 @@ char *if_indextoname (unsigned int ifindex, char *ifname);
 #if defined (__UTYPE_OSX) && !defined (HAVE_UUID)
 #   define HAVE_UUID 1
 #endif
+#if defined (__UTYPE_FREEBSD) && !defined (HAVE_UUID)
+#   define HAVE_UUID 1
+#endif
 #if defined (HAVE_UUID)
 #   if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD) || defined(__UTYPE_OPENBSD)
 #       include <uuid.h>

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -47,7 +47,7 @@ zuuid_new (void)
     assert (sizeof (uuid) == ZUUID_LEN);
     UuidCreate (&uuid);
     zuuid_set (self, (byte *) &uuid);
-#elif defined (HAVE_UUID)
+#elif defined (HAVE_UUID) && !defined (__UTYPE_FREEBSD)
     uuid_t uuid;
     assert (sizeof (uuid) == ZUUID_LEN);
     uuid_generate (uuid);


### PR DESCRIPTION
Problem: zuuid.c on v4.1.0 is broken on FreeBSD 11.1-STABLE

Solution: apply fixes in this pull request for include/czmq_prelude.h and src/zuuid.c

* This fix works on FreeBSD 10.4-RELEASE and 11.1-RELEASE, 11.1-STABLE
* Forcefully define HAVE_UUID in czmq_prelude.h if FreeBSD
    - FreeBSD has the stock UUID library, but it's not -luuid, it's in -lc, so HAVE_UUID is not defined during configure
* Skip code in zuuid.c assuming uuid_generate(2) if FreeBSD
    - FreeBSD does not have uuid_generate(2) (it's Linux specific); use existing code for FreeBSD instead

See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=224853 for the details
