### PR TITLE
zosc: sending a char was one byte too big

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -237,7 +237,7 @@ zosc_create (const char *address, const char *format, ...)
                 char char_v = (char)va_arg( argptr, int); // the standard dictates to use int for smaller vars
                 //  osc dictates we need to supply data in multitudes of 4 bytes so create a 0 array to hold our char
                 //  Not sure if this correct on big endian machines!!!
-                char v[5] = "\x00\x00\x00\x00";
+                char v[4] = "\x00\x00\x00\x00";
                 v[3] = char_v;
                 size = zchunk_extend( self->chunk, v, sizeof(v) );
                 break;


### PR DESCRIPTION
Problem: Sending a single char through zosc was one byte off
Solution: remove the offending byte
