### PR TITLE
Problem: SIGKILL is not defined on windows

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -919,9 +919,11 @@ zproc_shutdown (zproc_t *self, int timeout)
 
     zproc_kill (self, SIGTERM);
     zproc_wait (self, timeout);
+#if ! defined (__WINDOWS__)
     if (zproc_running (self)) {
         zproc_kill (self, SIGKILL);
     }
+#endif
 }
 
 void


### PR DESCRIPTION
Solution: Do not send SIGKILL on windows. SIGTERM actually behaves
as SIGKILL now so there is no issue here.
