### PR TITLE
Problem: unused variable in zargs

### DIFF
--- a/src/zargs.c
+++ b/src/zargs.c
@@ -222,7 +222,6 @@ zargs_has (zargs_t *self, const char *name) {
 bool
 zargs_hasx (zargs_t *self, const char *name, ...) {
     assert (self);
-    const char *ret = NULL;
     va_list args;
     va_start (args, name);
     while (name) {


### PR DESCRIPTION
Solution: drop the variable