### PR TITLE
Enable ipv4 multicast packet types when using zbeacon

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4048,6 +4048,27 @@ void
 const char *
     zsys_ipv6_mcast_address (void);
 
+// Set IPv4 multicast address to use for sending zbeacon messages. By default
+// IPv4 multicast is NOT used. If the environment variable
+// ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+// address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+// will enable IPv4 zbeacon messages.
+void
+    zsys_set_ipv4_mcast_address (const char *value);
+
+// Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+// set.
+const char *
+    zsys_ipv4_mcast_address (void);
+
+// Set multicast TTL default is 1
+void
+    zsys_set_mcast_ttl (byte value);
+
+// Get multicast TTL
+byte
+    zsys_mcast_ttl (void);
+
 // Configure the automatic use of pre-allocated FDs when creating new sockets.
 // If 0 (default), nothing will happen. Else, when a new socket is bound, the
 // system API will be used to check if an existing pre-allocated FD with a

--- a/api/zsys.api
+++ b/api/zsys.api
@@ -482,6 +482,31 @@
         <return type = "string" />
     </method>
 
+    <method name = "set ipv4 mcast address" singleton = "1"  state = "draft">
+        Set IPv4 multicast address to use for sending zbeacon messages. By default
+        IPv4 multicast is NOT used. If the environment variable
+        ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+        address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+        will enable IPv4 zbeacon messages.
+        <argument name = "value" type = "string" />
+    </method>
+
+    <method name = "ipv4 mcast address" singleton = "1" state = "draft">
+        Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+        set.
+        <return type = "string" />
+    </method>
+
+	<method name = "set mcast ttl" singleton = "1"  state = "draft">
+        Set multicast TTL default is 1
+        <argument name = "value" type = "byte" />
+    </method>
+
+	<method name = "mcast ttl" singleton = "1"  state = "draft">
+        Get multicast TTL
+        <return type = "byte" />
+    </method>
+
     <method name = "set auto use fd" singleton = "1">
         Configure the automatic use of pre-allocated FDs when creating new sockets.
         If 0 (default), nothing will happen. Else, when a new socket is bound, the

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -5559,6 +5559,23 @@ uses
     // set.
     class function Ipv6McastAddress: string;
 
+    // Set IPv4 multicast address to use for sending zbeacon messages. By default
+    // IPv4 multicast is NOT used. If the environment variable
+    // ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+    // address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+    // will enable IPv4 zbeacon messages.
+    class procedure SetIpv4McastAddress(const Value: string);
+
+    // Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+    // set.
+    class function Ipv4McastAddress: string;
+
+    // Set multicast TTL default is 1
+    class procedure SetMcastTtl(Value: Byte);
+
+    // Get multicast TTL
+    class function McastTtl: Byte;
+
     // Configure the automatic use of pre-allocated FDs when creating new sockets.
     // If 0 (default), nothing will happen. Else, when a new socket is bound, the
     // system API will be used to check if an existing pre-allocated FD with a
@@ -9990,6 +10007,29 @@ end;
   class function TZsys.Ipv6McastAddress: string;
   begin
     Result := string(UTF8String(zsys_ipv6_mcast_address));
+  end;
+
+  class procedure TZsys.SetIpv4McastAddress(const Value: string);
+  var
+    __Value__: UTF8String;
+  begin
+    __Value__ := UTF8String(Value);
+    zsys_set_ipv4_mcast_address(PAnsiChar(__Value__));
+  end;
+
+  class function TZsys.Ipv4McastAddress: string;
+  begin
+    Result := string(UTF8String(zsys_ipv4_mcast_address));
+  end;
+
+  class procedure TZsys.SetMcastTtl(Value: Byte);
+  begin
+    zsys_set_mcast_ttl(Value);
+  end;
+
+  class function TZsys.McastTtl: Byte;
+  begin
+    Result := zsys_mcast_ttl;
   end;
 
   class procedure TZsys.SetAutoUseFd(AutoUseFd: Integer);

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -3280,6 +3280,23 @@ type
   // set.
   function zsys_ipv6_mcast_address: PAnsiChar; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
