### PR TITLE
Don't define strtoull and atoll on MINGW environment

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -535,8 +535,10 @@ typedef struct {
 #   if (!defined (__cplusplus) && (!defined (inline)))
 #       define inline __inline
 #   endif
-#   define strtoull _strtoui64
-#   define atoll _atoi64
+#   if (!defined (__MINGW32__))
+#     define strtoull _strtoui64
+#     define atoll _atoi64
+#   endif
 #   define srandom srand
 #   define TIMEZONE _timezone
 #   if (!defined (__MINGW32__))


### PR DESCRIPTION
Same issue here: https://github.com/flavio/qjson/issues/26