### PR TITLE
Problem: zproc creates zombie process on SIGTERM

### DIFF
--- a/src/zproc.c
+++ b/src/zproc.c
@@ -538,8 +538,6 @@ static int
 s_zproc_alive (zloop_t *loop, int timer_id, void *args)
 {
     zproc_t *self = (zproc_t*) args;
-    if (zsys_interrupted)
-        return -1;
     if (! zproc_running (self))
         return 0;
 #if defined (__WINDOWS__)
@@ -752,6 +750,10 @@ s_zproc_actor (zsock_t *pipe, void *args)
     zsock_signal (pipe, 0);
     zloop_start (loop);
     zloop_destroy (&loop);
+    while (zproc_running (self)) {
+        zclock_sleep (500);
+        s_zproc_alive (NULL, -1, self);
+    }
     zsock_signal (pipe, 0);
 }
 


### PR DESCRIPTION
Solution: When SIGTERM is received in app and zsys_interrupted
is set zproc never reads exit code of the process and it waits full
timeout. Solution is to ask for sub-process exit code and quit.
