### PR TITLE
Check for ipv6 availability

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4034,6 +4034,12 @@ void
 int
     zsys_ipv6 (void);
 
+// Test if ipv6 is available on the system. Return true if available.
+// The only way to reliably check is to actually open a socket and
+// try to bind it. (ported from libzmq)
+bool
+    zsys_ipv6_available (void);
+
 // Set network interface name to use for broadcasts, particularly zbeacon.
 // This lets the interface be configured for test environments where required.
 // For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/api/zsys.api
+++ b/api/zsys.api
@@ -440,6 +440,13 @@
         <return type = "integer" />
     </method>
 
+    <method name = "ipv6 available" singleton = "1" state = "draft">
+        Test if ipv6 is available on the system. Return true if available.
+        The only way to reliably check is to actually open a socket and 
+        try to bind it. (ported from libzmq)
+        <return type = "boolean" />
+    </method>
+
     <method name = "set interface" singleton = "1">
         Set network interface name to use for broadcasts, particularly zbeacon.
         This lets the interface be configured for test environments where required.

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -5556,6 +5556,11 @@ uses
     // Return use of IPv6 for zsock instances.
     class function Ipv6: Integer;
 
+    // Test if ipv6 is available on the system. Return true if available.
+    // The only way to reliably check is to actually open a socket and
+    // try to bind it. (ported from libzmq)
+    class function Ipv6Available: Boolean;
+
     // Set network interface name to use for broadcasts, particularly zbeacon.
     // This lets the interface be configured for test environments where required.
     // For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is
@@ -10013,6 +10018,11 @@ end;
   class function TZsys.Ipv6: Integer;
   begin
     Result := zsys_ipv6;
+  end;
+
+  class function TZsys.Ipv6Available: Boolean;
+  begin
+    Result := zsys_ipv6_available;
   end;
 
   class procedure TZsys.SetInterface(const Value: string);

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -3269,6 +3269,11 @@ type
   // Return use of IPv6 for zsock instances.
   function zsys_ipv6: Integer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
+  // Test if ipv6 is available on the system. Return true if available.
+  // The only way to reliably check is to actually open a socket and
+  // try to bind it. (ported from libzmq)
+  function zsys_ipv6_available: Boolean; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
   // Set network interface name to use for broadcasts, particularly zbeacon.
   // This lets the interface be configured for test environments where required.
   // For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zsys.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zsys.c
@@ -375,6 +375,13 @@ Java_org_zeromq_czmq_Zsys__1_1ipv6 (JNIEnv *env, jclass c)
     return ipv6_;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_org_zeromq_czmq_Zsys__1_1ipv6Available (JNIEnv *env, jclass c)
