### PR TITLE
Regenerate CI build recipes with current zproject

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # This is a skeleton created by zproject.
 # You can add hand-written code here.
-
 # disables auto CRLF conversion for all files; create the file correctly and it will be allright
 * -text

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ src/czmq_selftest
 *.app
 core
 
- # Distcheck workspace and archives
+# Distcheck workspace and archives
 czmq-*/
 czmq-*.tar.gz
 czmq-*.zip
@@ -75,8 +75,7 @@ install_manifest.txt
 Testing/
 
 # Repositories downloaded by CI integration scripts
-libzmq/
-libcurl/
+tmp-deps/
 
 # Travis build area
 tmp/
@@ -105,7 +104,7 @@ src/app/gen/
 src/app/obj/
 src/app/local.properties
 
-# Android -dependencies
+# Android - dependencies
 src/app/jni/output
 
 # Python build directory
@@ -126,6 +125,9 @@ bindings/qt/selftest/selftest
 *.swp
 *.bak
 .test*
+
+# Netbeans directory
+nbproject/
 
 # editor backups
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,10 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_devtools
-        - *pkg_deps_zproject
+# Do not use packaged zproject as it may be stale if OBS lags,
+# use a fresh build every time, this one is cheap
+###        - *pkg_deps_zproject
+        - generator-scripting-language
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
 # For non-cmake users, there is an autotools solution with a bit more overhead
 # to have dependencies ready and pass configure script before making this check).

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,11 @@ pkg_deps_prereqs: &pkg_deps_prereqs
 # NOTE: Currently the shell script does support use of packages or checkout
 # of latest github code for these tools - but only from zeromq org repos,
 # no forks/branches.
+# NOTE: We do not use packaged zproject as it may be stale if OBS lags,
+# use a fresh build every time, this one is cheap.
 pkg_deps_zproject: &pkg_deps_zproject
     - generator-scripting-language
-    - zproject
+#    - zproject
 
 pkg_deps_doctools: &pkg_deps_doctools
     - asciidoc
@@ -183,10 +185,7 @@ matrix:
         sources: *pkg_src_zeromq_ubuntu14
         packages:
         - *pkg_deps_devtools
-# Do not use packaged zproject as it may be stale if OBS lags,
-# use a fresh build every time, this one is cheap
-###        - *pkg_deps_zproject
-        - generator-scripting-language
+        - *pkg_deps_zproject
   - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
 # For non-cmake users, there is an autotools solution with a bit more overhead
 # to have dependencies ready and pass configure script before making this check).

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,47 @@
 # Travis CI script
 # This is a skeleton created by zproject.
 # You can add hand-written code here.
+#
+# NOTE: Take care if regenerating this file, it was customized
+#   after generation, be sure to review and keep those changes.
+#   The `git difftool` is your friend here.
 
-language: c
+language:
+- c
+
+cache:
+- ccache
 
 os:
 - linux
 - osx
 
+### Note to use ubuntu14 repos below, if the default distro is trusty
+#dist:
+#- xenial
 dist: trusty
+
+#services:
+#- docker
 
 sudo: false
 
 compiler:
 - gcc
 
+# Set CI_TIME=true to enable build-step profiling in Travis
+# Set CI_TRACE=true to enable shell script tracing in Travis
+# Set CI_CONFIG_QUIET=true to enable "configure --quiet" (only report stderr)
+# Set CI_REQUIRE_GOOD_GITIGNORE=false to NOT fail if "git status -s" is not clean
+# Set CI_REQUIRE_GOOD_CLANG_FORMAT=true to fail if "clang-format" check is not clean
 env:
   global:
+    - CI_TIME=false
+    - CI_TRACE=false
+    - CI_CONFIG_QUIET=true
+    - CI_REQUIRE_GOOD_GITIGNORE=false
+    - CI_REQUIRE_GOOD_CLANG_FORMAT=false
+    - CI_TEST_DISTCHECK=true
     # Note: Secure variables must be global!
     #
     # Wikidot upload credentials.
