### PR TITLE
Support zmq zero copy option

### DIFF
--- a/api/zsys.api
+++ b/api/zsys.api
@@ -316,6 +316,18 @@
         <return type = "integer" />
     </method>
 
+    <method name = "set zero copy recv" singleton = "1" state = "draft" >
+        Configure whether to use zero copy strategy in libzmq. If the environment
+        variable ZSYS_ZERO_COPY_RECV is defined, that provides the default.
+        Otherwise the default is 1.
+        <argument name = "zero copy" type = "integer" />
+    </method>
+
+    <method name = "zero copy recv" singleton = "1" state = "draft" >
+        Return ZMQ_ZERO_COPY_RECV option.
+        <return type = "integer" />
+    </method>
+
     <method name = "set file stable age msec" singleton = "1" state = "draft">
         Configure the threshold value of filesystem object age per st_mtime
         that should elapse until we consider that object "stable" at the

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -253,6 +253,17 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int
     zsys_max_msgsz (void);
 
+//  Configure whether to use zero copy strategy in libzmq. If the environment
+//  variable ZSYS_ZERO_COPY_RECV is defined, that provides the default.
+//  Otherwise the default is 1.
+CZMQ_EXPORT void
+    zsys_set_zero_copy_recv(int zero_copy);
+
+//  --------------------------------------------------------------------------
+//  Return whether the zero copy strategy in libzmq is tuened on.
+CZMQ_EXPORT int
+    zsys_zero_copy_recv();
+
 //  Configure the default linger timeout in msecs for new zsock instances.
 //  You can also set this separately on each zsock_t instance. The default
 //  linger time is zero, i.e. any pending messages will be dropped. If the

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -99,6 +99,7 @@ static char *s_logident = NULL;     //  ZSYS_LOGIDENT=
 static FILE *s_logstream = NULL;    //  ZSYS_LOGSTREAM=stdout/stderr
 static bool s_logsystem = false;    //  ZSYS_LOGSYSTEM=true/false
 static zsock_t *s_logsender = NULL;    //  ZSYS_LOGSENDER=
+static int s_zero_copy_recv = 1;    // ZSYS_ZERO_COPY_RECV=1
 
 //  Track number of open sockets so we can zmq_term() safely
 static size_t s_open_sockets = 0;
@@ -156,6 +157,9 @@ zsys_init (void)
 
     if (getenv ("ZSYS_MAX_MSGSZ"))
         s_max_msgsz = atoi (getenv ("ZSYS_MAX_MSGSZ"));
+
+    if (getenv ("ZSYS_ZERO_COPY_RECV"))
+        s_zero_copy_recv = atoi (getenv ("ZSYS_ZERO_COPY_RECV"));
 
     if (getenv ("ZSYS_FILE_STABLE_AGE_MSEC"))
         s_file_stable_age_msec = atoi (getenv ("ZSYS_FILE_STABLE_AGE_MSEC"));
@@ -236,6 +240,10 @@ zsys_init (void)
         zsys_set_logsender (getenv ("ZSYS_LOGSENDER"));
 
     zsys_set_max_msgsz (s_max_msgsz);
+
+#if defined ZMQ_ZERO_COPY_RECV
+    zmq_ctx_set (s_process_ctx, ZMQ_ZERO_COPY_RECV, s_zero_copy_recv);
+#endif
 
     zsys_set_file_stable_age_msec (s_file_stable_age_msec);
 
@@ -1491,6 +1499,37 @@ zsys_set_max_msgsz (int max_msgsz)
     ZMUTEX_UNLOCK (s_mutex);
 }
 
+//  --------------------------------------------------------------------------
+//  Configure whether to use zero copy strategy in libzmq. If the environment
+//  variable ZSYS_ZERO_COPY_RECV is defined, that provides the default.
+//  Otherwise the default is 1.
+
+void
+zsys_set_zero_copy_recv(int zero_copy)
+{
+    zsys_init ();
+    ZMUTEX_LOCK (s_mutex);
+    s_zero_copy_recv = zero_copy;
+#if defined (ZMQ_ZERO_COPY_RECV)
+    zmq_ctx_set (s_process_ctx, ZMQ_ZERO_COPY_RECV, s_zero_copy_recv);
+#endif
+    ZMUTEX_UNLOCK (s_mutex);
+}
+
+//  --------------------------------------------------------------------------
+//  Return ZMQ_ZERO_COPY_RECV option.
+int
+zsys_zero_copy_recv()
+{
+    zsys_init ();
+    ZMUTEX_LOCK (s_mutex);
+#if defined (ZMQ_ZERO_COPY_RECV)
+    s_zero_copy_recv = zmq_ctx_get (s_process_ctx, ZMQ_ZERO_COPY_RECV);
+#endif
+    ZMUTEX_UNLOCK (s_mutex);
+    return s_zero_copy_recv;
+}
+
 
 //  --------------------------------------------------------------------------
 //  Return maximum message size.
@@ -2054,6 +2093,10 @@ zsys_test (bool verbose)
     zsys_set_ipv6 (0);
     zsys_set_thread_priority (-1);
     zsys_set_thread_sched_policy (-1);
+    zsys_set_zero_copy_recv(0);
+    assert (0 == zsys_zero_copy_recv());
+    zsys_set_zero_copy_recv(1);
+    assert (1 == zsys_zero_copy_recv());
 
     //  Test pipe creation
     zsock_t *pipe_back;


### PR DESCRIPTION
This PR adds support for the new ZMQ_ZERO_COPY_RECV option of libzmq.

It is needed because zmq contexts are handled internally by czmq. 