### PR TITLE
Problems: zproject regen generates broken JNI code and CI complains, packages not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,9 @@ matrix:
 # temporary disabled, does not work
 #  - env: BUILD_TYPE=docs
 #    os: linux
+  # until https://github.com/zeromq/zproject/issues/947 is solved
+  allow_failures:
+  - env: BUILD_TYPE=check_zproject
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,8 @@ addons:
     - xmlto
     - libsodium-dev
     - libzmq3-dev
+    - generator-scripting-language
+    - zproject
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi


### PR DESCRIPTION
Solutions: allow the regen job to fail until https://github.com/zeromq/zproject/issues/947 is fixed, and install gsl/zproject packages