### PR TITLE
Problem: release script for OBS build fails often

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,10 @@ env:
     - secure: "ZMvDhR/PxayFeHd70j8J5f260ydu4pSkMV4HFAjRd1e0YuYCy5PUCFIbXWpZ8XujlxcFVSOkfaekIvs4P5KejkKNxoJM+caJ4DAUW/zwtsrHhL1jT7HsCFdEpL2vcOZFXsfWBXkniVU800vgaV+YK4jfewyv0rPTQaImuMlrgRU="
     - secure: "Tc1HPM1HnWr4ZwtPKFMasrLLFgW0WHMZs6ncBFZMhKVKTjUnBO7zdKw4ZXvSEaa1pxqvJhuQRjcbmVL2H8NmT3IdWg7ToSTuDHazUP03QBGvXVKMxIhnPI9cOzsz6LQUklNY4WihairAwlt8hnD+85pU1vl0hEhMNmHLJ7RiT+4="
     - BINTRAY_USER_ORG=zeromq
-    # tokens to deploy releases on OBS and create/delete temporary branch on Github.
-    # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
-    #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
-    # 2) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
+    # tokens to deploy releases on OBS.
+    # 1) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
     #    encrypt them with travis encrypt --org -r <org>/<repo> OBS_<STABLE|DRAFT>_TOKEN="<token>"
-    # 3) Uncomment the three "secure" lines and paste the three generated hashed
+    # 2) Uncomment the three "secure" lines and paste the three generated hashed
     #    strings, which include each token's name, as parameters
     - secure: O0nI2RARxdXndopjlNI1EnnLvgbjbSk3+ZFuyxz2eW0zGm4/Bx7lRfQSqXnKtEGyjFsGdthVji24h5g1EQnrX0mmOvweH0tiTdfjfubnaUGMStU2DtGPOZMLE93khdwJcOsM9XeSsYK9MeTz3SYTLGsNcXDd6enOnrVygzUdmlk=
     - secure: LYZtGhy+XiKeUOLaqceeTRUZo76y2oo6f8Uv/c8Qvy9LcYueE+lDT5njXO/wUNVKt+V5TRZX/pURxo4osCB1Ax/tNoHIhcsvLzBEsjnd40MBfxvr8finBFVj4v/HOyguLMCljo4GhF4t71T+PY+Ewq5WYo3vxpKNmroZlrHp2Zg=

--- a/ci_deploy_obs.sh
+++ b/ci_deploy_obs.sh
@@ -8,15 +8,12 @@
 # do NOT set -x or it will log the secret tokens!
 set -e
 
-if [ "$BUILD_TYPE" == "default" -a -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
-    # Trigger source run on new tag on OBS. See travis.yml for token instructions.
-    # We have to create a temporary branch from the tag and delete it, as it is
-    # not possible to edit files on OBS with secure tokens, and it is not
-    # possible to dynamically fetch the latest git tag either.
-    TAG_SHA=$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET https://api.github.com/repos/zeromq/czmq/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\s).*(?=,)')
-    curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/czmq/git/refs/heads/latest_release
-    curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/latest_release\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/czmq/git/refs
-    sleep 2 # try to avoid races if Github is slow
-    curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
-    curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+if [ "$BUILD_TYPE" == "default" ] && [ -n "${OBS_STABLE_TOKEN}" -o -n "${OBS_DRAFT_TOKEN}" ]; then
+    # Trigger source run on new tag on OBS. The latest tag will be fetched.
+    if [ -n "${OBS_STABLE_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
+    if [ -n "${OBS_DRAFT_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
 fi

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -2,6 +2,8 @@
   <service name="tar_scm">
     <param name="url">https://github.com/zeromq/czmq</param>
     <param name="scm">git</param>
+    <!-- delete to build from latest master on each refresh -->
+    <param name="revision">@PARENT_TAG@</param>
     <param name="versionformat">@PARENT_TAG@+git%cd</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="versionrewrite-replacement">1</param>


### PR DESCRIPTION
Solution: now that tar_scm supports @PARENT_TAG@ as a revision to
automatically fetch the most recent tag on the default branch, use
it to simplify everything

https://github.com/openSUSE/obs-service-tar_scm/pull/359

Fixes https://github.com/zeromq/czmq/issues/2055