### PR TITLE
Problem: removing latest_branch breaks ABI CI job

### DIFF
--- a/builds/abi-compliance-checker/ci_build.sh
+++ b/builds/abi-compliance-checker/ci_build.sh
@@ -28,14 +28,17 @@ function print_abi_api_breakages() {
    exit 1
 }
 
+git fetch --all --tags
+git fetch --unshallow
+LATEST_VERSION=$(git describe --abbrev=0 --tags)
+
 ./autogen.sh
 ./configure "${CONFIG_OPTS[@]}"
 make VERBOSE=1 -j5
 abi-dumper -public-headers include src/.libs/libczmq.so -o ${BUILD_PREFIX}/libczmq.head.dump -lver HEAD
 
-git clone --depth 1 -b latest_release https://github.com/zeromq/czmq latest_release
+git clone --depth 1 -b ${LATEST_VERSION} https://github.com/zeromq/czmq latest_release
 cd latest_release
-LATEST_VERSION=$(git describe --abbrev=0 --tags)
 ./autogen.sh
 ./configure "${CONFIG_OPTS[@]}"
 make VERBOSe=1 -j5


### PR DESCRIPTION
Solution: clone latest tag instead
