### PR TITLE
Fix "is any is" typos, should be "if any is"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5117,7 +5117,7 @@ This is the class interface:
     CZMQ_EXPORT void *
         zlistx_detach_cur (zlistx_t *self);
     
-    //  Delete an item, using its handle. Calls the item destructor is any is
+    //  Delete an item, using its handle. Calls the item destructor if any is
     //  set. If handle is null, deletes the first item on the list. Returns 0
     //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
     //  to previous item, so you can delete items while iterating forwards

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -1848,7 +1848,7 @@ void *
 void *
     zlistx_detach_cur (zlistx_t *self);
 
-// Delete an item, using its handle. Calls the item destructor is any is
+// Delete an item, using its handle. Calls the item destructor if any is
 // set. If handle is null, deletes the first item on the list. Returns 0
 // if an item was deleted, -1 if not. If cursor was at item, moves cursor
 // to previous item, so you can delete items while iterating forwards

--- a/api/zlistx.api
+++ b/api/zlistx.api
@@ -140,7 +140,7 @@
     </method>
 
     <method name = "delete">
-        Delete an item, using its handle. Calls the item destructor is any is
+        Delete an item, using its handle. Calls the item destructor if any is
         set. If handle is null, deletes the first item on the list. Returns 0
         if an item was deleted, -1 if not. If cursor was at item, moves cursor
         to previous item, so you can delete items while iterating forwards

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -1048,7 +1048,7 @@ uses
     // you can detach items while iterating forwards through a list.
     function DetachCur: Pointer;
 
-    // Delete an item, using its handle. Calls the item destructor is any is
+    // Delete an item, using its handle. Calls the item destructor if any is
     // set. If handle is null, deletes the first item on the list. Returns 0
     // if an item was deleted, -1 if not. If cursor was at item, moves cursor
     // to previous item, so you can delete items while iterating forwards
@@ -3716,7 +3716,7 @@ uses
     // you can detach items while iterating forwards through a list.
     function DetachCur: Pointer;
 
-    // Delete an item, using its handle. Calls the item destructor is any is
+    // Delete an item, using its handle. Calls the item destructor if any is
     // set. If handle is null, deletes the first item on the list. Returns 0
     // if an item was deleted, -1 if not. If cursor was at item, moves cursor
     // to previous item, so you can delete items while iterating forwards

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -1521,7 +1521,7 @@ type
   // you can detach items while iterating forwards through a list.
   function zlistx_detach_cur(self: PZlistx): Pointer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
-  // Delete an item, using its handle. Calls the item destructor is any is
+  // Delete an item, using its handle. Calls the item destructor if any is
   // set. If handle is null, deletes the first item on the list. Returns 0
   // if an item was deleted, -1 if not. If cursor was at item, moves cursor
   // to previous item, so you can delete items while iterating forwards

