### PR TITLE
Problem: No logging if zsys is not initialized

### DIFF
--- a/src/zsys.c
+++ b/src/zsys.c
@@ -2248,6 +2248,9 @@ zsys_set_logsystem (bool logsystem)
 static void
 s_log (char loglevel, char *string)
 {
+    if (!s_initialized)
+        zsys_init ();
+
 #if defined (__UNIX__)
 #   if defined (__UTYPE_ANDROID)
     int priority = ANDROID_LOG_INFO;


### PR DESCRIPTION
Solution: Take care to initialize zsys before performing logging. This
is a lot more intuitive for new users because this issue can be quite
hard to figure out.
