### PR TITLE
Android NDK platform 24 and above supports ifaddrs.h

### DIFF
--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -286,9 +286,14 @@
 #   include <sys/un.h>
 #   include <sys/uio.h>             //  Let CZMQ build with libzmq/3.x
 #   include <netinet/in.h>          //  Must come before arpa/inet.h
-#   if (!defined (__UTYPE_ANDROID)) && (!defined (__UTYPE_IBMAIX)) \
-    && (!defined (__UTYPE_HPUX))
-#       include <ifaddrs.h>
+#   if (!defined (__UTYPE_IBMAIX)) && (!defined (__UTYPE_HPUX))
+#       if(defined(__UTYPE_ANDROID))
+#           if(defined(__ANDROID_API__)) && (__ANDROID_API__ >= 24)
+#               include <ifaddrs.h>
+#           endif
+#       else
+#           include <ifaddrs.h>
+#       endif
 #   endif
 #   if defined (__UTYPE_SUNSOLARIS) || defined (__UTYPE_SUNOS)
 #       include <sys/sockio.h>


### PR DESCRIPTION
```
Problem: The Android NDK API provides an implementation of ifaddrs.h after platform version 24.

Solution: Fixed ifdef code for android platforms to include a platform version check.
```
