### PR TITLE
Problem: zhttp_response_recv leaks memory when result is non-zero

### DIFF
--- a/src/zhttp_response.c
+++ b/src/zhttp_response.c
@@ -119,6 +119,7 @@ zhttp_response_recv (zhttp_response_t *self, zhttp_client_t *client, void** arg_
     self->free_content = self->content != NULL;
 
     if (result != 0) {
+        zhash_destroy(&self->headers);
         self->headers = zhash_new ();
         zhash_autofree (self->headers);
 


### PR DESCRIPTION
Solution: Destroy the headers received from zhttp_client