### PR TITLE
Problem: timers are called twice if they change the pollset

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -739,12 +739,12 @@ zloop_start (zloop_t *self)
                 if (self->verbose)
                     zsys_debug ("zloop: call timer handler id=%d", timer->timer_id);
                 rc = timer->handler (self, timer->timer_id, timer->arg);
-                if (rc == -1)
-                    break;      //  Timer handler signaled break
                 if (timer->times && --timer->times == 0)
                     zlistx_delete (self->timers, timer->list_handle);
                 else
                     timer->when += timer->delay;
+                if (rc == -1)
+                    break;      //  Timer handler signaled break
             }
             timer = (s_timer_t *) zlistx_next (self->timers);
         }

--- a/src/zloop.c
+++ b/src/zloop.c
@@ -712,6 +712,8 @@ zloop_start (zloop_t *self)
 
     //  Main reactor loop
     while (!zsys_interrupted || self->nonstop) {
+        if (rc == -1)      // somebody wanted us to quit
+            break;
         if (self->need_rebuild) {
             //  If s_rebuild_pollset() fails, break out of the loop and
             //  return its error
@@ -846,8 +848,6 @@ zloop_start (zloop_t *self)
             ptrdiff_t timer_id = (byte *) zlistx_detach (self->zombies, NULL) - (byte *) NULL;
             s_timer_remove (self, (int) timer_id);
         }
-        if (rc == -1)
-            break;
     }
     self->terminated = true;
     return rc;


### PR DESCRIPTION
Solution: 
* first delete timers to delete then break
* move rc==-1 check to beginning of loop to prevent the loop from not breaking

Here's a small test program which reproduces the problem:
```
#include "czmq.h"

static
int timer_end(zloop_t *loop, int timer_id, void *args) {
    zloop_reader_end( loop, (zsock_t *)args);
    return -1;
}

int socket_event(zloop_t *loop, zsock_t *handle, void *args)
{
    zmsg_t *msg = zmsg_recv(handle);
    zsys_notice( "Main sockect event: %s", zmsg_popstr( msg ));
    zmsg_destroy(&msg);
    return -1;
}

int main (void) {
    zsys_init();

    zloop_t *loop = zloop_new ();
    assert (loop);
    zloop_set_verbose (loop, true);

    //add a socket
    zsock_t *pub = zsock_new_pair("inproc://bla");
    int rc = zloop_reader( loop, pub, socket_event, pub);
    assert(rc == 0);
    zloop_timer(loop, 1000, 1, timer_end, pub);
    zstr_send(pub, "Test");
    zloop_start(loop);
    zsys_notice("loop ended");
    zloop_destroy(&loop);
    zsock_destroy(&pub);
    return 0;
}
```
it outputs:
```
D: 19-02-09 13:02:10 zloop: register PAIR reader
D: 19-02-09 13:02:10 zloop: register timer id=1 delay=1000 times=1
D: 19-02-09 13:02:10 zloop polling for 1000 msec
D: 19-02-09 13:02:11 zloop: call timer handler id=1
D: 19-02-09 13:02:11 zloop: cancel PAIR reader
D: 19-02-09 13:02:11 zloop polling for 0 msec
D: 19-02-09 13:02:11 zloop: call timer handler id=1
D: 19-02-09 13:02:11 zloop: cancel PAIR reader
N: 19-02-09 13:02:11 loop ended
```
which clearly shows the timer handler being called twice while we registered it as only to be called once