### PR TITLE
fix windows build: explicitly use non unicode versions for CreateProc…

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -513,7 +513,7 @@ s_zproc_execve (zproc_t *self)
 {
     assert (self);
 #if defined(__WINDOWS__)
-    STARTUPINFO siStartInfo;
+    STARTUPINFOA siStartInfo;
     ZeroMemory (&siStartInfo, sizeof (siStartInfo));
 
     char *commandline = strdup ((char *)zlist_first (self->args));
@@ -529,7 +529,7 @@ s_zproc_execve (zproc_t *self)
 
     siStartInfo.cb = sizeof (siStartInfo);
     zsock_signal (zpair_write (self->execpair), 0);
-    self->running = CreateProcess(
+    self->running = CreateProcessA(
         NULL,          // app name
         commandline,   // command line
         NULL,          // process security attributes


### PR DESCRIPTION
…ess and STARTUPINFO

# Pull Request Notice

Compiling with Visual Studio 2015 fails in function s_zproc_execve in file zproc.c.
As the _UNICODE preprocessor macro is defined, CreateProcess and STARTUPINFO automatically resolve
to their unicode versions CreateProcessW and STARTUPINFOW. However CreateProcessW does not work 
with the "commandline" parameter of type char*.
Explicitly using the non-unicode version of CreateProcess and STARTUPINFO fixes the comilation error.