### PR TITLE
zcertstore has no API to get the disk state from a custom loader #2113

### DIFF
--- a/include/zcertstore.h
+++ b/include/zcertstore.h
@@ -87,6 +87,11 @@ CZMQ_EXPORT void
 CZMQ_EXPORT zlistx_t *
     zcertstore_certs (zcertstore_t *self);
 
+//  --------------------------------------------------------------------------
+//  Return the state stored in certstore
+CZMQ_EXPORT void *
+ zcertstore_get_state (zcertstore_t *self);
+
 #endif // CZMQ_BUILD_DRAFT_API
 //  @end
 

--- a/src/zcertstore.c
+++ b/src/zcertstore.c
@@ -267,6 +267,17 @@ zcertstore_print (zcertstore_t *self)
     }
 }
 
+//  --------------------------------------------------------------------------
+//  Return the state stored in certstore
+void *
+zcertstore_get_state (zcertstore_t *self)
+{
+    if (self)
+        return self->state;
+
+    return NULL;
+}
+
 
 //  --------------------------------------------------------------------------
 //  Selftest


### PR DESCRIPTION
# Pull Request Notice

Before sending a pull request make sure each commit solves one clear, minimal,
plausible problem. Further each commit should have the following format:

```
Problem: 
We encountered 2 different issues listed below w.r.t CURVE authentication which uses zcertstore internally to store the client keys.

If there are multiple client certs with same timestamp or one of the cert has timestamp
a. On client connection request certstore gets refreshed
b. after that a new client cert is copied or valid cert is overwritten as the previous cert was invalid or corrupted, the certstore does not get refreshed and there after that connection will never be allowed as there is not change w.r.t timestamp, count and current size of the cert dir
If an application wants to load its custom disk loader (which loads all the certs on a change), then there is no API available to access the state store in zcertstore struct.

Solution:
1. The custom disk loader can have its own way of determining the cert directory changes. In our case we created SHA1 of the directory and compared every time before refreshing the certstore (test code and patch is attached for reference)
[czmq_certstore_custom_loader.zip](https://github.com/zeromq/czmq/files/5242953/czmq_certstore_custom_loader.zip)

2. Added a new API zcertstore_get_state() that returns the user defined disk state to the caller

