### PR TITLE
Using ZeroMQ cmake package config file if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,19 +120,30 @@ set(OPTIONAL_LIBRARIES_STATIC)
 ########################################################################
 # LIBZMQ dependency
 ########################################################################
-find_package(libzmq REQUIRED)
-IF (LIBZMQ_FOUND)
-    include_directories(${LIBZMQ_INCLUDE_DIRS})
-    list(APPEND MORE_LIBRARIES ${LIBZMQ_LIBRARIES})
-  IF (PC_LIBZMQ_FOUND)
-      set(pkg_config_names_private "${pkg_config_names_private} libzmq")
-      list(APPEND OPTIONAL_LIBRARIES_STATIC ${PC_LIBZMQ_STATIC_LDFLAGS})
-  ELSE (PC_LIBZMQ_FOUND)
-      set(pkg_config_libs_private "${pkg_config_libs_private} -lzmq")
-  ENDIF (PC_LIBZMQ_FOUND)
-ELSE (LIBZMQ_FOUND)
-    message( FATAL_ERROR "libzmq not found." )
-ENDIF (LIBZMQ_FOUND)
+
+# Find libzmq using cmake package config file
+set(REQUIRED_LIBRARIES)
+set(REQUIRED_LIBRARIES_STATIC)
+find_package(ZeroMQ CONFIG)
+IF(ZeroMQ_FOUND)
+  list(APPEND REQUIRED_LIBRARIES libzmq)
+  list(APPEND REQUIRED_LIBRARIES_STATIC libzmq-static)
+ELSE()
+  # Fallback to findlibzmq.cmake
+  find_package(libzmq REQUIRED)
+  IF (LIBZMQ_FOUND)
+      include_directories(${LIBZMQ_INCLUDE_DIRS})
+      list(APPEND MORE_LIBRARIES ${LIBZMQ_LIBRARIES})
+    IF (PC_LIBZMQ_FOUND)
+        set(pkg_config_names_private "${pkg_config_names_private} libzmq")
+        list(APPEND OPTIONAL_LIBRARIES_STATIC ${PC_LIBZMQ_STATIC_LDFLAGS})
+    ELSE (PC_LIBZMQ_FOUND)
+        set(pkg_config_libs_private "${pkg_config_libs_private} -lzmq")
+    ENDIF (PC_LIBZMQ_FOUND)
+  ELSE (LIBZMQ_FOUND)
+      message( FATAL_ERROR "libzmq not found." )
+  ENDIF (LIBZMQ_FOUND)
+ENDIF(ZeroMQ_FOUND)
 
 ########################################################################
 # UUID dependency
@@ -417,7 +428,7 @@ if (CZMQ_BUILD_SHARED)
   )
 
   target_link_libraries(czmq
-    PUBLIC ${MORE_LIBRARIES}
+    PUBLIC ${MORE_LIBRARIES} ${REQUIRED_LIBRARIES}
   )
 
   install(TARGETS czmq
@@ -454,7 +465,7 @@ if (CZMQ_BUILD_STATIC)
   )
 
   target_link_libraries(czmq-static
-    PUBLIC ${MORE_LIBRARIES}
+    PUBLIC ${MORE_LIBRARIES} ${REQUIRED_LIBRARIES_STATIC}
   )
 
   install(TARGETS czmq-static


### PR DESCRIPTION
```
Problem: ZeroMQ provides a cmake package config file that we can use

Solution: If available use the ZMQ package config file, otherwise fallback to FindlibZMQ.cmake
```