+{
+    jboolean ipv6_available_ = (jboolean) zsys_ipv6_available ();
+    return ipv6_available_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zsys__1_1setInterface (JNIEnv *env, jclass c, jstring value)
 {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -478,6 +478,15 @@ public class Zsys {
         return __ipv6 ();
     }
     /*
+    Test if ipv6 is available on the system. Return true if available.
+    The only way to reliably check is to actually open a socket and
+    try to bind it. (ported from libzmq)
+    */
+    native static boolean __ipv6Available ();
+    public static boolean ipv6Available () {
+        return __ipv6Available ();
+    }
+    /*
     Set network interface name to use for broadcasts, particularly zbeacon.
     This lets the interface be configured for test environments where required.
     For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4029,6 +4029,12 @@ void
 int
     zsys_ipv6 (void);
 
+// Test if ipv6 is available on the system. Return true if available.
+// The only way to reliably check is to actually open a socket and
+// try to bind it. (ported from libzmq)
+bool
+    zsys_ipv6_available (void);
+
 // Set network interface name to use for broadcasts, particularly zbeacon.
 // This lets the interface be configured for test environments where required.
 // For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -4276,6 +4276,14 @@ integer my_zsys.ipv6 ()
 Return use of IPv6 for zsock instances.
 
 ```
+boolean my_zsys.ipv6Available ()
+```
+
+Test if ipv6 is available on the system. Return true if available.
+The only way to reliably check is to actually open a socket and
+try to bind it. (ported from libzmq)
+
+```
 nothing my_zsys.setInterface (String)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -7430,6 +7430,7 @@ NAN_MODULE_INIT (Zsys::Init) {
     Nan::SetPrototypeMethod (tpl, "pipehwm", _pipehwm);
     Nan::SetPrototypeMethod (tpl, "setIpv6", _set_ipv6);
     Nan::SetPrototypeMethod (tpl, "ipv6", _ipv6);
+    Nan::SetPrototypeMethod (tpl, "ipv6Available", _ipv6_available);
     Nan::SetPrototypeMethod (tpl, "setInterface", _set_interface);
     Nan::SetPrototypeMethod (tpl, "interface", _interface);
     Nan::SetPrototypeMethod (tpl, "setIpv6Address", _set_ipv6_address);
@@ -8059,6 +8060,11 @@ NAN_METHOD (Zsys::_set_ipv6) {
 NAN_METHOD (Zsys::_ipv6) {
     int result = zsys_ipv6 ();
     info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zsys::_ipv6_available) {
+    bool result = zsys_ipv6_available ();
+    info.GetReturnValue ().Set (Nan::New<Boolean>(result));
 }
 
 NAN_METHOD (Zsys::_set_interface) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -894,6 +894,7 @@ class Zsys: public Nan::ObjectWrap {
     static NAN_METHOD (_pipehwm);
     static NAN_METHOD (_set_ipv6);
     static NAN_METHOD (_ipv6);
+    static NAN_METHOD (_ipv6_available);
     static NAN_METHOD (_set_interface);
     static NAN_METHOD (_interface);
     static NAN_METHOD (_set_ipv6_address);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -7569,6 +7569,8 @@ lib.zsys_set_ipv6.restype = None
 lib.zsys_set_ipv6.argtypes = [c_int]
 lib.zsys_ipv6.restype = c_int
 lib.zsys_ipv6.argtypes = []
+lib.zsys_ipv6_available.restype = c_bool
+lib.zsys_ipv6_available.argtypes = []
 lib.zsys_set_interface.restype = None
 lib.zsys_set_interface.argtypes = [c_char_p]
 lib.zsys_interface.restype = c_char_p
@@ -8154,6 +8156,15 @@ default. Note: has no effect on ZMQ v2.
         Return use of IPv6 for zsock instances.
         """
         return lib.zsys_ipv6()
+
+    @staticmethod
+    def ipv6_available():
+        """
+        Test if ipv6 is available on the system. Return true if available.
+The only way to reliably check is to actually open a socket and
+try to bind it. (ported from libzmq)
+        """
+        return lib.zsys_ipv6_available()
 
     @staticmethod
     def set_interface(value):

--- a/bindings/python_cffi/czmq_cffi/Zsys.py
+++ b/bindings/python_cffi/czmq_cffi/Zsys.py
@@ -519,6 +519,15 @@ class Zsys(object):
         return utils.lib.zsys_ipv6()
 
     @staticmethod
+    def ipv6_available():
+        """
+        Test if ipv6 is available on the system. Return true if available.
+        The only way to reliably check is to actually open a socket and
+        try to bind it. (ported from libzmq)
+        """
+        return utils.lib.zsys_ipv6_available()
+
+    @staticmethod
     def set_interface(value):
         """
         Set network interface name to use for broadcasts, particularly zbeacon.

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4036,6 +4036,12 @@ void
 int
     zsys_ipv6 (void);
 
+// Test if ipv6 is available on the system. Return true if available.
+// The only way to reliably check is to actually open a socket and
+// try to bind it. (ported from libzmq)
+bool
+    zsys_ipv6_available (void);
+
 // Set network interface name to use for broadcasts, particularly zbeacon.
 // This lets the interface be configured for test environments where required.
 // For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -470,6 +470,14 @@ int QmlZsysAttached::ipv6 () {
 };
 
 ///
+//  Test if ipv6 is available on the system. Return true if available.
+//  The only way to reliably check is to actually open a socket and
+//  try to bind it. (ported from libzmq)
+bool QmlZsysAttached::ipv6Available () {
+    return zsys_ipv6_available ();
+};
+
+///
 //  Set network interface name to use for broadcasts, particularly zbeacon.
 //  This lets the interface be configured for test environments where required.
 //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -323,6 +323,11 @@ public slots:
     //  Return use of IPv6 for zsock instances.
     int ipv6 ();
 
+    //  Test if ipv6 is available on the system. Return true if available.
+    //  The only way to reliably check is to actually open a socket and
+    //  try to bind it. (ported from libzmq)
+    bool ipv6Available ();
+
     //  Set network interface name to use for broadcasts, particularly zbeacon.
     //  This lets the interface be configured for test environments where required.
     //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -540,6 +540,16 @@ int QZsys::ipv6 ()
 }
 
 ///
+//  Test if ipv6 is available on the system. Return true if available.
+//  The only way to reliably check is to actually open a socket and
+//  try to bind it. (ported from libzmq)
+bool QZsys::ipv6Available ()
+{
+    bool rv = zsys_ipv6_available ();
+    return rv;
+}
+
+///
 //  Set network interface name to use for broadcasts, particularly zbeacon.
 //  This lets the interface be configured for test environments where required.
 //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -281,6 +281,11 @@ public:
     //  Return use of IPv6 for zsock instances.
     static int ipv6 ();
 
+    //  Test if ipv6 is available on the system. Return true if available.
+    //  The only way to reliably check is to actually open a socket and
+    //  try to bind it. (ported from libzmq)
+    static bool ipv6Available ();
+
     //  Set network interface name to use for broadcasts, particularly zbeacon.
     //  This lets the interface be configured for test environments where required.
     //  For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -839,6 +839,7 @@ module CZMQ
       attach_function :zsys_pipehwm, [], :size_t, **opts
       attach_function :zsys_set_ipv6, [:int], :void, **opts
       attach_function :zsys_ipv6, [], :int, **opts
+      attach_function :zsys_ipv6_available, [], :bool, **opts
       attach_function :zsys_set_interface, [:string], :void, **opts
       attach_function :zsys_interface, [], :string, **opts
       attach_function :zsys_set_ipv6_address, [:string], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/zsys.rb
+++ b/bindings/ruby/lib/czmq/ffi/zsys.rb
@@ -735,6 +735,16 @@ module CZMQ
         result
       end
 
+      # Test if ipv6 is available on the system. Return true if available.
+      # The only way to reliably check is to actually open a socket and
+      # try to bind it. (ported from libzmq)
+      #
+      # @return [Boolean]
+      def self.ipv6_available()
+        result = ::CZMQ::FFI.zsys_ipv6_available()
+        result
+      end
+
       # Set network interface name to use for broadcasts, particularly zbeacon.
       # This lets the interface be configured for test environments where required.
       # For example, on Mac OS X, zbeacon cannot bind to 255.255.255.255 which is

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -479,6 +479,13 @@ CZMQ_EXPORT int64_t
     zsys_file_stable_age_msec (void);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Test if ipv6 is available on the system. Return true if available.
+//  The only way to reliably check is to actually open a socket and
+//  try to bind it. (ported from libzmq)
+CZMQ_EXPORT bool
+    zsys_ipv6_available (void);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Set IPv4 multicast address to use for sending zbeacon messages. By default
 //  IPv4 multicast is NOT used. If the environment variable
 //  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -432,6 +432,13 @@ CZMQ_PRIVATE int64_t
     zsys_file_stable_age_msec (void);
 
 //  *** Draft method, defined for internal use only ***
+//  Test if ipv6 is available on the system. Return true if available.
+//  The only way to reliably check is to actually open a socket and
+//  try to bind it. (ported from libzmq)
+CZMQ_PRIVATE bool
+    zsys_ipv6_available (void);
+
+//  *** Draft method, defined for internal use only ***
 //  Set IPv4 multicast address to use for sending zbeacon messages. By default
 //  IPv4 multicast is NOT used. If the environment variable
 //  ZSYS_IPV4_MCAST_ADDRESS is set, use that as the default IPv4 multicast


### PR DESCRIPTION
Problem: it's inconvenient to do ipv6 stuff if it isn't available
Solution: add a zsys_ipv6_available method to test whether ipv6 is available like done in libzmq

This method is ported from libzmq and it has served me well. Might as well add it to czmq.
