### PR TITLE
Problem: openSUSE packaging requires SPDX formatted license

### DIFF
--- a/packaging/redhat/czmq.spec
+++ b/packaging/redhat/czmq.spec
@@ -37,7 +37,7 @@ Name:           czmq
 Version:        4.2.1
 Release:        1
 Summary:        the high-level c binding for 0mq
-License:        MPLv2
+License:        MPL-2.0
 URL:            https://github.com/zeromq/czmq
 Source0:        %{name}-%{version}.tar.gz
 Group:          System/Libraries

--- a/project.xml
+++ b/project.xml
@@ -3,7 +3,7 @@
     description = "The high-level C binding for 0MQ"
     script = "zproject.gsl"
     email = "zeromq-dev@lists.zeromq.org"
-    license = "MPLv2"
+    license = "MPL-2.0"
     url = "https://github.com/zeromq/czmq"
     repository = "https://github.com/zeromq/czmq"
     >


### PR DESCRIPTION
Solution: Change license name formating to SPDX format in spec and project
metadata (so regenerating spec would keep the change).