### PR TITLE
Problem: We can't wait for process with timeout

### DIFF
--- a/include/zproc.h
+++ b/include/zproc.h
@@ -122,9 +122,10 @@ CZMQ_EXPORT bool
     zproc_running (zproc_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
-//  wait or poll process status, return return code
+//  wait or poll process status, return return code or ZPROC_RUNNING
+//  The timeout should be zero or greater, or -1 to wait indefinitely.
 CZMQ_EXPORT int
-    zproc_wait (zproc_t *self, bool hang);
+    zproc_wait (zproc_t *self, int timeout);
 
 //  *** Draft method, for development use, may change without warning ***
 //  return internal actor, useful for the polling if process died
@@ -135,6 +136,12 @@ CZMQ_EXPORT void *
 //  send a signal to the subprocess
 CZMQ_EXPORT void
     zproc_kill (zproc_t *self, int signal);
+
+//  *** Draft method, for development use, may change without warning ***
+//  send SIGTERM signal to the subprocess, wait for grace period and
+//  eventually send SIGKILL
+CZMQ_EXPORT void
+    zproc_shutdown (zproc_t *self, int timeout);
 
 //  *** Draft method, for development use, may change without warning ***
 //  set verbose mode

--- a/src/zsp.c
+++ b/src/zsp.c
@@ -30,6 +30,7 @@ int main (int argc, char *argv [])
     bool use_stderr = false;
     bool use_stdout = false;
     bool abrt = false;
+    int quit = 0;
 
     char *message = NULL;
 
@@ -44,6 +45,7 @@ int main (int argc, char *argv [])
             puts ("  --stdout / -o          output on stdout");
             puts ("  --abrt / -a            crash with SIGABRT on start");
             puts ("  --verbose / -v         verbose mode");
+            puts ("  --quit / -q X          quit after X seconds");
             puts ("  --help / -h            this information");
             return 0;
         }
@@ -67,6 +69,12 @@ int main (int argc, char *argv [])
         if (streq (argv [argn], "--abrt")
         ||  streq (argv [argn], "-a"))
             abrt = true;
+        else
+        if (streq (argv [argn], "--quit")
+        ||  streq (argv [argn], "-q")) {
+            quit = atoi (argv [argn + 1]) * 1000;
+            ++argn;
+        }
         else
         if (argv [argn][0] == '-') {
             printf ("Unknown option: %s\n", argv [argn]);
@@ -104,6 +112,7 @@ int main (int argc, char *argv [])
     }
 
     //  Insert main code here
+    int start = zclock_mono ();
     while (!zsys_interrupted) {
 #if ! defined (__WINDOWS__)
         if (use_stdin) {
@@ -126,6 +135,7 @@ int main (int argc, char *argv [])
             fprintf (stdout, "%s\n", message);
 
         zclock_sleep (50);
+        if (quit && zclock_mono () - start > quit) break;
     }
 
     zfile_destroy (&stdinf);


### PR DESCRIPTION
Solution: Rework zproc_wait to use timeout, use alarm () to exit from waitpid call
Create zproc_shutdown function that does the typical usecase TERM, wait, KILL

