### PR TITLE
Problem: zproc_run returns before execve is called

### DIFF
--- a/include/zproc.h
+++ b/include/zproc.h
@@ -95,7 +95,7 @@ CZMQ_EXPORT void *
     zproc_stderr (zproc_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Starts the process.
+//  Starts the process, return just before execve/CreateProcess
 CZMQ_EXPORT int
     zproc_run (zproc_t *self);
 


### PR DESCRIPTION
Solution: create new execpair zeromq pair, which is used to make
zproc_run synchronized with internal actor. This is the best
approximation of making sure zproc_run ends just before
execve/CreateProcess is called.