@@ -33,37 +58,102 @@ env:
     #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
     # 2) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
     #    encrypt them with travis encrypt --org -r <org>/<repo> OBS_<STABLE|DRAFT>_TOKEN="<token>"
-    # 3) Uncomment the "secure" lines and paste the encrypted tokens
+    # 3) Uncomment the three "secure" lines and paste the three generated hashed
+    #    strings, which include each token's name, as parameters
     - secure: O0nI2RARxdXndopjlNI1EnnLvgbjbSk3+ZFuyxz2eW0zGm4/Bx7lRfQSqXnKtEGyjFsGdthVji24h5g1EQnrX0mmOvweH0tiTdfjfubnaUGMStU2DtGPOZMLE93khdwJcOsM9XeSsYK9MeTz3SYTLGsNcXDd6enOnrVygzUdmlk=
     - secure: LYZtGhy+XiKeUOLaqceeTRUZo76y2oo6f8Uv/c8Qvy9LcYueE+lDT5njXO/wUNVKt+V5TRZX/pURxo4osCB1Ax/tNoHIhcsvLzBEsjnd40MBfxvr8finBFVj4v/HOyguLMCljo4GhF4t71T+PY+Ewq5WYo3vxpKNmroZlrHp2Zg=
     - secure: lrkGh4GMacTQJPXgOTtb4PhUnMJEaiXUFXbrsVxeqZBHtFua5bX3gJ34yNkcDOhSqY6LrRJAB4NJu7qIJoh+SzoOwKtR4+pTGh86ioOswjImSNBvVnid/DVPI1w0eDPlMSeq8zESZQ4rurFqRi+gvi7oW2BIlCRrejagDErNmpY=
   matrix:
     - BUILD_TYPE=default
+    - BUILD_TYPE=default-Werror
     - BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq2-x
     - BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq3-x
     - BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq4-x
     - BUILD_TYPE=stable_zmq ZMQ_REPO=zeromq4-1
     - BUILD_TYPE=cmake
-    - BUILD_TYPE=check_zproject
     - BUILD_TYPE=bindings BINDING=python
+#   - BUILD_TYPE=check-py
+
+# Prerequisite packages provided by OS distro and used "as is"
+# NOTE: For travis, we want the pre-built libcurl4-nss-dev variant
+#      rather than a build from scratch
+pkg_deps_prereqs_distro: &pkg_deps_prereqs_distro
+    - uuid-dev
+    - libsystemd-dev
+    - liblz4-dev
+    - libcurl4-nss-dev
+
+# Prerequisite packages that may be built from source or used from
+# prebuilt packages of that source (usually not from an OS distro)
+# NOTE: For travis, we want also libsodium as a common dependency
+pkg_deps_prereqs_source: &pkg_deps_prereqs_source
+    - libsodium-dev
+    - libzmq3-dev
+#    - libcurl4-nss-dev
+
+pkg_deps_prereqs: &pkg_deps_prereqs
+    - *pkg_deps_prereqs_source
+    - *pkg_deps_prereqs_distro
+
+# NOTE: Currently the shell script does support use of packages or checkout
+# of latest github code for these tools - but only from zeromq org repos,
+# no forks/branches.
+pkg_deps_zproject: &pkg_deps_zproject
+    - generator-scripting-language
+    - zproject
+
+pkg_deps_doctools: &pkg_deps_doctools
+    - asciidoc
+    - xmlto
+
+pkg_deps_devtools: &pkg_deps_devtools
+    - git
+
+pkg_src_zeromq_ubuntu14: &pkg_src_zeromq_ubuntu14
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
+
+pkg_src_zeromq_ubuntu16: &pkg_src_zeromq_ubuntu16
+- sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/ ./'
+  key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_16.04/Release.key'
+
+# Note: refer to ubuntu16 if you use dist==xenial
+# Also note that as of early 2017, either dist==trusty or services==docker
+# is needed for C++11 support; docker envs are usually faster to start up
+addons:
+  apt:
+    sources: *pkg_src_zeromq_ubuntu14
+    packages: &pkg_deps_common
+    - *pkg_deps_devtools
+    - *pkg_deps_prereqs
 
 matrix:
