### PR TITLE
[WIP] zdir.c : zdir_new() : make sure all inputs are valid

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -105,9 +105,15 @@ zdir_new (const char *path, const char *parent)
 {
     zdir_t *self = (zdir_t *) zmalloc (sizeof (zdir_t));
     assert (self);
+    assert (path);
+    assert (parent);
 
     if (parent) {
         if (streq (parent, "-")) {
+            if (streq (path, "")) {
+                zdir_destroy (&self);
+                return NULL;
+            }
             self->trimmed = true;
             self->path = strdup (path);
             if (!self->path) {


### PR DESCRIPTION
Solutions:
* check for NULL arguments before using them
* check for empty `path` when it is the full path (parent is `-`)

Notes about empty inputs to discuss (the more I look into this, the more I have no idea what we really want here)?
* empty path and empty parent implicitly means rootfs here; should it?.. actually empty parent seems not checked at all
* empty path and non-empty parent resolves into parent, this looks right
* empty parent and non-empty path resolves into a slash prefixed to path, so even a relative path becomes verbatim absolutized; is this expected?

Note: currently some tests actually pass the NULL parent value and so CI fails. Is this expected behavior (would enforcing the fix and updating tests break czmq consumer projects)? Does not seem to be well specified...