### PR TITLE
Fix segfault when no USER environment variable exists

### DIFF
--- a/src/zproxy.c
+++ b/src/zproxy.c
@@ -560,7 +560,7 @@ zproxy_test (bool verbose)
 	sink = zsock_new_sub(">inproc://backend", "whatever");
 #else
     // vagrant vms don't like using shared storage for ipc pipes..
-    if (streq(getenv("USER"), "vagrant"))
+    if (getenv("USER") && streq(getenv("USER"), "vagrant"))
         sink = zsock_new_sub (">ipc:///tmp/backend", "whatever");
     else
 	    sink = zsock_new_sub (">ipc://backend", "whatever");
@@ -571,7 +571,7 @@ zproxy_test (bool verbose)
 	zstr_sendx (proxy, "BACKEND", "XPUB", "inproc://backend", NULL);
 #else
     // vagrant vms don't like using shared storage for ipc pipes..
-    if (streq(getenv("USER"), "vagrant"))
+    if (getenv("USER") && streq(getenv("USER"), "vagrant"))
         zstr_sendx(proxy, "BACKEND", "XPUB", "ipc:///tmp/backend", NULL);
     else
         zstr_sendx(proxy, "BACKEND", "XPUB", "ipc://backend", NULL);


### PR DESCRIPTION
# Problem:
streq(getenv(envvar), ...) segfaults when the envvar variable does not exist because the return value of getenv is 0

# Solution:
Extend the if condition with a short-circuit check of the getenv's return value 


Fixes zeromq/czmq#1844