### PR TITLE
Revert "Problem: We would like to use tabs in ZPL configs."

### DIFF
--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -736,18 +736,11 @@ static int
 s_collect_level (char **start, int lineno)
 {
     char *readptr = *start;
-    int spaces = 0;
-    int tabs = 0;
-    while (*readptr == ' ' || *readptr == '\t') {
-        if (*readptr == ' ')
-            spaces++;
-        else
-            tabs++;
+    while (*readptr == ' ')
         readptr++;
-    }
-    ptrdiff_t level = (spaces + 4*tabs) / 4;
-    if (level * 4 != spaces + 4*tabs) {
-        zclock_log ("E (zconfig): (%d) indent 4 spaces at once or use tabs", lineno);
+    ptrdiff_t level = (readptr - *start) / 4;
+    if (level * 4 != readptr - *start) {
+        zclock_log ("E (zconfig): (%d) indent 4 spaces at once", lineno);
         level = -1;
     }
     *start = readptr;


### PR DESCRIPTION
Reverts zeromq/czmq#1842

Two reasons:

1. PR does not solve a problem. You can set your favourite editor to expand tabs.

2. The [ZPL RFC specification](https://rfc.zeromq.org/spec:4/ZPL/) clearly states that `Hierarchy is signaled by indentation, where a child is indented *4 spaces* more than its parent.`