-  exclude:
-  - os: osx
-    env: BUILD_TYPE=check_zproject
   include:
-  - env: BUILD_TYPE=valgrind
+  - env: BUILD_TYPE=default-with-docs
     os: linux
+#    dist: xenial
     dist: trusty
     compiler: gcc
     addons:
       apt:
-        sources:
-        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
-          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
+        sources: *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
+        - *pkg_deps_doctools
+# temporary disabled, does not work
+#  - env: BUILD_TYPE=docs
+#    os: linux
+  - env: BUILD_TYPE=valgrind
+    os: linux
+#    dist: xenial
+    dist: trusty
+    compiler: gcc
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu14
         packages:
         - valgrind
-        - libzmq3-dev
+        - *pkg_deps_common
   - env: BUILD_TYPE=android
     compiler: clang
   - env: BUILD_TYPE=bindings BINDING=jni
@@ -75,15 +165,45 @@ matrix:
         - openjdk-7-jdk
   - env: BUILD_TYPE=default ADDRESS_SANITIZER=enabled
     os: linux
+#    dist: xenial
     dist: trusty
     compiler: gcc
     addons:
       apt:
-        sources:
-        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
-          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
+        sources: *pkg_src_zeromq_ubuntu14
         packages:
-        - libzmq3-dev
+        - *pkg_deps_common
+  - env: BUILD_TYPE=check_zproject
+    os: linux
+#    dist: xenial
+    dist: trusty
+    compiler: gcc
+    addons:
+      apt:
+        sources: *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_devtools
+        - *pkg_deps_zproject
+  - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
+# For non-cmake users, there is an autotools solution with a bit more overhead
+# to have dependencies ready and pass configure script before making this check).
+# Note that the autotools variant will also require dependencies preinstalled to
+# pass its configure script:
+#  - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
+    os: linux
+    dist: xenial
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-xenial-5.0
+        packages:
+        - clang-5.0
+        - clang-format-5.0
+#autotools#  - *pkg_deps_prereqs
+# Note: the ABI compliance checker script currently assumes that:
+# 1) Your project sources have a "latest_release" branch or tag
+#    to check out and compare the current commit's ABI to;
+# 2) Prerequisites are available as packages - no custom rebuilds.
   - env: BUILD_TYPE=abi-compliance-checker
     os: linux
     dist: xenial
@@ -93,38 +213,15 @@ matrix:
         - sourceline: 'deb http://ppa.launchpad.net/hnakamur/universal-ctags/ubuntu bionic main'
           key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x60D954A11017341E'
         packages:
-        - libzmq3-dev
-        - libsystemd-dev
-        - liblz4-dev
-        - uuid-dev
-        - libcurl4-nss-dev
+        - *pkg_deps_common
         - universal-ctags
         - abi-dumper
         - abi-compliance-checker
-# temporary disabled, does not work
-#  - env: BUILD_TYPE=docs
-#    os: linux
-
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/ ./'
-      key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-draft/xUbuntu_14.04/Release.key'
-    packages:
-    - libsystemd-dev
-    - liblz4-dev
-    - uuid-dev
-    - asciidoc
-    - xmlto
-    - libsodium-dev
-    - libzmq3-dev
-    - generator-scripting-language
-    - zproject
-    - libcurl4-nss-dev
 
 before_install:
