### PR TITLE
Problem: ci_deploy check for empty BINDING_OPTS does the opposite

### DIFF
--- a/ci_deploy.sh
+++ b/ci_deploy.sh
@@ -20,7 +20,7 @@ if [ "$BUILD_TYPE" == "default" ]; then
     md5sum *.zip *.tar.gz > MD5SUMS
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
-elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ] && [ ! -z "$BINDING_OPTS" ]; then
+elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ] && [ -z "$BINDING_OPTS" ]; then
     ( cd bindings/jni && TERM=dumb ./gradlew clean bintrayUpload -PisRelease -PbuildPrefix=/tmp/jni_build )
 elif [ "$BUILD_TYPE" == "bindings" ] && [ "$BINDING" == "jni" ] && [ "$BINDING_OPTS" == "android" ]; then
     export CZMQ_DEPLOYMENT=bindings/jni/czmq-jni/android/czmq-android-*.jar


### PR DESCRIPTION
Solution: Re-generate the fix from zproject