### PR TITLE
Problem: zsys_interrupted not available from lang bindings

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -2335,12 +2335,6 @@ void
 void
     zproc_set_verbose (zproc_t *self, bool verbose);
 
-// Returns true if the process received a SIGINT or SIGTERM signal.
-// It is good practice to use this method to exit any infinite loop
-// processing messages.
-bool
-    zproc_interrupted (void);
-
 // Self test of this class.
 void
     zproc_test (bool verbose);
@@ -3496,6 +3490,18 @@ void
 // *** This is for CZMQ internal use only and may change arbitrarily ***
 void
     zsys_catch_interrupts (void);
+
+// Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+// Does not work if ZSYS_SIGHANDLER is false and code does not call
+// set interrupted on signal.
+bool
+    zsys_is_interrupted (void);
+
+// Set interrupted flag. This is done by default signal handler, however
+// this can be handy for language bindings or cases without default
+// signal handler.
+void
+    zsys_set_interrupted (void);
 
 // Return 1 if file exists, else zero
 bool

--- a/api/zproc.api
+++ b/api/zproc.api
@@ -124,11 +124,4 @@ CZMQ_EXPORT int
     zsubproc_run (zsubproc_t *self, const char *filename, char *const argv[], char *const envp[]);
 -->
 
-    <method name = "interrupted" singleton = "1">
-        Returns true if the process received a SIGINT or SIGTERM signal.
-        It is good practice to use this method to exit any infinite loop
-        processing messages.
-        <return type = "boolean" />
-    </method>
-
 </class>

--- a/api/zproc.api
+++ b/api/zproc.api
@@ -117,11 +117,4 @@
         <argument name = "verbose" type = "boolean" />
     </method>
 
-<!--
-TODO: cannot express such method in zproto API model!!
-//  run the subprocess
-CZMQ_EXPORT int
-    zsubproc_run (zsubproc_t *self, const char *filename, char *const argv[], char *const envp[]);
--->
-
 </class>

--- a/api/zsys.api
+++ b/api/zsys.api
@@ -86,6 +86,19 @@
         *** This is for CZMQ internal use only and may change arbitrarily ***
     </method>
 
+    <method name = "is interrupted" singleton = "1" state = "draft">
+        Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+        Does not work if ZSYS_SIGHANDLER is false and code does not call
+        set interrupted on signal.
+        <return type = "boolean" />
+    </method>
+
+    <method name = "set interrupted" singleton = "1" state = "draft">
+        Set interrupted flag. This is done by default signal handler, however
+        this can be handy for language bindings or cases without default
+        signal handler.
+    </method>
+
     <method name = "file exists" singleton = "1">
         Return 1 if file exists, else zero
         <argument name = "filename" type = "string" />

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zproc.c
@@ -138,13 +138,6 @@ Java_org_zeromq_czmq_Zproc__1_1setVerbose (JNIEnv *env, jclass c, jlong self, jb
     zproc_set_verbose ((zproc_t *) (intptr_t) self, (bool) verbose);
 }
 
-JNIEXPORT jboolean JNICALL
-Java_org_zeromq_czmq_Zproc__1_1interrupted (JNIEnv *env, jclass c)
-{
-    jboolean interrupted_ = (jboolean) zproc_interrupted ();
-    return interrupted_;
-}
-
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zproc__1_1test (JNIEnv *env, jclass c, jboolean verbose)
 {

--- a/bindings/jni/src/main/c/org_zeromq_czmq_Zsys.c
+++ b/bindings/jni/src/main/c/org_zeromq_czmq_Zsys.c
@@ -69,6 +69,19 @@ Java_org_zeromq_czmq_Zsys__1_1catchInterrupts (JNIEnv *env, jclass c)
 }
 
 JNIEXPORT jboolean JNICALL