--- a/bindings/jni/src/main/java/org/zeromq/czmq/Zlistx.java
+++ b/bindings/jni/src/main/java/org/zeromq/czmq/Zlistx.java
@@ -179,7 +179,7 @@ public class Zlistx implements AutoCloseable {
         return __detachCur (self);
     }
     /*
-    Delete an item, using its handle. Calls the item destructor is any is
+    Delete an item, using its handle. Calls the item destructor if any is
     set. If handle is null, deletes the first item on the list. Returns 0
     if an item was deleted, -1 if not. If cursor was at item, moves cursor
     to previous item, so you can delete items while iterating forwards

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1843,7 +1843,7 @@ void *
 void *
     zlistx_detach_cur (zlistx_t *self);
 
-// Delete an item, using its handle. Calls the item destructor is any is
+// Delete an item, using its handle. Calls the item destructor if any is
 // set. If handle is null, deletes the first item on the list. Returns 0
 // if an item was deleted, -1 if not. If cursor was at item, moves cursor
 // to previous item, so you can delete items while iterating forwards

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -4044,7 +4044,7 @@ you can detach items while iterating forwards through a list.
 
     def delete(self, handle):
         """
-        Delete an item, using its handle. Calls the item destructor is any is
+        Delete an item, using its handle. Calls the item destructor if any is
 set. If handle is null, deletes the first item on the list. Returns 0
 if an item was deleted, -1 if not. If cursor was at item, moves cursor
 to previous item, so you can delete items while iterating forwards

--- a/bindings/python_cffi/czmq_cffi/Zlistx.py
+++ b/bindings/python_cffi/czmq_cffi/Zlistx.py
@@ -148,7 +148,7 @@ class Zlistx(object):
 
     def delete(self, handle):
         """
-        Delete an item, using its handle. Calls the item destructor is any is
+        Delete an item, using its handle. Calls the item destructor if any is
         set. If handle is null, deletes the first item on the list. Returns 0
         if an item was deleted, -1 if not. If cursor was at item, moves cursor
         to previous item, so you can delete items while iterating forwards

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -1850,7 +1850,7 @@ void *
 void *
     zlistx_detach_cur (zlistx_t *self);
 
-// Delete an item, using its handle. Calls the item destructor is any is
+// Delete an item, using its handle. Calls the item destructor if any is
 // set. If handle is null, deletes the first item on the list. Returns 0
 // if an item was deleted, -1 if not. If cursor was at item, moves cursor
 // to previous item, so you can delete items while iterating forwards

--- a/bindings/qml/src/QmlZlistx.cpp
+++ b/bindings/qml/src/QmlZlistx.cpp
@@ -114,7 +114,7 @@ void *QmlZlistx::detachCur () {
 };
 
 ///
-//  Delete an item, using its handle. Calls the item destructor is any is
+//  Delete an item, using its handle. Calls the item destructor if any is
 //  set. If handle is null, deletes the first item on the list. Returns 0
 //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
 //  to previous item, so you can delete items while iterating forwards

--- a/bindings/qml/src/QmlZlistx.h
+++ b/bindings/qml/src/QmlZlistx.h
@@ -91,7 +91,7 @@ public slots:
     //  you can detach items while iterating forwards through a list.
     void *detachCur ();
 
-    //  Delete an item, using its handle. Calls the item destructor is any is
+    //  Delete an item, using its handle. Calls the item destructor if any is
     //  set. If handle is null, deletes the first item on the list. Returns 0
     //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
     //  to previous item, so you can delete items while iterating forwards

--- a/bindings/qt/src/qzlistx.cpp
+++ b/bindings/qt/src/qzlistx.cpp
@@ -182,7 +182,7 @@ void * QZlistx::detachCur ()
 }
 
 ///
-//  Delete an item, using its handle. Calls the item destructor is any is
+//  Delete an item, using its handle. Calls the item destructor if any is
 //  set. If handle is null, deletes the first item on the list. Returns 0
 //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
 //  to previous item, so you can delete items while iterating forwards

--- a/bindings/qt/src/qzlistx.h
+++ b/bindings/qt/src/qzlistx.h
@@ -96,7 +96,7 @@ public:
     //  you can detach items while iterating forwards through a list.
     void * detachCur ();
 
-    //  Delete an item, using its handle. Calls the item destructor is any is
+    //  Delete an item, using its handle. Calls the item destructor if any is
     //  set. If handle is null, deletes the first item on the list. Returns 0
     //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
     //  to previous item, so you can delete items while iterating forwards

--- a/bindings/ruby/lib/czmq/ffi/zlistx.rb
+++ b/bindings/ruby/lib/czmq/ffi/zlistx.rb
@@ -326,7 +326,7 @@ module CZMQ
         result
       end
 
-      # Delete an item, using its handle. Calls the item destructor is any is
+      # Delete an item, using its handle. Calls the item destructor if any is
       # set. If handle is null, deletes the first item on the list. Returns 0
       # if an item was deleted, -1 if not. If cursor was at item, moves cursor
       # to previous item, so you can delete items while iterating forwards

--- a/include/zlistx.h
+++ b/include/zlistx.h
@@ -128,7 +128,7 @@ CZMQ_EXPORT void *
 CZMQ_EXPORT void *
     zlistx_detach_cur (zlistx_t *self);
 
-//  Delete an item, using its handle. Calls the item destructor is any is
+//  Delete an item, using its handle. Calls the item destructor if any is
 //  set. If handle is null, deletes the first item on the list. Returns 0
 //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
 //  to previous item, so you can delete items while iterating forwards

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -390,7 +390,7 @@ zlistx_detach_cur (zlistx_t *self)
 
 
 //  --------------------------------------------------------------------------
-//  Delete an item, using its handle. Calls the item destructor is any is
+//  Delete an item, using its handle. Calls the item destructor if any is
 //  set. If handle is null, deletes the first item on the list. Returns 0
 //  if an item was deleted, -1 if not. If cursor was at item, moves cursor
 //  to previous item, so you can delete items while iterating forwards


### PR DESCRIPTION
Problem: typo in zlistx documentation

Solution: fix the typos

