### PR TITLE
Problem: QNX does not support AI_V4MAPPED

### DIFF
--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -124,7 +124,7 @@ s_self_prepare_udp (self_t *self)
     struct addrinfo hint;
     memset (&hint, 0, sizeof(struct addrinfo));
     hint.ai_flags = AI_NUMERICHOST;
-#if !defined (CZMQ_HAVE_ANDROID) && !defined (CZMQ_HAVE_FREEBSD) && !defined (CZMQ_HAVE_OPENBSD)
+#if !defined (CZMQ_HAVE_ANDROID) && !defined (CZMQ_HAVE_FREEBSD) && !defined (CZMQ_HAVE_OPENBSD) && !defined (CZMQ_HAVE_QNXNTO)
     hint.ai_flags |= AI_V4MAPPED;
 #endif
     hint.ai_socktype = SOCK_DGRAM;


### PR DESCRIPTION
Solution: removes usage when building for QNX. Closes #2118
