### PR TITLE
Problem: debian-kfreebsd build broken

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -695,10 +695,7 @@ char *if_indextoname (unsigned int ifindex, char *ifname);
 #if defined (__UTYPE_OSX) && !defined (HAVE_UUID)
 #   define HAVE_UUID 1
 #endif
-#if defined (__UTYPE_FREEBSD) && !defined (HAVE_UUID)
-#   define HAVE_UUID 1
-#endif
-#if defined (HAVE_UUID)
+#if defined (HAVE_UUID) || defined (__UTYPE_FREEBSD)
 #   if defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD) || defined(__UTYPE_OPENBSD)
 #       include <uuid.h>
 #   elif defined __UTYPE_HPUX

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -47,7 +47,7 @@ zuuid_new (void)
     assert (sizeof (uuid) == ZUUID_LEN);
     UuidCreate (&uuid);
     zuuid_set (self, (byte *) &uuid);
-#elif defined (HAVE_UUID) && !defined (__UTYPE_FREEBSD)
+#elif defined (HAVE_UUID)
     uuid_t uuid;
     assert (sizeof (uuid) == ZUUID_LEN);
     uuid_generate (uuid);


### PR DESCRIPTION
Solution: adjust the UUID defines so that libuuid is correctly used
on debian-kfreebsd, but not on other BSDs