### PR TITLE
Makemodule-local.am : require ZSP helper available before check recipes

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -11,5 +11,16 @@ if ENABLE_TEST_RANDOF
 src_test_randof_CPPFLAGS += $(test_randof_macros)
 endif
 
+# Make sure there is the helper utility for the zproc tests
+if ENABLE_ZSP
+coverage \
+    check-local check-verbose \
+    memcheck memcheck-verbose \
+    debug debug-verbose \
+    callcheck callcheck-verbose \
+    animate animate-verbose \
+    : src/zsp
+endif
+
 check-py: src/libczmq.la
 	$(LIBTOOL) --mode=execute -dlopen src/libczmq.la python bindings/python/test.py


### PR DESCRIPTION
Until now, it is possible to build from scratch (or remove `src/zsp`) and end up with skipped zproc tests because the helper is not found. Not anymore (if it is enabled).