### PR TITLE
Problem: Check for symbol AI_V4MAPPED based on incomplete platform list

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -4,6 +4,7 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
         [CFLAGS="${CFLAGS} -pthread"],
         [AC_MSG_WARN([cannot link with -pthread.])]
     )
+    AC_CHECK_DECLS([AI_V4MAPPED], [], [], [[#include <netdb.h>]])
 
     AC_CACHE_CHECK([whether SOCK_CLOEXEC is supported], [czmq_cv_sock_cloexec],
         [AC_TRY_RUN([/* SOCK_CLOEXEC test */

--- a/src/CMakeLists-local.txt
+++ b/src/CMakeLists-local.txt
@@ -43,3 +43,12 @@ int main(int argc, char *argv [])
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCZMQ_HAVE_SOCK_CLOEXEC=1")
   endif()
 endif()
+
+include(CheckSymbolExists)
+check_symbol_exists(AI_V4MAPPED "netdb.h" HAVE_DECL_AI_V4MAPPED)
+
+file(APPEND "${PROJECT_BINARY_DIR}/platform.h.in" "
+#cmakedefine01 HAVE_DECL_AI_V4MAPPED
+")
+
+configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/platform.h")

--- a/src/zbeacon.c
+++ b/src/zbeacon.c
@@ -124,7 +124,7 @@ s_self_prepare_udp (self_t *self)
     struct addrinfo hint;
     memset (&hint, 0, sizeof(struct addrinfo));
     hint.ai_flags = AI_NUMERICHOST;
-#if !defined (CZMQ_HAVE_ANDROID) && !defined (CZMQ_HAVE_FREEBSD) && !defined (CZMQ_HAVE_OPENBSD) && !defined (CZMQ_HAVE_QNXNTO)
+#if HAVE_DECL_AI_V4MAPPED
     hint.ai_flags |= AI_V4MAPPED;
 #endif
     hint.ai_socktype = SOCK_DGRAM;


### PR DESCRIPTION
Solution: Instead of checking for platforms that don't have AI_V4MAPPED
defined - which may to change in the future - use autotools or cmake
to check for the symbol.

If found they'll declare the define HAVE_DECL_AI_V4MAPPED with value 1
otherwise 0.