### PR TITLE
Problem: can't build czmq on osx

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -60,7 +60,9 @@ content of the messages in any way. See test example on how to use it.
 
 #if defined (__UNIX__)
 #   if defined (__UTYPE_OSX)
-char **environ = *_NSGetEnviron (); // issue#1836
+// issue#1836
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron ()) 
 #   else
 extern char **environ;              // should be declared as a part of unistd.h, but fail in some targets in Travis
                                     // declare it explicitly

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -539,7 +539,7 @@ s_zproc_execve (zproc_t *self)
         }
         else
 #if defined (__UTYPE_OSX)
-            env = _NSGetEnviron ();
+            env = *_NSGetEnviron ();
 #else
             env = environ;
 #endif

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -59,8 +59,11 @@ content of the messages in any way. See test example on how to use it.
 #include "czmq_classes.h"
 
 #if defined (__UNIX__)
-#   if !defined (_GNU_SOURCE)
-extern char **environ;          // declared in unistd.h if _GNU_SOURCE is defined
+#   if defined (__UTYPE_OSX)
+char **environ = *_NSGetEnviron (); // issue#1836
+#   else
+extern char **environ;              // should be declared as a part of unistd.h, but fail in some targets in Travis
+                                    // declare it explicitly
 #   endif
 #endif
 
@@ -544,11 +547,7 @@ s_zproc_execve (zproc_t *self)
             arr_add_ref (env, i, NULL);
         }
         else
-#if defined (__UTYPE_OSX)
-            env = *_NSGetEnviron ();
-#else
             env = environ;
-#endif
 
         r = execve (filename, argv2, env);
         if (r == -1) {

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -65,6 +65,10 @@ content of the messages in any way. See test example on how to use it.
 # include <unistd.h>
 #endif
 
+#if defined (__UTYPE_OSX)
+#include <crt_externs.h>
+#endif
+
 #define ZPROC_RUNNING -42
 
 //      #######     internal helpers for zproc      #######
@@ -534,7 +538,11 @@ s_zproc_execve (zproc_t *self)
             arr_add_ref (env, i, NULL);
         }
         else
+#if defined (__UTYPE_OSX)
+            env = _NSGetEnviron ();
+#else
             env = environ;
+#endif
 
         r = execve (filename, argv2, env);
         if (r == -1) {

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -58,6 +58,12 @@ content of the messages in any way. See test example on how to use it.
 
 #include "czmq_classes.h"
 
+#if defined (__UNIX__)
+#   if !defined (_GNU_SOURCE)
+extern char **environ;          // declared in unistd.h if _GNU_SOURCE is defined
+#   endif
+#endif
+
 // For getcwd() variants
 #if (defined (WIN32))
 # include <direct.h>


### PR DESCRIPTION
Solution: use _NSGetEnviron () routine to get environ variable on OSX

I've no access to OSX, someone should check if it builds and works before merging. Should fix #1834 