### PR TITLE
Problem: tests hang due to ZMQ_POLL_MSEC used with zpoller and zmq_poller

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -618,7 +618,7 @@ zbeacon_test (bool verbose)
         long timeout = (long) (stop_at - zclock_mono ());
         if (timeout < 0)
             timeout = 0;
-        void *which = zpoller_wait (poller, timeout * ZMQ_POLL_MSEC);
+        void *which = zpoller_wait (poller, timeout);
         if (which) {
             assert (which == node1);
             char *ipaddress, *received;

--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -227,7 +227,7 @@ zpoller_wait (zpoller_t *self, int timeout)
 
 #ifdef ZMQ_HAVE_POLLER
     zmq_poller_event_t event;
-    if (!zmq_poller_wait (self->zmq_poller, &event, timeout * ZMQ_POLL_MSEC))
+    if (!zmq_poller_wait (self->zmq_poller, &event, timeout))
         return event.user_data;
     else
     if (errno == ETIMEDOUT || errno == EAGAIN)


### PR DESCRIPTION
Solution: remove it. It is a backward-compat macro to use only with
the zmq_poll API, which used to take nanoseconds until libzmq 3.x
where it was changed to milliseconds.
In the zbeacon test it was used with zpoller_wait, which itself used it,
which means that when building with libzmq 2.x the timeout was twice
multiplied by 1000 and caused the test to hang.
Also remove it from the zmq_poller usage, which is new and has always
taken milliseconds.

Fixes #1825