### PR TITLE
Made snprintf available on MSVC versions over 1500

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -541,7 +541,7 @@ typedef struct {
 #   endif
 #   define srandom srand
 #   define TIMEZONE _timezone
-#   if (!defined (__MINGW32__))
+#   if (!defined (__MINGW32__)) && (defined(_MSC_VER) && _MSC_VER < 1500)
 #       define snprintf _snprintf
 #       define vsnprintf _vsnprintf
 #   endif


### PR DESCRIPTION
Problem: MSVC now supports snprintf

Solution: Only replace snprintf with _snprint if the MSVC version is underneath 1500