-- if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi
-- if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "stable_zmq" ] ; then brew update; brew install libsodium lz4 ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "android" ] ; then brew update; brew install binutils ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew update; brew install valgrind ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "stable_zmq" ] ; then brew update; brew install libsodium lz4 ; fi
 
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so
@@ -132,7 +229,7 @@ before_install:
 before_script:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then sudo sysctl -w kern.maxfiles=64000 ; sudo sysctl -w kern.maxfilesperproc=64000 ; sudo launchctl limit maxfiles 64000 64000 ; ulimit -n 64000 ; fi
 
-# Build and check this project according to the BUILD_TYPE
+# Hand off to generated script for each BUILD_TYPE
 script: ./ci_build.sh
 # Prepare deployment
 before_deploy: . ./ci_deploy.sh && ./ci_deploy_obs.sh
@@ -140,6 +237,8 @@ before_deploy: . ./ci_deploy.sh && ./ci_deploy_obs.sh
 deploy:
   provider: releases
   api_key:
+    # To encrypt your access token run: `travis encrypt -r user/repo`
+    #secure: <encrypted github access token>
     secure: mmpmM0uhaMIKjL7ZkZduDOHkhAWA4Ngaq2FtjQVnUXrsCelSObSLe6BwcvvPp7yYGW44mAmoYPEPWAADatt+6bdVCcf0hgSJS02G4EiuxRAOiZ/ffTaAOhaqfmjuwmZ1cftFUFwehS9JEE9Be59Hv+tGnOOZSkxMWhkQ7xTvidQ=
   file_glob: true
   file: ${CZMQ_DEPLOYMENT}

--- a/builds/abi-compliance-checker/ci_build.sh
+++ b/builds/abi-compliance-checker/ci_build.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -x
 
+# Note: the ABI compliance checker script currently assumes that:
+# 1) Your project sources have a "latest_release" branch or tag
+#    to check out and compare the current commit's ABI to;
+# 2) Prerequisites are available as packages - no custom rebuilds.
+
 cd ../../
 
 mkdir tmp

--- a/project.xml
+++ b/project.xml
@@ -88,6 +88,11 @@
         </option>
     </target>
 
+    <target name = "travis" >
+        <option name = "check_zproject" value = "1" />
+        <option name = "check_abi_compliance" value = "1" />
+    </target>
+
     <target name = "jenkins" >
         <!-- While Jenkinsfile does not build prerequisites,
              request via node label that they are expected

--- a/src/zhttp_client.c
+++ b/src/zhttp_client.c
@@ -316,8 +316,6 @@ zhttp_client_execute (zhttp_client_t *self) {
     zhttp_client_fn *handler;
     int rc;
 
-    int events = zsock_events (self);
-
     while (zsock_has_in (self)) {
         rc = zsock_recv (self, "icpp", &response_code, &data, &handler, &arg);
 
@@ -325,8 +323,6 @@ zhttp_client_execute (zhttp_client_t *self) {
             return rc;
 
         handler (arg, response_code, data);
-
-        events = zsock_events (self);
     }
 
     return 0;

--- a/src/zhttp_client.c
+++ b/src/zhttp_client.c
@@ -47,11 +47,11 @@ size_t write_data (void *buffer, size_t size, size_t nmemb, void *userp) {
 static struct curl_slist *zlistx_to_slist (zlistx_t *zlist) {
     struct curl_slist *slist = NULL;
 
-    char *header = zlistx_first (zlist);
+    char *header = (char *) zlistx_first (zlist);
 
     while (header) {
         slist = curl_slist_append (slist, header);
-        header = zlistx_next (zlist);
+        header = (char *) zlistx_next (zlist);
     }
 
     return slist;


### PR DESCRIPTION
Commented what was customized in the travis script, updated the solution with recent Jenkinsfile patterns improvements, etc.

Note that currently the travis script retains "trusty" as the build environment, like it was before. If this one works on CI, a next iteration can update the recipes to be even more compliant with current zproject.

PLEASE DO NOT MERGE before this ends up green in CI ;)