### PR TITLE
Implement zosc_print similar to liblo oscdump

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4689,7 +4689,7 @@ zframe_t *
 zosc_t *
     zosc_unpack (zframe_t *frame);
 
-// Dump OSC message to stderr, for debugging and tracing.
+// Dump OSC message to stdout, for debugging and tracing.
 void
     zosc_print (zosc_t *self);
 

--- a/api/zosc.api
+++ b/api/zosc.api
@@ -146,7 +146,7 @@
     </method>
 
     <method name = "print">
-        Dump OSC message to stderr, for debugging and tracing.
+        Dump OSC message to stdout, for debugging and tracing.
     </method>
 
     <method name = "is" singleton = "1">

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
@@ -171,7 +171,7 @@ public class Zosc implements AutoCloseable {
         return new Zosc (__unpack (frame.self));
     }
     /*
-    Dump OSC message to stderr, for debugging and tracing.
+    Dump OSC message to stdout, for debugging and tracing.
     */
     native static void __print (long self);
     public void print () {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4684,7 +4684,7 @@ zframe_t *
 zosc_t *
     zosc_unpack (zframe_t *frame);
 
-// Dump OSC message to stderr, for debugging and tracing.
+// Dump OSC message to stdout, for debugging and tracing.
 void
     zosc_print (zosc_t *self);
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -5132,7 +5132,7 @@ Transform a zframe into a zosc.
 nothing my_zosc.print ()
 ```
 
-Dump OSC message to stderr, for debugging and tracing.
+Dump OSC message to stdout, for debugging and tracing.
 
 ```
 nothing my_zosc.test (Boolean)

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -9700,7 +9700,7 @@ Take ownership of the chunk.
 
     def print(self):
         """
-        Dump OSC message to stderr, for debugging and tracing.
+        Dump OSC message to stdout, for debugging and tracing.
         """
         return lib.zosc_print(self._as_parameter_)
 

--- a/bindings/python_cffi/czmq_cffi/Zosc.py
+++ b/bindings/python_cffi/czmq_cffi/Zosc.py
@@ -164,7 +164,7 @@ See the class's test method for more examples how to use the class.
 
     def print_py(self):
         """
-        Dump OSC message to stderr, for debugging and tracing.
+        Dump OSC message to stdout, for debugging and tracing.
         """
         utils.lib.zosc_print(self._p)
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4691,7 +4691,7 @@ zframe_t *
 zosc_t *
     zosc_unpack (zframe_t *frame);
 
-// Dump OSC message to stderr, for debugging and tracing.
+// Dump OSC message to stdout, for debugging and tracing.
 void
     zosc_print (zosc_t *self);
 

--- a/bindings/qml/src/QmlZosc.cpp
+++ b/bindings/qml/src/QmlZosc.cpp
@@ -77,7 +77,7 @@ QmlZframe *QmlZosc::pack () {
 };
 
 ///
-//  Dump OSC message to stderr, for debugging and tracing.
+//  Dump OSC message to stdout, for debugging and tracing.
 void QmlZosc::print () {
     zosc_print (self);
 };

--- a/bindings/qml/src/QmlZosc.h
+++ b/bindings/qml/src/QmlZosc.h
@@ -71,7 +71,7 @@ public slots:
     //  Transform zosc into a zframe that can be sent in a message.
     QmlZframe *pack ();
 
-    //  Dump OSC message to stderr, for debugging and tracing.
+    //  Dump OSC message to stdout, for debugging and tracing.
     void print ();
 };
 

--- a/bindings/qt/src/qzosc.cpp
+++ b/bindings/qt/src/qzosc.cpp
@@ -127,7 +127,7 @@ QZosc * QZosc::unpack (QZframe *frame)
 }
 
 ///
-//  Dump OSC message to stderr, for debugging and tracing.
+//  Dump OSC message to stdout, for debugging and tracing.
 void QZosc::print ()
 {
     zosc_print (self);

--- a/bindings/qt/src/qzosc.h
+++ b/bindings/qt/src/qzosc.h
@@ -72,7 +72,7 @@ public:
     //  Transform a zframe into a zosc.
     static QZosc * unpack (QZframe *frame);
 
-    //  Dump OSC message to stderr, for debugging and tracing.
+    //  Dump OSC message to stdout, for debugging and tracing.
     void print ();
 
     //  Probe the supplied object, and report if it looks like a zosc_t.

--- a/bindings/ruby/lib/czmq/ffi/zosc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zosc.rb
@@ -277,7 +277,7 @@ module CZMQ
         result
       end
 
-      # Dump OSC message to stderr, for debugging and tracing.
+      # Dump OSC message to stdout, for debugging and tracing.
       #
       # @return [void]
       def print()

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -243,12 +243,15 @@ function android_build_verify_so {
     fi
     android_build_check_fail
 
-    if command -v readelf >/dev/null 2>&1 ; then
+    local READELF="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-readelf"
+    if command -v ${READELF} >/dev/null 2>&1 ; then
+        local readelf_bin="${READELF}"
+    elif command -v readelf >/dev/null 2>&1 ; then
         local readelf_bin="readelf"
     elif command -v greadelf >/dev/null 2>&1 ; then
         local readelf_bin="greadelf"
     else
-        ANDROID_BUILD_FAIL+=("Could not find [g]readelf")
+        ANDROID_BUILD_FAIL+=("Could not find any of readelf, greadelf, or ${READELF}")
     fi
     android_build_check_fail
 

--- a/include/zosc.h
+++ b/include/zosc.h
@@ -140,7 +140,7 @@ CZMQ_EXPORT zosc_t *
     zosc_unpack (zframe_t *frame);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Dump OSC message to stderr, for debugging and tracing.
+//  Dump OSC message to stdout, for debugging and tracing.
 CZMQ_EXPORT void
     zosc_print (zosc_t *self);
 


### PR DESCRIPTION
Problem: zosc_print wasn't implemented, zproject is out of date.
Solution: implement zosc_print similar to liblo, regenerate from zproject