+  // Set IPv4 multicast address to use for sending zbeacon messages. By default
+  // IPv4 multicast is NOT used. If the environment variable
+  // ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+  // address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+  // will enable IPv4 zbeacon messages.
+  procedure zsys_set_ipv4_mcast_address(Value: PAnsiChar); cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
+  // Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+  // set.
+  function zsys_ipv4_mcast_address: PAnsiChar; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
+  // Set multicast TTL default is 1
+  procedure zsys_set_mcast_ttl(Value: Byte); cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
+  // Get multicast TTL
+  function zsys_mcast_ttl: Byte; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
   // Configure the automatic use of pre-allocated FDs when creating new sockets.
   // If 0 (default), nothing will happen. Else, when a new socket is bound, the
   // system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zsys.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zsys.c
@@ -424,6 +424,35 @@ Java_org_zeromq_czmq_Zsys__1_1ipv6McastAddress (JNIEnv *env, jclass c)
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsys__1_1setIpv4McastAddress (JNIEnv *env, jclass c, jstring value)
+{
+    char *value_ = (char *) (*env)->GetStringUTFChars (env, value, NULL);
+    zsys_set_ipv4_mcast_address (value_);
+    (*env)->ReleaseStringUTFChars (env, value, value_);
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_zeromq_czmq_Zsys__1_1ipv4McastAddress (JNIEnv *env, jclass c)
+{
+    char *ipv4_mcast_address_ = (char *) zsys_ipv4_mcast_address ();
+    jstring return_string_ = (*env)->NewStringUTF (env, ipv4_mcast_address_);
+    return return_string_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_Zsys__1_1setMcastTtl (JNIEnv *env, jclass c, jbyte value)
+{
+    zsys_set_mcast_ttl ((byte) value);
+}
+
+JNIEXPORT jbyte JNICALL
+Java_org_zeromq_czmq_Zsys__1_1mcastTtl (JNIEnv *env, jclass c)
+{
+    jbyte mcast_ttl_ = (jbyte) zsys_mcast_ttl ();
+    return mcast_ttl_;
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zsys__1_1setAutoUseFd (JNIEnv *env, jclass c, jint auto_use_fd)
 {
     zsys_set_auto_use_fd ((int) auto_use_fd);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -532,6 +532,39 @@ public class Zsys {
         return __ipv6McastAddress ();
     }
     /*
+    Set IPv4 multicast address to use for sending zbeacon messages. By default
+    IPv4 multicast is NOT used. If the environment variable
+    ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+    address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+    will enable IPv4 zbeacon messages.
+    */
+    native static void __setIpv4McastAddress (String value);
+    public static void setIpv4McastAddress (String value) {
+        __setIpv4McastAddress (value);
+    }
+    /*
+    Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+    set.
+    */
+    native static String __ipv4McastAddress ();
+    public static String ipv4McastAddress () {
+        return __ipv4McastAddress ();
+    }
+    /*
+    Set multicast TTL default is 1
+    */
+    native static void __setMcastTtl (byte value);
+    public static void setMcastTtl (byte value) {
+        __setMcastTtl (value);
+    }
+    /*
+    Get multicast TTL
+    */
+    native static byte __mcastTtl ();
+    public static byte mcastTtl () {
+        return __mcastTtl ();
+    }
+    /*
     Configure the automatic use of pre-allocated FDs when creating new sockets.
     If 0 (default), nothing will happen. Else, when a new socket is bound, the
     system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4043,6 +4043,27 @@ void
 const char *
     zsys_ipv6_mcast_address (void);
 
+// Set IPv4 multicast address to use for sending zbeacon messages. By default
+// IPv4 multicast is NOT used. If the environment variable
+// ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+// address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+// will enable IPv4 zbeacon messages.
+void
+    zsys_set_ipv4_mcast_address (const char *value);
+
+// Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+// set.
+const char *
+    zsys_ipv4_mcast_address (void);
+
+// Set multicast TTL default is 1
+void
+    zsys_set_mcast_ttl (byte value);
+
+// Get multicast TTL
+byte
+    zsys_mcast_ttl (void);
+
 // Configure the automatic use of pre-allocated FDs when creating new sockets.
 // If 0 (default), nothing will happen. Else, when a new socket is bound, the
 // system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -4310,6 +4310,23 @@ Return IPv6 multicast address to use for sending zbeacon, or "" if none was
 set.
 
 ```
+nothing my_zsys.setIpv4McastAddress (String)
+```
+
+Set IPv4 multicast address to use for sending zbeacon messages. By default
+IPv4 multicast is NOT used. If the environment variable
+ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+will enable IPv4 zbeacon messages.
+
+```
+string my_zsys.ipv4McastAddress ()
+```
+
+Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+set.
+
+```
 nothing my_zsys.setAutoUseFd (Number)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -7419,6 +7419,8 @@ NAN_MODULE_INIT (Zsys::Init) {
     Nan::SetPrototypeMethod (tpl, "ipv6Address", _ipv6_address);
     Nan::SetPrototypeMethod (tpl, "setIpv6McastAddress", _set_ipv6_mcast_address);
     Nan::SetPrototypeMethod (tpl, "ipv6McastAddress", _ipv6_mcast_address);
+    Nan::SetPrototypeMethod (tpl, "setIpv4McastAddress", _set_ipv4_mcast_address);
+    Nan::SetPrototypeMethod (tpl, "ipv4McastAddress", _ipv4_mcast_address);
     Nan::SetPrototypeMethod (tpl, "setAutoUseFd", _set_auto_use_fd);
     Nan::SetPrototypeMethod (tpl, "autoUseFd", _auto_use_fd);
     Nan::SetPrototypeMethod (tpl, "zprintf", _zprintf);
@@ -8096,6 +8098,25 @@ NAN_METHOD (Zsys::_set_ipv6_mcast_address) {
 
 NAN_METHOD (Zsys::_ipv6_mcast_address) {
     char *result = (char *) zsys_ipv6_mcast_address ();
+    info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
+}
+
+NAN_METHOD (Zsys::_set_ipv4_mcast_address) {
+    char *value;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `value`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`value` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String value_utf8 (info [0].As<String>());
+    value = *value_utf8;
+         //} //bjornw end
+    zsys_set_ipv4_mcast_address ((const char *)value);
+}
+
+NAN_METHOD (Zsys::_ipv4_mcast_address) {
+    char *result = (char *) zsys_ipv4_mcast_address ();
     info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
 }
 

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -898,6 +898,8 @@ class Zsys: public Nan::ObjectWrap {
     static NAN_METHOD (_ipv6_address);
     static NAN_METHOD (_set_ipv6_mcast_address);
     static NAN_METHOD (_ipv6_mcast_address);
+    static NAN_METHOD (_set_ipv4_mcast_address);
+    static NAN_METHOD (_ipv4_mcast_address);
     static NAN_METHOD (_set_auto_use_fd);
     static NAN_METHOD (_auto_use_fd);
     static NAN_METHOD (_zprintf);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -7546,6 +7546,14 @@ lib.zsys_set_ipv6_mcast_address.restype = None
 lib.zsys_set_ipv6_mcast_address.argtypes = [c_char_p]
 lib.zsys_ipv6_mcast_address.restype = c_char_p
 lib.zsys_ipv6_mcast_address.argtypes = []
+lib.zsys_set_ipv4_mcast_address.restype = None
+lib.zsys_set_ipv4_mcast_address.argtypes = [c_char_p]
+lib.zsys_ipv4_mcast_address.restype = c_char_p
+lib.zsys_ipv4_mcast_address.argtypes = []
+lib.zsys_set_mcast_ttl.restype = None
+lib.zsys_set_mcast_ttl.argtypes = [c_ubyte]
+lib.zsys_mcast_ttl.restype = c_ubyte
+lib.zsys_mcast_ttl.argtypes = []
 lib.zsys_set_auto_use_fd.restype = None
 lib.zsys_set_auto_use_fd.argtypes = [c_int]
 lib.zsys_auto_use_fd.restype = c_int
@@ -8165,6 +8173,39 @@ address.
 set.
         """
         return lib.zsys_ipv6_mcast_address()
+
+    @staticmethod
+    def set_ipv4_mcast_address(value):
+        """
+        Set IPv4 multicast address to use for sending zbeacon messages. By default
+IPv4 multicast is NOT used. If the environment variable
+ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+will enable IPv4 zbeacon messages.
+        """
+        return lib.zsys_set_ipv4_mcast_address(value)
+
+    @staticmethod
+    def ipv4_mcast_address():
+        """
+        Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+set.
+        """
+        return lib.zsys_ipv4_mcast_address()
+
+    @staticmethod
+    def set_mcast_ttl(value):
+        """
+        Set multicast TTL default is 1
+        """
+        return lib.zsys_set_mcast_ttl(value)
+
+    @staticmethod
+    def mcast_ttl():
+        """
+        Get multicast TTL
+        """
+        return lib.zsys_mcast_ttl()
 
     @staticmethod
     def set_auto_use_fd(auto_use_fd):

--- a/bindings/python_cffi/czmq_cffi/Zsys.py
+++ b/bindings/python_cffi/czmq_cffi/Zsys.py
@@ -573,6 +573,39 @@ class Zsys(object):
         return utils.lib.zsys_ipv6_mcast_address()
 
     @staticmethod
+    def set_ipv4_mcast_address(value):
+        """
+        Set IPv4 multicast address to use for sending zbeacon messages. By default
+        IPv4 multicast is NOT used. If the environment variable
+        ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+        address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+        will enable IPv4 zbeacon messages.
+        """
+        utils.lib.zsys_set_ipv4_mcast_address(utils.to_bytes(value))
+
+    @staticmethod
+    def ipv4_mcast_address():
+        """
+        Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+        set.
+        """
+        return utils.lib.zsys_ipv4_mcast_address()
+
+    @staticmethod
+    def set_mcast_ttl(value):
+        """
+        Set multicast TTL default is 1
+        """
+        utils.lib.zsys_set_mcast_ttl(value)
+
+    @staticmethod
+    def mcast_ttl():
+        """
+        Get multicast TTL
+        """
+        return utils.lib.zsys_mcast_ttl()
+
+    @staticmethod
     def set_auto_use_fd(auto_use_fd):
         """
         Configure the automatic use of pre-allocated FDs when creating new sockets.

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4050,6 +4050,27 @@ void
 const char *
     zsys_ipv6_mcast_address (void);
 
+// Set IPv4 multicast address to use for sending zbeacon messages. By default
+// IPv4 multicast is NOT used. If the environment variable
+// ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+// address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+// will enable IPv4 zbeacon messages.
+void
+    zsys_set_ipv4_mcast_address (const char *value);
+
+// Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+// set.
+const char *
+    zsys_ipv4_mcast_address (void);
+
+// Set multicast TTL default is 1
+void
+    zsys_set_mcast_ttl (byte value);
+
+// Get multicast TTL
+byte
+    zsys_mcast_ttl (void);
+
 // Configure the automatic use of pre-allocated FDs when creating new sockets.
 // If 0 (default), nothing will happen. Else, when a new socket is bound, the
 // system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -518,6 +518,35 @@ const QString QmlZsysAttached::ipv6McastAddress () {
 };
 
 ///
+//  Set IPv4 multicast address to use for sending zbeacon messages. By default
+//  IPv4 multicast is NOT used. If the environment variable
+//  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+//  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+//  will enable IPv4 zbeacon messages.
+void QmlZsysAttached::setIpv4McastAddress (const QString &value) {
+    zsys_set_ipv4_mcast_address (value.toUtf8().data());
+};
+
+///
+//  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+//  set.
+const QString QmlZsysAttached::ipv4McastAddress () {
+    return QString (zsys_ipv4_mcast_address ());
+};
+
+///
+//  Set multicast TTL default is 1
+void QmlZsysAttached::setMcastTtl (byte value) {
+    zsys_set_mcast_ttl (value);
+};
+
+///
+//  Get multicast TTL
+byte QmlZsysAttached::mcastTtl () {
+    return zsys_mcast_ttl ();
+};
+
+///
 //  Configure the automatic use of pre-allocated FDs when creating new sockets.
 //  If 0 (default), nothing will happen. Else, when a new socket is bound, the
 //  system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -353,6 +353,23 @@ public slots:
     //  set.
     const QString ipv6McastAddress ();
 
+    //  Set IPv4 multicast address to use for sending zbeacon messages. By default
+    //  IPv4 multicast is NOT used. If the environment variable
+    //  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+    //  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+    //  will enable IPv4 zbeacon messages.
+    void setIpv4McastAddress (const QString &value);
+
+    //  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+    //  set.
+    const QString ipv4McastAddress ();
+
+    //  Set multicast TTL default is 1
+    void setMcastTtl (byte value);
+
+    //  Get multicast TTL
+    byte mcastTtl ();
+
     //  Configure the automatic use of pre-allocated FDs when creating new sockets.
     //  If 0 (default), nothing will happen. Else, when a new socket is bound, the
     //  system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -600,6 +600,43 @@ const QString QZsys::ipv6McastAddress ()
 }
 
 ///
+//  Set IPv4 multicast address to use for sending zbeacon messages. By default
+//  IPv4 multicast is NOT used. If the environment variable
+//  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+//  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+//  will enable IPv4 zbeacon messages.
+void QZsys::setIpv4McastAddress (const QString &value)
+{
+    zsys_set_ipv4_mcast_address (value.toUtf8().data());
+
+}
+
+///
+//  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+//  set.
+const QString QZsys::ipv4McastAddress ()
+{
+    const QString rv = QString (zsys_ipv4_mcast_address ());
+    return rv;
+}
+
+///
+//  Set multicast TTL default is 1
+void QZsys::setMcastTtl (byte value)
+{
+    zsys_set_mcast_ttl (value);
+
+}
+
+///
+//  Get multicast TTL
+byte QZsys::mcastTtl ()
+{
+    byte rv = zsys_mcast_ttl ();
+    return rv;
+}
+
+///
 //  Configure the automatic use of pre-allocated FDs when creating new sockets.
 //  If 0 (default), nothing will happen. Else, when a new socket is bound, the
 //  system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -311,6 +311,23 @@ public:
     //  set.
     static const QString ipv6McastAddress ();
 
+    //  Set IPv4 multicast address to use for sending zbeacon messages. By default
+    //  IPv4 multicast is NOT used. If the environment variable
+    //  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+    //  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+    //  will enable IPv4 zbeacon messages.
+    static void setIpv4McastAddress (const QString &value);
+
+    //  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+    //  set.
+    static const QString ipv4McastAddress ();
+
+    //  Set multicast TTL default is 1
+    static void setMcastTtl (byte value);
+
+    //  Get multicast TTL
+    static byte mcastTtl ();
+
     //  Configure the automatic use of pre-allocated FDs when creating new sockets.
     //  If 0 (default), nothing will happen. Else, when a new socket is bound, the
     //  system API will be used to check if an existing pre-allocated FD with a

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -842,6 +842,10 @@ module CZMQ
       attach_function :zsys_ipv6_address, [], :string, **opts
       attach_function :zsys_set_ipv6_mcast_address, [:string], :void, **opts
       attach_function :zsys_ipv6_mcast_address, [], :string, **opts
+      attach_function :zsys_set_ipv4_mcast_address, [:string], :void, **opts
+      attach_function :zsys_ipv4_mcast_address, [], :string, **opts
+      attach_function :zsys_set_mcast_ttl, [:char], :void, **opts
+      attach_function :zsys_mcast_ttl, [], :char, **opts
       attach_function :zsys_set_auto_use_fd, [:int], :void, **opts
       attach_function :zsys_auto_use_fd, [], :int, **opts
       attach_function :zsys_zprintf, [:string, :pointer], :pointer, **opts

--- a/bindings/ruby/lib/czmq/ffi/zsys.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsys.rb
@@ -798,6 +798,46 @@ module CZMQ
         result
       end
 
+      # Set IPv4 multicast address to use for sending zbeacon messages. By default
+      # IPv4 multicast is NOT used. If the environment variable
+      # ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+      # address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+      # will enable IPv4 zbeacon messages.
+      #
+      # @param value [String, #to_s, nil]
+      # @return [void]
+      def self.set_ipv4_mcast_address(value)
+        result = ::CZMQ::FFI.zsys_set_ipv4_mcast_address(value)
+        result
+      end
+
+      # Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+      # set.
+      #
+      # @return [String]
+      def self.ipv4_mcast_address()
+        result = ::CZMQ::FFI.zsys_ipv4_mcast_address()
+        result
+      end
+
+      # Set multicast TTL default is 1
+      #
+      # @param value [Integer, #to_int, #to_i]
+      # @return [void]
+      def self.set_mcast_ttl(value)
+        value = Integer(value)
+        result = ::CZMQ::FFI.zsys_set_mcast_ttl(value)
+        result
+      end
+
+      # Get multicast TTL
+      #
+      # @return [Integer]
+      def self.mcast_ttl()
+        result = ::CZMQ::FFI.zsys_mcast_ttl()
+        result
+      end
+
       # Configure the automatic use of pre-allocated FDs when creating new sockets.
       # If 0 (default), nothing will happen. Else, when a new socket is bound, the
       # system API will be used to check if an existing pre-allocated FD with a

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -479,6 +479,31 @@ CZMQ_EXPORT int64_t
     zsys_file_stable_age_msec (void);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Set IPv4 multicast address to use for sending zbeacon messages. By default
+//  IPv4 multicast is NOT used. If the environment variable
+//  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+//  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+//  will enable IPv4 zbeacon messages.
+CZMQ_EXPORT void
+    zsys_set_ipv4_mcast_address (const char *value);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+//  set.
+CZMQ_EXPORT const char *
+    zsys_ipv4_mcast_address (void);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set multicast TTL default is 1
+CZMQ_EXPORT void
+    zsys_set_mcast_ttl (byte value);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Get multicast TTL
+CZMQ_EXPORT byte
+    zsys_mcast_ttl (void);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Print formatted string. Format is specified by variable names
 //  in Python-like format style
 //

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -406,6 +406,31 @@ CZMQ_PRIVATE int64_t
     zsys_file_stable_age_msec (void);
 
 //  *** Draft method, defined for internal use only ***
+//  Set IPv4 multicast address to use for sending zbeacon messages. By default
+//  IPv4 multicast is NOT used. If the environment variable
+//  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast
+//  address. Calling this function or setting ZSYS_IPV4_MCAST_ADDRESS
+//  will enable IPv4 zbeacon messages.
+CZMQ_PRIVATE void
+    zsys_set_ipv4_mcast_address (const char *value);
+
+//  *** Draft method, defined for internal use only ***
+//  Return IPv4 multicast address to use for sending zbeacon, or NULL if none was
+//  set.
+CZMQ_PRIVATE const char *
+    zsys_ipv4_mcast_address (void);
+
+//  *** Draft method, defined for internal use only ***
+//  Set multicast TTL default is 1
+CZMQ_PRIVATE void
+    zsys_set_mcast_ttl (byte value);
+
+//  *** Draft method, defined for internal use only ***
+//  Get multicast TTL
+CZMQ_PRIVATE byte
+    zsys_mcast_ttl (void);
+
+//  *** Draft method, defined for internal use only ***
 //  Print formatted string. Format is specified by variable names
 //  in Python-like format style
 //


### PR DESCRIPTION
Problem: ipv4 multicast packet types when using zbeacon are not implemented - but some notes about it already exist in the code

Solution: Enable ipv4 multicast packet types when using zbeacon

Open Items:
I could not find the files used to gen czmq_selftest or czmq_private_selftest, thefore I could not update the auto code generator files for these. Do they exist?

I intentionally did not modify any behavior for ipv6 with this change zsys_udp_new() has the code to configure the socket differently for IPv6 but its not enabled.

I have not tested this code on any OS aside from windows. There I tested it going through atleast 1 router and verified TTL and addresses were set correctly with wire shark. Additionally I copied the existing beacon test and added the calls to configure it with multicast. These tests pass as well.

Please advise how we can best move this code forward and hopefully have it added into official codebase.
