### PR TITLE
Allow zbeacon to resolve ip address to interface or interface name to interface

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -219,8 +219,9 @@ s_self_prepare_udp (self_t *self)
         const char *name = ziflist_first (iflist);
         while (name) {
             //  If IPv6 is not enabled ignore IPv6 interfaces.
-            if ((streq (iface, name) || streq (iface, "")) &&
-                    ((ziflist_is_ipv6 (iflist) && zsys_ipv6 ()) ||
+            if ( (streq (iface, name) || streq (iface, "") ||
+                    streq (ziflist_address (iflist), iface)) &&
+                        ((ziflist_is_ipv6 (iflist) && zsys_ipv6 ()) ||
                             (!ziflist_is_ipv6 (iflist) && !zsys_ipv6 ()))) {
                 rc = getaddrinfo (ziflist_address (iflist), self->port_nbr,
                         &hint, &bind_to);


### PR DESCRIPTION
Problem: To set the interface used in zyre you must call zyre_set_interface, which ultimately calls zsys_set_interface(). The argument for this call is an interface NAME to use for resolution. 

On windows machines trying to determine an interface name is nearly a nightmare as its typically something like "Local Network Interface (1)" or something else long winded. Additionally this can change over time, and its hard for end users to deduce in the first place.

Solution: Allow the argument for zsys_set_interface to be an IP address OR interface name. This allows the end user to use something they can be more certain about (ip address) that is additionally guaranteed to not be randomly changed by the OS.

Ultimately you may wish to also update the docs for the other external functions to explain that IP address strings can be used.