### PR TITLE
Fixed the warning on Windows, start should use int64_t type.

### DIFF
--- a/src/zsp.c
+++ b/src/zsp.c
@@ -112,7 +112,7 @@ int main (int argc, char *argv [])
     }
 
     //  Insert main code here
-    int start = zclock_mono ();
+    int64_t start = zclock_mono ();
     while (!zsys_interrupted) {
 #if ! defined (__WINDOWS__)
         if (use_stdin) {


### PR DESCRIPTION
Problem: Warning on compilation by Windows Visual Studio 2015.

Solution: Use int64_t as zclock_mono().
