### PR TITLE
Problem: appveyor jobs are very slow

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ after_build:
   - cmd: ctest -C "%Configuration%" -V
   - cmd: cd "%Configuration%"
   - cmd: test_randof.exe -h | find "ZSYS"
-  - cmd: test_randof.exe -r 10000000 -i 300000000
+  - cmd: test_randof.exe -r 1000000 -i 30000000
 
 test:
   none


### PR DESCRIPTION
Solution: reduce the number of randof tests by one order to save 3+ minutes (~40% of runtime)