### PR TITLE
Remove CZMQ_EXPORT for function definitions

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -311,7 +311,7 @@ zproc_set_args (zproc_t *self, zlist_t **args_p) {
 
 //  Setup the command line arguments, the first item must be an (absolute) filename
 //  to run. Variadic function, must be NULL terminated.
-CZMQ_EXPORT void
+void
     zproc_set_argsx (zproc_t *self, const char *args, ...)
 {
     assert (self);

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1513,7 +1513,7 @@ zsys_max_msgsz (void)
 //  Check if default interrupt handler of Ctrl-C or SIGTERM was called.
 //  Does not work if ZSYS_SIGHANDLER is false and code does not call
 //  set interrupted on signal.
-CZMQ_EXPORT bool
+bool
     zsys_is_interrupted (void)
 {
     return zsys_interrupted != 0;
@@ -1524,7 +1524,7 @@ CZMQ_EXPORT bool
 //  Set interrupted flag. This is done by default signal handler, however
 //  this can be handy for language bindings or cases without default
 //  signal handler.
-CZMQ_EXPORT void
+void
     zsys_set_interrupted (void)
 {
     zctx_interrupted = 1;


### PR DESCRIPTION
When trying to build on windows with the draft-api disabled, compilation fails for multiple reasons.

- some functions definitions in zsys.c have the CZMQ_EXPORT macro which conflicts in non-draft builds with the CZMQ_PRIVATE declaration of these functions in czmq_classes.h
- declaration of structs ztrie_t, zproc_t, zargs_t and ztimerset_t are disables in czmq_library.h for non-draft builds causing comilation errors in ztrie.c, zproc.c, zargs.c and ztimerset.c

For the second point I disabled the respective classes completely using the CZMQ_BUILD_DRAFT_API macro as they were not declared as private classes in non-draft builds.