+Java_org_zeromq_czmq_Zsys__1_1isInterrupted (JNIEnv *env, jclass c)
+{
+    jboolean is_interrupted_ = (jboolean) zsys_is_interrupted ();
+    return is_interrupted_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsys__1_1setInterrupted (JNIEnv *env, jclass c)
+{
+    zsys_set_interrupted ();
+}
+
+JNIEXPORT jboolean JNICALL
 Java_org_zeromq_czmq_Zsys__1_1fileExists (JNIEnv *env, jclass c, jstring filename)
 {
     char *filename_ = (char *) (*env)->GetStringUTFChars (env, filename, NULL);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -169,15 +169,6 @@ public class Zproc implements AutoCloseable{
         __setVerbose (self, verbose);
     }
     /*
-    Returns true if the process received a SIGINT or SIGTERM signal.
-    It is good practice to use this method to exit any infinite loop
-    processing messages.
-    */
-    native static boolean __interrupted ();
-    public boolean interrupted () {
-        return __interrupted ();
-    }
-    /*
     Self test of this class.
     */
     native static void __test (boolean verbose);

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -92,6 +92,24 @@ public class Zsys {
         __catchInterrupts ();
     }
     /*
+    Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+    Does not work if ZSYS_SIGHANDLER is false and code does not call
+    set interrupted on signal.
+    */
+    native static boolean __isInterrupted ();
+    public boolean isInterrupted () {
+        return __isInterrupted ();
+    }
+    /*
+    Set interrupted flag. This is done by default signal handler, however
+    this can be handy for language bindings or cases without default
+    signal handler.
+    */
+    native static void __setInterrupted ();
+    public void setInterrupted () {
+        __setInterrupted ();
+    }
+    /*
     Return 1 if file exists, else zero
     */
     native static boolean __fileExists (String filename);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -2330,12 +2330,6 @@ void
 void
     zproc_set_verbose (zproc_t *self, bool verbose);
 
-// Returns true if the process received a SIGINT or SIGTERM signal.
-// It is good practice to use this method to exit any infinite loop
-// processing messages.
-bool
-    zproc_interrupted (void);
-
 // Self test of this class.
 void
     zproc_test (bool verbose);
@@ -3491,6 +3485,18 @@ void
 // *** This is for CZMQ internal use only and may change arbitrarily ***
 void
     zsys_catch_interrupts (void);
+
+// Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+// Does not work if ZSYS_SIGHANDLER is false and code does not call
+// set interrupted on signal.
+bool
+    zsys_is_interrupted (void);
+
+// Set interrupted flag. This is done by default signal handler, however
+// this can be handy for language bindings or cases without default
+// signal handler.
+void
+    zsys_set_interrupted (void);
 
 // Return 1 if file exists, else zero
 bool

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2248,14 +2248,6 @@ nothing my_zproc.setVerbose (Boolean)
 set verbose mode
 
 ```
-boolean my_zproc.interrupted ()
-```
-
-Returns true if the process received a SIGINT or SIGTERM signal.
-It is good practice to use this method to exit any infinite loop
-processing messages.
-
-```
 nothing my_zproc.test (Boolean)
 ```
 
@@ -3643,6 +3635,22 @@ Set default interrupt handler, so Ctrl-C or SIGTERM will set
 zsys_interrupted. Idempotent; safe to call multiple times.
 Can be supressed by ZSYS_SIGHANDLER=false
 *** This is for CZMQ internal use only and may change arbitrarily ***
+
+```
+boolean my_zsys.isInterrupted ()
+```
+
+Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+Does not work if ZSYS_SIGHANDLER is false and code does not call
+set interrupted on signal.
+
+```
+nothing my_zsys.setInterrupted ()
+```
+
+Set interrupted flag. This is done by default signal handler, however
+this can be handy for language bindings or cases without default
+signal handler.
 
 ```
 boolean my_zsys.fileExists (String)

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -4223,7 +4223,6 @@ NAN_MODULE_INIT (Zproc::Init) {
     Nan::SetPrototypeMethod (tpl, "wait", _wait);
     Nan::SetPrototypeMethod (tpl, "kill", _kill);
     Nan::SetPrototypeMethod (tpl, "setVerbose", _set_verbose);
-    Nan::SetPrototypeMethod (tpl, "interrupted", _interrupted);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -4366,11 +4365,6 @@ NAN_METHOD (Zproc::_set_verbose) {
     else
         return Nan::ThrowTypeError ("`verbose` must be a Boolean");
     zproc_set_verbose (zproc->self, (bool) verbose);
-}
-
-NAN_METHOD (Zproc::_interrupted) {
-    bool result = zproc_interrupted ();
-    info.GetReturnValue ().Set (Nan::New<Boolean>(result));
 }
 
 NAN_METHOD (Zproc::_test) {
@@ -6833,6 +6827,8 @@ NAN_MODULE_INIT (Zsys::Init) {
     Nan::SetPrototypeMethod (tpl, "createPipe", _create_pipe);
     Nan::SetPrototypeMethod (tpl, "handlerReset", _handler_reset);
     Nan::SetPrototypeMethod (tpl, "catchInterrupts", _catch_interrupts);
+    Nan::SetPrototypeMethod (tpl, "isInterrupted", _is_interrupted);
+    Nan::SetPrototypeMethod (tpl, "setInterrupted", _set_interrupted);
     Nan::SetPrototypeMethod (tpl, "fileExists", _file_exists);
     Nan::SetPrototypeMethod (tpl, "fileModified", _file_modified);
     Nan::SetPrototypeMethod (tpl, "fileMode", _file_mode);
@@ -6944,6 +6940,15 @@ NAN_METHOD (Zsys::_handler_reset) {
 
 NAN_METHOD (Zsys::_catch_interrupts) {
     zsys_catch_interrupts ();
+}
+
+NAN_METHOD (Zsys::_is_interrupted) {
+    bool result = zsys_is_interrupted ();
+    info.GetReturnValue ().Set (Nan::New<Boolean>(result));
+}
+
+NAN_METHOD (Zsys::_set_interrupted) {
+    zsys_set_interrupted ();
 }
 
 NAN_METHOD (Zsys::_file_exists) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -599,7 +599,6 @@ class Zproc: public Nan::ObjectWrap {
     static NAN_METHOD (_wait);
     static NAN_METHOD (_kill);
     static NAN_METHOD (_set_verbose);
-    static NAN_METHOD (_interrupted);
     static NAN_METHOD (_test);
 };
 
@@ -812,6 +811,8 @@ class Zsys: public Nan::ObjectWrap {
     static NAN_METHOD (_create_pipe);
     static NAN_METHOD (_handler_reset);
     static NAN_METHOD (_catch_interrupts);
+    static NAN_METHOD (_is_interrupted);
+    static NAN_METHOD (_set_interrupted);
     static NAN_METHOD (_file_exists);
     static NAN_METHOD (_file_modified);
     static NAN_METHOD (_file_mode);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -4850,8 +4850,6 @@ lib.zproc_kill.restype = None
 lib.zproc_kill.argtypes = [zproc_p, c_int]
 lib.zproc_set_verbose.restype = None
 lib.zproc_set_verbose.argtypes = [zproc_p, c_bool]
-lib.zproc_interrupted.restype = c_bool
-lib.zproc_interrupted.argtypes = []
 lib.zproc_test.restype = None
 lib.zproc_test.argtypes = [c_bool]
 
@@ -5017,15 +5015,6 @@ not initialized or external sockets.
         set verbose mode
         """
         return lib.zproc_set_verbose(self._as_parameter_, verbose)
-
-    @staticmethod
-    def interrupted():
-        """
-        Returns true if the process received a SIGINT or SIGTERM signal.
-It is good practice to use this method to exit any infinite loop
-processing messages.
-        """
-        return lib.zproc_interrupted()
 
     @staticmethod
     def test(verbose):
@@ -7028,6 +7017,10 @@ lib.zsys_handler_reset.restype = None
 lib.zsys_handler_reset.argtypes = []
 lib.zsys_catch_interrupts.restype = None
 lib.zsys_catch_interrupts.argtypes = []
+lib.zsys_is_interrupted.restype = c_bool
+lib.zsys_is_interrupted.argtypes = []
+lib.zsys_set_interrupted.restype = None
+lib.zsys_set_interrupted.argtypes = []
 lib.zsys_file_exists.restype = c_bool
 lib.zsys_file_exists.argtypes = [c_char_p]
 lib.zsys_file_modified.restype = c_int
@@ -7251,6 +7244,24 @@ Can be supressed by ZSYS_SIGHANDLER=false
 *** This is for CZMQ internal use only and may change arbitrarily ***
         """
         return lib.zsys_catch_interrupts()
+
+    @staticmethod
+    def is_interrupted():
+        """
+        Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+Does not work if ZSYS_SIGHANDLER is false and code does not call
+set interrupted on signal.
+        """
+        return lib.zsys_is_interrupted()
+
+    @staticmethod
+    def set_interrupted():
+        """
+        Set interrupted flag. This is done by default signal handler, however
+this can be handy for language bindings or cases without default
+signal handler.
+        """
+        return lib.zsys_set_interrupted()
 
     @staticmethod
     def file_exists(filename):

--- a/bindings/python_cffi/czmq_cffi/Zproc.py
+++ b/bindings/python_cffi/czmq_cffi/Zproc.py
@@ -146,14 +146,6 @@ class Zproc(object):
         """
         utils.lib.zproc_set_verbose(self._p, verbose)
 
-    def interrupted():
-        """
-        Returns true if the process received a SIGINT or SIGTERM signal.
-        It is good practice to use this method to exit any infinite loop
-        processing messages.
-        """
-        return utils.lib.zproc_interrupted()
-
     def test(verbose):
         """
         Self test of this class.

--- a/bindings/python_cffi/czmq_cffi/Zsys.py
+++ b/bindings/python_cffi/czmq_cffi/Zsys.py
@@ -87,6 +87,22 @@ class Zsys(object):
         """
         utils.lib.zsys_catch_interrupts()
 
+    def is_interrupted():
+        """
+        Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+        Does not work if ZSYS_SIGHANDLER is false and code does not call
+        set interrupted on signal.
+        """
+        return utils.lib.zsys_is_interrupted()
+
+    def set_interrupted():
+        """
+        Set interrupted flag. This is done by default signal handler, however
+        this can be handy for language bindings or cases without default
+        signal handler.
+        """
+        utils.lib.zsys_set_interrupted()
+
     def file_exists(filename):
         """
         Return 1 if file exists, else zero

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -2337,12 +2337,6 @@ void
 void
     zproc_set_verbose (zproc_t *self, bool verbose);
 
-// Returns true if the process received a SIGINT or SIGTERM signal.
-// It is good practice to use this method to exit any infinite loop
-// processing messages.
-bool
-    zproc_interrupted (void);
-
 // Self test of this class.
 void
     zproc_test (bool verbose);
@@ -3498,6 +3492,18 @@ void
 // *** This is for CZMQ internal use only and may change arbitrarily ***
 void
     zsys_catch_interrupts (void);
+
+// Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+// Does not work if ZSYS_SIGHANDLER is false and code does not call
+// set interrupted on signal.
+bool
+    zsys_is_interrupted (void);
+
+// Set interrupted flag. This is done by default signal handler, however
+// this can be handy for language bindings or cases without default
+// signal handler.
+void
+    zsys_set_interrupted (void);
 
 // Return 1 if file exists, else zero
 bool

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -128,14 +128,6 @@ QObject* QmlZproc::qmlAttachedProperties(QObject* object) {
 
 
 ///
-//  Returns true if the process received a SIGINT or SIGTERM signal.
-//  It is good practice to use this method to exit any infinite loop
-//  processing messages.
-bool QmlZprocAttached::interrupted () {
-    return zproc_interrupted ();
-};
-
-///
 //  Self test of this class.
 void QmlZprocAttached::test (bool verbose) {
     zproc_test (verbose);

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -102,11 +102,6 @@ public:
     };
 
 public slots:
-    //  Returns true if the process received a SIGINT or SIGTERM signal.
-    //  It is good practice to use this method to exit any infinite loop
-    //  processing messages.
-    bool interrupted ();
-
     //  Self test of this class.
     void test (bool verbose);
 

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -93,6 +93,22 @@ void QmlZsysAttached::catchInterrupts () {
 };
 
 ///
+//  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+//  Does not work if ZSYS_SIGHANDLER is false and code does not call
+//  set interrupted on signal.
+bool QmlZsysAttached::isInterrupted () {
+    return zsys_is_interrupted ();
+};
+
+///
+//  Set interrupted flag. This is done by default signal handler, however
+//  this can be handy for language bindings or cases without default
+//  signal handler.
+void QmlZsysAttached::setInterrupted () {
+    zsys_set_interrupted ();
+};
+
+///
 //  Return 1 if file exists, else zero
 bool QmlZsysAttached::fileExists (const QString &filename) {
     return zsys_file_exists (filename.toUtf8().data());

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -89,6 +89,16 @@ public slots:
     //  *** This is for CZMQ internal use only and may change arbitrarily ***
     void catchInterrupts ();
 
+    //  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+    //  Does not work if ZSYS_SIGHANDLER is false and code does not call
+    //  set interrupted on signal.
+    bool isInterrupted ();
+
+    //  Set interrupted flag. This is done by default signal handler, however
+    //  this can be handy for language bindings or cases without default
+    //  signal handler.
+    void setInterrupted ();
+
     //  Return 1 if file exists, else zero
     bool fileExists (const QString &filename);
 

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -170,16 +170,6 @@ void QZproc::setVerbose (bool verbose)
 }
 
 ///
-//  Returns true if the process received a SIGINT or SIGTERM signal.
-//  It is good practice to use this method to exit any infinite loop
-//  processing messages.
-bool QZproc::interrupted ()
-{
-    bool rv = zproc_interrupted ();
-    return rv;
-}
-
-///
 //  Self test of this class.
 void QZproc::test (bool verbose)
 {

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -83,11 +83,6 @@ public:
     //  set verbose mode
     void setVerbose (bool verbose);
 
-    //  Returns true if the process received a SIGINT or SIGTERM signal.
-    //  It is good practice to use this method to exit any infinite loop
-    //  processing messages.
-    static bool interrupted ();
-
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -110,6 +110,26 @@ void QZsys::catchInterrupts ()
 }
 
 ///
+//  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+//  Does not work if ZSYS_SIGHANDLER is false and code does not call
+//  set interrupted on signal.
+bool QZsys::isInterrupted ()
+{
+    bool rv = zsys_is_interrupted ();
+    return rv;
+}
+
+///
+//  Set interrupted flag. This is done by default signal handler, however
+//  this can be handy for language bindings or cases without default
+//  signal handler.
+void QZsys::setInterrupted ()
+{
+    zsys_set_interrupted ();
+
+}
+
+///
 //  Return 1 if file exists, else zero
 bool QZsys::fileExists (const QString &filename)
 {

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -66,6 +66,16 @@ public:
     //  *** This is for CZMQ internal use only and may change arbitrarily ***
     static void catchInterrupts ();
 
+    //  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+    //  Does not work if ZSYS_SIGHANDLER is false and code does not call
+    //  set interrupted on signal.
+    static bool isInterrupted ();
+
+    //  Set interrupted flag. This is done by default signal handler, however
+    //  this can be handy for language bindings or cases without default
+    //  signal handler.
+    static void setInterrupted ();
+
     //  Return 1 if file exists, else zero
     static bool fileExists (const QString &filename);
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -533,7 +533,6 @@ module CZMQ
       attach_function :zproc_actor, [:pointer], :pointer, **opts
       attach_function :zproc_kill, [:pointer, :int], :void, **opts
       attach_function :zproc_set_verbose, [:pointer, :bool], :void, **opts
-      attach_function :zproc_interrupted, [], :bool, **opts
       attach_function :zproc_test, [:bool], :void, **opts
 
       require_relative 'ffi/zproc'
@@ -748,6 +747,8 @@ module CZMQ
       attach_function :zsys_handler_set, [:pointer], :void, **opts
       attach_function :zsys_handler_reset, [], :void, **opts
       attach_function :zsys_catch_interrupts, [], :void, **opts
+      attach_function :zsys_is_interrupted, [], :bool, **opts
+      attach_function :zsys_set_interrupted, [], :void, **opts
       attach_function :zsys_file_exists, [:string], :bool, **opts
       attach_function :zsys_file_modified, [:string], :pointer, **opts
       attach_function :zsys_file_mode, [:string], :int, **opts

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -288,16 +288,6 @@ module CZMQ
         result
       end
 
-      # Returns true if the process received a SIGINT or SIGTERM signal.
-      # It is good practice to use this method to exit any infinite loop
-      # processing messages.
-      #
-      # @return [Boolean]
-      def self.interrupted()
-        result = ::CZMQ::FFI.zproc_interrupted()
-        result
-      end
-
       # Self test of this class.
       #
       # @param verbose [Boolean]

--- a/bindings/ruby/lib/czmq/ffi/zsys.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsys.rb
@@ -197,6 +197,26 @@ module CZMQ
         result
       end
 
+      # Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+      # Does not work if ZSYS_SIGHANDLER is false and code does not call
+      # set interrupted on signal.
+      #
+      # @return [Boolean]
+      def self.is_interrupted()
+        result = ::CZMQ::FFI.zsys_is_interrupted()
+        result
+      end
+
+      # Set interrupted flag. This is done by default signal handler, however
+      # this can be handy for language bindings or cases without default
+      # signal handler.
+      #
+      # @return [void]
+      def self.set_interrupted()
+        result = ::CZMQ::FFI.zsys_set_interrupted()
+        result
+      end
+
       # Return 1 if file exists, else zero
       #
       # @param filename [String, #to_s, nil]

--- a/include/zproc.h
+++ b/include/zproc.h
@@ -135,13 +135,6 @@ CZMQ_EXPORT void
     zproc_set_verbose (zproc_t *self, bool verbose);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Returns true if the process received a SIGINT or SIGTERM signal.
-//  It is good practice to use this method to exit any infinite loop
-//  processing messages.
-CZMQ_EXPORT bool
-    zproc_interrupted (void);
-
-//  *** Draft method, for development use, may change without warning ***
 //  Self test of this class.
 CZMQ_EXPORT void
     zproc_test (bool verbose);

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -404,6 +404,20 @@ CZMQ_EXPORT void
 
 #ifdef CZMQ_BUILD_DRAFT_API
 //  *** Draft method, for development use, may change without warning ***
+//  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+//  Does not work if ZSYS_SIGHANDLER is false and code does not call
+//  set interrupted on signal.
+CZMQ_EXPORT bool
+    zsys_is_interrupted (void);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set interrupted flag. This is done by default signal handler, however
+//  this can be handy for language bindings or cases without default
+//  signal handler.
+CZMQ_EXPORT void
+    zsys_set_interrupted (void);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Configure the threshold value of filesystem object age per st_mtime
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -270,6 +270,20 @@ CZMQ_PRIVATE char *
     zstr_str (void *source);
 
 //  *** Draft method, defined for internal use only ***
+//  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+//  Does not work if ZSYS_SIGHANDLER is false and code does not call
+//  set interrupted on signal.
+CZMQ_PRIVATE bool
+    zsys_is_interrupted (void);
+
+//  *** Draft method, defined for internal use only ***
+//  Set interrupted flag. This is done by default signal handler, however
+//  this can be handy for language bindings or cases without default
+//  signal handler.
+CZMQ_PRIVATE void
+    zsys_set_interrupted (void);
+
+//  *** Draft method, defined for internal use only ***
 //  Configure the threshold value of filesystem object age per st_mtime
 //  that should elapse until we consider that object "stable" at the
 //  current zclock_time() moment.

--- a/src/zproc.c
+++ b/src/zproc.c
@@ -836,17 +836,6 @@ zproc_set_verbose (zproc_t *self, bool verbose) {
 }
 
 //  --------------------------------------------------------------------------
-//  Returns true if the process received a SIGINT or SIGTERM signal.
-//  It is good practice to use this method to exit any infinite loop
-//  processing messages.
-
-bool
-zproc_interrupted (void)
-{
-    return zsys_interrupted == 1;
-}
-
-//  --------------------------------------------------------------------------
 //  Self test of this class.
 
 void

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1508,6 +1508,30 @@ zsys_max_msgsz (void)
 }
 
 
+#ifdef CZMQ_BUILD_DRAFT_API
+//  --------------------------------------------------------------------------
+//  *** Draft method, for development use, may change without warning ***
+//  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+//  Does not work if ZSYS_SIGHANDLER is false and code does not call
+//  set interrupted on signal.
+CZMQ_EXPORT bool
+    zsys_is_interrupted (void)
+{
+    return zsys_interrupted != 0;
+}
+
+//  --------------------------------------------------------------------------
+//  *** Draft method, for development use, may change without warning ***
+//  Set interrupted flag. This is done by default signal handler, however
+//  this can be handy for language bindings or cases without default
+//  signal handler.
+CZMQ_EXPORT void
+    zsys_set_interrupted (void)
+{
+    zctx_interrupted = 1;
+    zsys_interrupted = 1;
+}
+
 //  --------------------------------------------------------------------------
 //  Configure the threshold value of filesystem object age per st_mtime
 //  that should elapse until we consider that object "stable" at the
@@ -1547,6 +1571,7 @@ int64_t
     return s_file_stable_age_msec;
 }
 
+#endif // CZMQ_BUILD_DRAFT_API
 
 //  --------------------------------------------------------------------------
 //  Configure the default linger timeout in msecs for new zsock instances.
@@ -1986,7 +2011,6 @@ zsys_debug (const char *format, ...)
     zstr_free (&string);
 }
 
-
 //  --------------------------------------------------------------------------
 //  Selftest
 
@@ -2018,10 +2042,12 @@ zsys_test (bool verbose)
         freen (hostname);
         zsys_info ("system limit is %zu ZeroMQ sockets", zsys_socket_limit ());
     }
+#ifdef CZMQ_BUILD_DRAFT_API
     zsys_set_file_stable_age_msec (5123);
     assert (zsys_file_stable_age_msec() == 5123);
     zsys_set_file_stable_age_msec (-1);
     assert (zsys_file_stable_age_msec() == 5123);
+#endif // CZMQ_BUILD_DRAFT_API
     zsys_set_linger (0);
     zsys_set_sndhwm (1000);
     zsys_set_rcvhwm (1000);


### PR DESCRIPTION
Solution: draft two new `zsys` methods, clean `zproc` class completely and regenerate language bindings to get new methods there.

Follow up of https://github.com/zeromq/czmq/pull/1855

cc @bluca 