### PR TITLE
clang-format custom target failes to build if building with libzmq

### DIFF
--- a/builds/cmake/Modules/ClangFormat.cmake
+++ b/builds/cmake/Modules/ClangFormat.cmake
@@ -19,7 +19,7 @@ if("${CLANG_FORMAT}" STREQUAL "")
 endif()
 
 add_custom_target(
-        clang-format
+        clang-format-czmq
         COMMAND ${CLANG_FORMAT} -style=file -i ${ALL_SOURCE_FILES}
 )
 
@@ -31,14 +31,14 @@ endfunction()
 configure_file(builds/cmake/clang-format-check.sh.in clang-format-check.sh @ONLY)
 
 add_custom_target(
-        clang-format-check
+        clang-format-czmq-check
         COMMAND chmod +x clang-format-check.sh
         COMMAND ./clang-format-check.sh
         COMMENT "Checking correct formatting according to .clang-format file using ${CLANG_FORMAT}"
 )
 
 add_custom_target(
-        clang-format-diff
+        clang-format-czmq-diff
         COMMAND ${CLANG_FORMAT} -style=file -i ${ALL_SOURCE_FILES}
         COMMAND git diff ${ALL_SOURCE_FILES}
         COMMENT "Formatting with clang-format (using ${CLANG_FORMAT}) and showing differences with latest commit"


### PR DESCRIPTION
Problem:
When building both libzmq and czmq with cmake, cmake fails because of the clang-format target being defined twice.  This PR renames the clang-format target to clang-format-czmq.  You can then make target with make clang-format-czmq.

(Also note that running clang-format target seems to break the code - it does not seem like this target is maintained or used for code checkins so maybe should remove)