### PR TITLE
Problem: Windows build broken by non-existing macro

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -998,7 +998,7 @@ zsys_udp_new (bool routable)
     //  On Windows, preventing sockets to be inherited by child processes.
 #if defined (__WINDOWS__) && defined (HANDLE_FLAG_INHERIT)
     BOOL brc = SetHandleInformation ((HANDLE) udpsock, HANDLE_FLAG_INHERIT, 0);
-    win_assert (brc);
+    assert (brc);
 #endif
 
     //  Ask operating system for broadcast permissions on socket


### PR DESCRIPTION
Solution: simply call assert - win_assert is an internal macro of libzmq