### PR TITLE
Problem: can't get a copy of zconfig

### DIFF
--- a/api/zconfig.api
+++ b/api/zconfig.api
@@ -27,6 +27,14 @@
         Destroy a config item and all its children
     </destructor>
 
+    <method name = "dup" state = "draft">
+        Create copy of zconfig, caller MUST free the value
+        Create copy of config, as new zconfig object. Returns a fresh zconfig_t
+        object. If config is null, or memory was exhausted, returns null.
+        <return type = "zconfig" fresh = "1" />
+    </method>
+
+
     <method name = "name">
         Return name of config item
         <return type = "string" mutable = "1" />

--- a/include/zconfig.h
+++ b/include/zconfig.h
@@ -169,6 +169,14 @@ CZMQ_EXPORT void
 
 #ifdef CZMQ_BUILD_DRAFT_API
 //  *** Draft method, for development use, may change without warning ***
+//  Create copy of zconfig, caller MUST free the value
+//  Create copy of config, as new zconfig object. Returns a fresh zconfig_t
+//  object. If config is null, or memory was exhausted, returns null.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT zconfig_t *
+    zconfig_dup (zconfig_t *self);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Destroy subtree (all children)
 CZMQ_EXPORT void
     zconfig_remove_subtree (zconfig_t *self);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -94,6 +94,14 @@ CZMQ_PRIVATE zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 
 //  *** Draft method, defined for internal use only ***
+//  Create copy of zconfig, caller MUST free the value
+//  Create copy of config, as new zconfig object. Returns a fresh zconfig_t
+//  object. If config is null, or memory was exhausted, returns null.
+//  Caller owns return value and must destroy it when done.
+CZMQ_PRIVATE zconfig_t *
+    zconfig_dup (zconfig_t *self);
+
+//  *** Draft method, defined for internal use only ***
 //  Destroy subtree (all children)
 CZMQ_PRIVATE void
     zconfig_remove_subtree (zconfig_t *self);

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -137,6 +137,21 @@ zconfig_destroy (zconfig_t **self_p)
     }
 }
 
+//  --------------------------------------------------------------------------
+//  Create copy of zconfig, caller MUST free the value
+//  Create copy of config, as new zconfig object. Returns a fresh zconfig_t
+//  object. If config is null, or memory was exhausted, returns null.
+zconfig_t *
+zconfig_dup (zconfig_t *self) {
+    if (self) {
+        zchunk_t *chunk = zconfig_chunk_save (self);
+        zconfig_t *ret = zconfig_chunk_load (chunk);
+        zchunk_destroy (&chunk);
+        return ret;
+    }
+    else
+        return NULL;
+}
 
 //  --------------------------------------------------------------------------
 //  Destroy node and subtree (all children)
@@ -1123,6 +1138,11 @@ zconfig_test (bool verbose)
     assert (!c);
 
     assert (streq (zconfig_get (config, "server/verbose", NULL), "true"));
+
+    zconfig_t *dup = zconfig_dup (config);
+    assert (dup);
+    assert (streq (zconfig_get (dup, "server/verbose", NULL), "true"));
+    zconfig_destroy (&dup);
 
     zconfig_destroy (&config);
 


### PR DESCRIPTION
Solution: add `zconfig_dup` method, with the same semantics wrt NULL
handling as `zmsg_dup` has.

@bluca I did not mark it as draft, I'd say `dup` methods are pretty standard in CLASS/czmq, so there is nothing surprising on this method.