### PR TITLE
Problem: zchunck pack() is creating frames based on the maximum instead of actual size

### DIFF
--- a/src/zchunk.c
+++ b/src/zchunk.c
@@ -477,7 +477,7 @@ zchunk_pack (zchunk_t *self)
 {
     assert (self);
     assert (zchunk_is (self));
-    return zframe_new (self->data, self->max_size);
+    return zframe_new (self->data, self->size);
 }
 
 
@@ -505,7 +505,7 @@ zchunk_packx (zchunk_t **self_p) {
     zchunk_t *self = *self_p;
     *self_p = NULL;
 
-    return zframe_frommem (self->data, self->max_size, (zchunk_destructor_fn *) zchunk_destroy, self);
+    return zframe_frommem (self->data, self->size, (zchunk_destructor_fn *) zchunk_destroy, self);
 }
 
 

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -2747,6 +2747,8 @@ zsys_test (bool verbose)
     zsys_set_max_msgsz (-1);
     assert (zsys_max_msgsz () == 2000);
 
+    // cleanup log_sender
+    zsys_set_logsender(NULL);
 
 #if defined (__WINDOWS__)
     zsys_shutdown();


### PR DESCRIPTION
Solution: use the chunk's actual size (self->size) instead of max_size.

Also added the cleanup of log_sender in zsys which left a dangling socket during tests.