### PR TITLE
Problem: zhttp_server fails to build with libmicrohttpd << 0.9.34

### DIFF
--- a/api/zhttp_server.api
+++ b/api/zhttp_server.api
@@ -19,6 +19,11 @@
     You can connect as many dealers as you want.
     The Server is using simple dealer socket to route the requests.
 
+    NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+    high CPU usage due to the lack of MHD_suspend_connection and
+    MHD_resume_connection APIs. It is recommended to use this class only with
+    libmicrohttpd at least 0.9.34 in production.
+
     <constructor>
         Create a new http server
 	    <argument name = "options" type = "zhttp_server_options" />

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -4549,6 +4549,11 @@ To start handling requests:
 You can connect as many dealers as you want.
 The Server is using simple dealer socket to route the requests.
 
+NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+high CPU usage due to the lack of MHD_suspend_connection and
+MHD_resume_connection APIs. It is recommended to use this class only with
+libmicrohttpd at least 0.9.34 in production.
+
 Constructor:
 
 ```

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -8652,6 +8652,11 @@ To start handling requests:
 
 You can connect as many dealers as you want.
 The Server is using simple dealer socket to route the requests.
+
+NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+high CPU usage due to the lack of MHD_suspend_connection and
+MHD_resume_connection APIs. It is recommended to use this class only with
+libmicrohttpd at least 0.9.34 in production.
     """
 
     allow_destruct = False

--- a/bindings/python_cffi/czmq_cffi/ZhttpServer.py
+++ b/bindings/python_cffi/czmq_cffi/ZhttpServer.py
@@ -18,6 +18,11 @@ To start handling requests:
 
 You can connect as many dealers as you want.
 The Server is using simple dealer socket to route the requests.
+
+NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+high CPU usage due to the lack of MHD_suspend_connection and
+MHD_resume_connection APIs. It is recommended to use this class only with
+libmicrohttpd at least 0.9.34 in production.
     """
 
     def __init__(self, options):

--- a/bindings/ruby/lib/czmq/ffi/zhttp_server.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhttp_server.rb
@@ -16,6 +16,11 @@ module CZMQ
     #
     # You can connect as many dealers as you want.
     # The Server is using simple dealer socket to route the requests.
+    #
+    # NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+    # high CPU usage due to the lack of MHD_suspend_connection and
+    # MHD_resume_connection APIs. It is recommended to use this class only with
+    # libmicrohttpd at least 0.9.34 in production.
     # @note This class is 100% generated using zproject.
     class ZhttpServer
       # Raised when one tries to use an instance of {ZhttpServer} after

--- a/src/zhttp_server.c
+++ b/src/zhttp_server.c
@@ -92,13 +92,17 @@ request_destroy (request_t **self_p) {
 
 static void *
 s_insert_connection (struct MHD_Connection *connection) {
+#if MHD_VERSION >= 0x00093400
     MHD_suspend_connection (connection);
+#endif
     return connection;
 }
 
 static void
 s_destroy_connection (struct MHD_Connection **connection) {
+#if MHD_VERSION >= 0x00093400
     MHD_resume_connection (*connection);
+#endif
     *connection = NULL;
 }
 


### PR DESCRIPTION
Solution: ifdef out the newer API, and warn users in the documentation
about possible side effects with the older version of the library.
It only affects SUSE 12/42 among the currently maintained Linux
distributions.