### PR TITLE
Problem: zchunk_slurp() causes assert if file can't be opened

### DIFF
--- a/src/zchunk.c
+++ b/src/zchunk.c
@@ -376,6 +376,9 @@ zchunk_slurp (const char *filename, size_t maxsize)
         size = maxsize;
 
     FILE *handle = fopen (filename, "r");
+    if (!handle)
+        return NULL;
+
     zchunk_t *chunk = zchunk_read (handle, size);
     assert (chunk);
     fclose (handle);


### PR DESCRIPTION
Solution: Ensure filehandle is non-null before calling zchunk_read().
