### PR TITLE
Problem: getting values from zosc message without knowing the format before hand

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4701,19 +4701,67 @@ bool
 // Sets the given char argument to the type tag of the data.
 // If the message is empty, returns NULL and the sets the
 // given char to NULL.
-void *
+const void *
     zosc_first (zosc_t *self, char *type);
 
 // Return the next item of the OSC message. If the list is empty, returns
 // NULL. To move to the start of the OSC message call zosc_first ().
-void *
+const void *
     zosc_next (zosc_t *self, char *type);
 
 // Return a pointer to the item at the tail of the OSC message.
 // Sets the given char argument to the type tag of the data. If
 // the message is empty, returns NULL.
-void *
+const void *
     zosc_last (zosc_t *self, char *type);
+
+// Set the provided 32 bit integer from value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int32 (zosc_t *self, int *val);
+
+// Set the provided 64 bit integer from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int64 (zosc_t *self, int64_t *val);
+
+// Set the provided float from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_float (zosc_t *self, float *val);
+
+// Set the provided double from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_double (zosc_t *self, double *val);
+
+// Set the provided string from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success. Caller owns the string!
+int
+    zosc_pop_string (zosc_t *self, char **val);
+
+// Set the provided char from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_char (zosc_t *self, char *val);
+
+// Set the provided boolean from the type tag in the message. Booleans are not represented
+// in the data in the message, only in the type tag. If the type tag at the current
+// position does not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_bool (zosc_t *self, bool *val);
+
+// Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+// cursor position in the message. If the type tag at the current position does
+// not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_midi (zosc_t *self, uint32_t *val);
 
 // Self test of this class.
 void

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4697,6 +4697,24 @@ void
 bool
     zosc_is (void *self);
 
+// Return a pointer to the item at the head of the OSC data.
+// Sets the given char argument to the type tag of the data.
+// If the message is empty, returns NULL and the sets the
+// given char to NULL.
+void *
+    zosc_first (zosc_t *self, char *type);
+
+// Return the next item of the OSC message. If the list is empty, returns
+// NULL. To move to the start of the OSC message call zosc_first ().
+void *
+    zosc_next (zosc_t *self, char *type);
+
+// Return a pointer to the item at the tail of the OSC message.
+// Sets the given char argument to the type tag of the data. If
+// the message is empty, returns NULL.
+void *
+    zosc_last (zosc_t *self, char *type);
+
 // Self test of this class.
 void
     zosc_test (bool verbose);

--- a/api/zosc.api
+++ b/api/zosc.api
@@ -161,14 +161,14 @@
         If the message is empty, returns NULL and the sets the 
         given char to NULL.
         <argument name = "type" type = "char" by_reference = "1" />
-        <return type = "anything" />
+        <return type = "anything" mutable = "0" />
     </method>
 
     <method name = "next">
         Return the next item of the OSC message. If the list is empty, returns 
         NULL. To move to the start of the OSC message call zosc_first (). 
         <argument name = "type" type = "char" by_reference = "1" />
-        <return type = "anything" />
+        <return type = "anything" mutable = "0" />
     </method>
 
     <method name = "last">
@@ -176,6 +176,71 @@
         Sets the given char argument to the type tag of the data. If 
         the message is empty, returns NULL. 
         <argument name = "type" type = "char" by_reference = "1" />
-        <return type = "anything" />
+        <return type = "anything" mutable = "0" />
     </method>
+
+    <method name = "pop int32">
+        Set the provided 32 bit integer from value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success.
+        <argument name = "val" type = "integer" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop int64">
+        Set the provided 64 bit integer from the value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success.
+        <argument name = "val" type = "msecs" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop float">
+        Set the provided float from the value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success.
+        <argument name = "val" type = "real" size = "4" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop double">
+        Set the provided double from the value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success.
+        <argument name = "val" type = "real" size = "8" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop string">
+        Set the provided string from the value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success. Caller owns the string!
+        <argument name = "val" type = "string" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop char">
+        Set the provided char from the value at the current cursor position in the message. 
+        If the type tag at the current position does not correspond it will fail and 
+        return -1. Returns 0 on success.
+        <argument name = "val" type = "char" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop bool">
+        Set the provided boolean from the type tag in the message. Booleans are not represented
+        in the data in the message, only in the type tag. If the type tag at the current 
+        position does not correspond it will fail and return -1. Returns 0 on success.
+        <argument name = "val" type = "boolean" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
+    <method name = "pop midi">
+        Set the provided 4 bytes (unsigned 32bit int) from the value at the current 
+        cursor position in the message. If the type tag at the current position does 
+        not correspond it will fail and return -1. Returns 0 on success.
+        <argument name = "val" type = "number" size = "4" by_reference = "1" />
+        <return type = "integer" />
+    </method>
+
 </class>

--- a/api/zosc.api
+++ b/api/zosc.api
@@ -154,4 +154,28 @@
         <argument name = "self" type = "anything" mutable = "1" />
         <return type = "boolean" />
     </method>
+
+    <method name = "first">
+        Return a pointer to the item at the head of the OSC data. 
+        Sets the given char argument to the type tag of the data.
+        If the message is empty, returns NULL and the sets the 
+        given char to NULL.
+        <argument name = "type" type = "char" by_reference = "1" />
+        <return type = "anything" />
+    </method>
+
+    <method name = "next">
+        Return the next item of the OSC message. If the list is empty, returns 
+        NULL. To move to the start of the OSC message call zosc_first (). 
+        <argument name = "type" type = "char" by_reference = "1" />
+        <return type = "anything" />
+    </method>
+
+    <method name = "last">
+        Return a pointer to the item at the tail of the OSC message. 
+        Sets the given char argument to the type tag of the data. If 
+        the message is empty, returns NULL. 
+        <argument name = "type" type = "char" by_reference = "1" />
+        <return type = "anything" />
+    </method>
 </class>

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
@@ -137,6 +137,27 @@ Java_org_zeromq_czmq_Zosc__1_1is (JNIEnv *env, jclass c, jlong self)
     return is_;
 }
 
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zosc__1_1first (JNIEnv *env, jclass c, jlong self, jchar type)
+{
+    jlong first_ = (jlong) (intptr_t) zosc_first ((zosc_t *) (intptr_t) self, (char *) (intptr_t) &type);
+    return first_;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zosc__1_1next (JNIEnv *env, jclass c, jlong self, jchar type)
+{
+    jlong next_ = (jlong) (intptr_t) zosc_next ((zosc_t *) (intptr_t) self, (char *) (intptr_t) &type);
+    return next_;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zosc__1_1last (JNIEnv *env, jclass c, jlong self, jchar type)
+{
+    jlong last_ = (jlong) (intptr_t) zosc_last ((zosc_t *) (intptr_t) self, (char *) (intptr_t) &type);
+    return last_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zosc__1_1test (JNIEnv *env, jclass c, jboolean verbose)
 {

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
@@ -158,6 +158,55 @@ Java_org_zeromq_czmq_Zosc__1_1last (JNIEnv *env, jclass c, jlong self, jchar typ
     return last_;
 }
 
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popInt32 (JNIEnv *env, jclass c, jlong self, jint val)
+{
+    jint pop_int32_ = (jint) zosc_pop_int32 ((zosc_t *) (intptr_t) self, (int *) (intptr_t) &val);
+    return pop_int32_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popInt64 (JNIEnv *env, jclass c, jlong self, jlong val)
+{
+    jint pop_int64_ = (jint) zosc_pop_int64 ((zosc_t *) (intptr_t) self, (int64_t *) (intptr_t) &val);
+    return pop_int64_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popFloat (JNIEnv *env, jclass c, jlong self, jfloat val)
+{
+    jint pop_float_ = (jint) zosc_pop_float ((zosc_t *) (intptr_t) self, (float *) (intptr_t) &val);
+    return pop_float_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popDouble (JNIEnv *env, jclass c, jlong self, jdouble val)
+{
+    jint pop_double_ = (jint) zosc_pop_double ((zosc_t *) (intptr_t) self, (double *) (intptr_t) &val);
+    return pop_double_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popChar (JNIEnv *env, jclass c, jlong self, jchar val)
+{
+    jint pop_char_ = (jint) zosc_pop_char ((zosc_t *) (intptr_t) self, (char *) (intptr_t) &val);
+    return pop_char_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popBool (JNIEnv *env, jclass c, jlong self, jboolean val)
+{
+    jint pop_bool_ = (jint) zosc_pop_bool ((zosc_t *) (intptr_t) self, (bool *) (intptr_t) &val);
+    return pop_bool_;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_zeromq_czmq_Zosc__1_1popMidi (JNIEnv *env, jclass c, jlong self, jint val)
+{
+    jint pop_midi_ = (jint) zosc_pop_midi ((zosc_t *) (intptr_t) self, (uint32_t *) (intptr_t) &val);
+    return pop_midi_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zosc__1_1test (JNIEnv *env, jclass c, jboolean verbose)
 {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
@@ -212,6 +212,69 @@ public class Zosc implements AutoCloseable {
         return __last (self, type);
     }
     /*
+    Set the provided 32 bit integer from value at the current cursor position in the message.
+    If the type tag at the current position does not correspond it will fail and
+    return -1. Returns 0 on success.
+    */
+    native static int __popInt32 (long self, int val);
+    public int popInt32 (int val) {
+        return __popInt32 (self, val);
+    }
+    /*
+    Set the provided 64 bit integer from the value at the current cursor position in the message.
+    If the type tag at the current position does not correspond it will fail and
+    return -1. Returns 0 on success.
+    */
+    native static int __popInt64 (long self, long val);
+    public int popInt64 (long val) {
+        return __popInt64 (self, val);
+    }
+    /*
+    Set the provided float from the value at the current cursor position in the message.
+    If the type tag at the current position does not correspond it will fail and
+    return -1. Returns 0 on success.
+    */
+    native static int __popFloat (long self, float val);
+    public int popFloat (float val) {
+        return __popFloat (self, val);
+    }
+    /*
+    Set the provided double from the value at the current cursor position in the message.
+    If the type tag at the current position does not correspond it will fail and
+    return -1. Returns 0 on success.
+    */
+    native static int __popDouble (long self, double val);
+    public int popDouble (double val) {
+        return __popDouble (self, val);
+    }
+    /*
+    Set the provided char from the value at the current cursor position in the message.
+    If the type tag at the current position does not correspond it will fail and
+    return -1. Returns 0 on success.
+    */
+    native static int __popChar (long self, char val);
+    public int popChar (char val) {
+        return __popChar (self, val);
+    }
+    /*
+    Set the provided boolean from the type tag in the message. Booleans are not represented
+    in the data in the message, only in the type tag. If the type tag at the current
+    position does not correspond it will fail and return -1. Returns 0 on success.
+    */
+    native static int __popBool (long self, boolean val);
+    public int popBool (boolean val) {
+        return __popBool (self, val);
+    }
+    /*
+    Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+    cursor position in the message. If the type tag at the current position does
+    not correspond it will fail and return -1. Returns 0 on success.
+    */
+    native static int __popMidi (long self, int val);
+    public int popMidi (int val) {
+        return __popMidi (self, val);
+    }
+    /*
     Self test of this class.
     */
     native static void __test (boolean verbose);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
@@ -185,6 +185,33 @@ public class Zosc implements AutoCloseable {
         return __is (self);
     }
     /*
+    Return a pointer to the item at the head of the OSC data.
+    Sets the given char argument to the type tag of the data.
+    If the message is empty, returns NULL and the sets the
+    given char to NULL.
+    */
+    native static long __first (long self, char type);
+    public long first (char type) {
+        return __first (self, type);
+    }
+    /*
+    Return the next item of the OSC message. If the list is empty, returns
+    NULL. To move to the start of the OSC message call zosc_first ().
+    */
+    native static long __next (long self, char type);
+    public long next (char type) {
+        return __next (self, type);
+    }
+    /*
+    Return a pointer to the item at the tail of the OSC message.
+    Sets the given char argument to the type tag of the data. If
+    the message is empty, returns NULL.
+    */
+    native static long __last (long self, char type);
+    public long last (char type) {
+        return __last (self, type);
+    }
+    /*
     Self test of this class.
     */
     native static void __test (boolean verbose);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4696,19 +4696,67 @@ bool
 // Sets the given char argument to the type tag of the data.
 // If the message is empty, returns NULL and the sets the
 // given char to NULL.
-void *
+const void *
     zosc_first (zosc_t *self, char *type);
 
 // Return the next item of the OSC message. If the list is empty, returns
 // NULL. To move to the start of the OSC message call zosc_first ().
-void *
+const void *
     zosc_next (zosc_t *self, char *type);
 
 // Return a pointer to the item at the tail of the OSC message.
 // Sets the given char argument to the type tag of the data. If
 // the message is empty, returns NULL.
-void *
+const void *
     zosc_last (zosc_t *self, char *type);
+
+// Set the provided 32 bit integer from value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int32 (zosc_t *self, int *val);
+
+// Set the provided 64 bit integer from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int64 (zosc_t *self, int64_t *val);
+
+// Set the provided float from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_float (zosc_t *self, float *val);
+
+// Set the provided double from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_double (zosc_t *self, double *val);
+
+// Set the provided string from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success. Caller owns the string!
+int
+    zosc_pop_string (zosc_t *self, char **val);
+
+// Set the provided char from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_char (zosc_t *self, char *val);
+
+// Set the provided boolean from the type tag in the message. Booleans are not represented
+// in the data in the message, only in the type tag. If the type tag at the current
+// position does not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_bool (zosc_t *self, bool *val);
+
+// Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+// cursor position in the message. If the type tag at the current position does
+// not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_midi (zosc_t *self, uint32_t *val);
 
 // Self test of this class.
 void

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4692,6 +4692,24 @@ void
 bool
     zosc_is (void *self);
 
+// Return a pointer to the item at the head of the OSC data.
+// Sets the given char argument to the type tag of the data.
+// If the message is empty, returns NULL and the sets the
+// given char to NULL.
+void *
+    zosc_first (zosc_t *self, char *type);
+
+// Return the next item of the OSC message. If the list is empty, returns
+// NULL. To move to the start of the OSC message call zosc_first ().
+void *
+    zosc_next (zosc_t *self, char *type);
+
+// Return a pointer to the item at the tail of the OSC message.
+// Sets the given char argument to the type tag of the data. If
+// the message is empty, returns NULL.
+void *
+    zosc_last (zosc_t *self, char *type);
+
 // Self test of this class.
 void
     zosc_test (bool verbose);

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -5135,6 +5135,70 @@ nothing my_zosc.print ()
 Dump OSC message to stdout, for debugging and tracing.
 
 ```
+integer my_zosc.popInt32 (Number)
+```
+
+Set the provided 32 bit integer from value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+
+```
+integer my_zosc.popInt64 (Number)
+```
+
+Set the provided 64 bit integer from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+
+```
+integer my_zosc.popFloat (Number)
+```
+
+Set the provided float from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+
+```
+integer my_zosc.popDouble (Number)
+```
+
+Set the provided double from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+
+```
+integer my_zosc.popString (String)
+```
+
+Set the provided string from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success. Caller owns the string!
+
+```
+integer my_zosc.popChar (String)
+```
+
+Set the provided char from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+
+```
+integer my_zosc.popBool (Boolean)
+```
+
+Set the provided boolean from the type tag in the message. Booleans are not represented
+in the data in the message, only in the type tag. If the type tag at the current
+position does not correspond it will fail and return -1. Returns 0 on success.
+
+```
+integer my_zosc.popMidi (Number)
+```
+
+Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+cursor position in the message. If the type tag at the current position does
+not correspond it will fail and return -1. Returns 0 on success.
+
+```
 nothing my_zosc.test (Boolean)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -9586,6 +9586,14 @@ NAN_MODULE_INIT (Zosc::Init) {
     Nan::SetPrototypeMethod (tpl, "packx", _packx);
     Nan::SetPrototypeMethod (tpl, "unpack", _unpack);
     Nan::SetPrototypeMethod (tpl, "print", _print);
+    Nan::SetPrototypeMethod (tpl, "popInt32", _pop_int32);
+    Nan::SetPrototypeMethod (tpl, "popInt64", _pop_int64);
+    Nan::SetPrototypeMethod (tpl, "popFloat", _pop_float);
+    Nan::SetPrototypeMethod (tpl, "popDouble", _pop_double);
+    Nan::SetPrototypeMethod (tpl, "popString", _pop_string);
+    Nan::SetPrototypeMethod (tpl, "popChar", _pop_char);
+    Nan::SetPrototypeMethod (tpl, "popBool", _pop_bool);
+    Nan::SetPrototypeMethod (tpl, "popMidi", _pop_midi);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
     constructor ().Reset (Nan::GetFunction (tpl).ToLocalChecked ());
@@ -9725,6 +9733,158 @@ NAN_METHOD (Zosc::_unpack) {
 NAN_METHOD (Zosc::_print) {
     Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
     zosc_print (zosc->self);
+}
+
+NAN_METHOD (Zosc::_pop_int32) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //int * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    int val;
+
+
+    if (info [0]->IsNumber ())
+    {
+          val = Nan::To<int>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a number");
+    int result = zosc_pop_int32 (zosc->self, (int *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_int64) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //int64_t * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    int64_t val;
+
+
+    if (info [0]->IsNumber ())
+    {
+          val = Nan::To<int64_t>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a number");
+    int result = zosc_pop_int64 (zosc->self, (int64_t *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_float) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //float * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    double val;
+
+
+    if (info [0]->IsDouble ())
+    {
+          val = Nan::To<double>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a number");
+    int result = zosc_pop_float (zosc->self, (float *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_double) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //double * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    double val;
+
+
+    if (info [0]->IsDouble ())
+    {
+          val = Nan::To<double>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a number");
+    int result = zosc_pop_double (zosc->self, (double *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_string) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    char *val;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`val` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String val_utf8 (info [0].As<String>());
+    val = *val_utf8;
+         //} //bjornw end
+    int result = zosc_pop_string (zosc->self, (char **)&val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_char) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    char val;
+    if (info [0]->IsUndefined ())
+    {
+        return Nan::ThrowTypeError ("method requires a `val`");
+    }
+    else if (!info [0]->IsString ())
+    {
+        return Nan::ThrowTypeError ("`val` must be a string");
+    }
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String val_utf8 (info [0].As<String>());
+
+    if (strlen (*val_utf8) != 1)
+        return Nan::ThrowTypeError ("`val` must be a single character");
+    val = (*val_utf8) [0];
+    //} // bjornw end
+    int result = zosc_pop_char (zosc->self, (char *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_bool) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //bool * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    bool val;
+
+
+    if (info [0]->IsBoolean ())
+    {
+          val = Nan::To<bool>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a Boolean");
+    int result = zosc_pop_bool (zosc->self, (bool *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zosc::_pop_midi) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `val`");
+
+    //uint32_t * val; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    uint32_t val;
+
+
+    if (info [0]->IsNumber ())
+    {
+          val = Nan::To<uint32_t>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`val` must be a number");
+    int result = zosc_pop_midi (zosc->self, (uint32_t *) &val);
+    info.GetReturnValue ().Set (Nan::New<Number>(result));
 }
 
 NAN_METHOD (Zosc::_test) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -1122,6 +1122,14 @@ class Zosc: public Nan::ObjectWrap {
     static NAN_METHOD (_packx);
     static NAN_METHOD (_unpack);
     static NAN_METHOD (_print);
+    static NAN_METHOD (_pop_int32);
+    static NAN_METHOD (_pop_int64);
+    static NAN_METHOD (_pop_float);
+    static NAN_METHOD (_pop_double);
+    static NAN_METHOD (_pop_string);
+    static NAN_METHOD (_pop_char);
+    static NAN_METHOD (_pop_bool);
+    static NAN_METHOD (_pop_midi);
     static NAN_METHOD (_test);
 };
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -9509,6 +9509,12 @@ lib.zosc_print.restype = None
 lib.zosc_print.argtypes = [zosc_p]
 lib.zosc_is.restype = c_bool
 lib.zosc_is.argtypes = [c_void_p]
+lib.zosc_first.restype = c_void_p
+lib.zosc_first.argtypes = [zosc_p, POINTER(char_p)]
+lib.zosc_next.restype = c_void_p
+lib.zosc_next.argtypes = [zosc_p, POINTER(char_p)]
+lib.zosc_last.restype = c_void_p
+lib.zosc_last.argtypes = [zosc_p, POINTER(char_p)]
 lib.zosc_test.restype = None
 lib.zosc_test.argtypes = [c_bool]
 
@@ -9710,6 +9716,30 @@ Take ownership of the chunk.
         Probe the supplied object, and report if it looks like a zosc_t.
         """
         return lib.zosc_is(self)
+
+    def first(self, type):
+        """
+        Return a pointer to the item at the head of the OSC data.
+Sets the given char argument to the type tag of the data.
+If the message is empty, returns NULL and the sets the
+given char to NULL.
+        """
+        return c_void_p(lib.zosc_first(self._as_parameter_, byref(char_p.from_param(type))))
+
+    def next(self, type):
+        """
+        Return the next item of the OSC message. If the list is empty, returns
+NULL. To move to the start of the OSC message call zosc_first ().
+        """
+        return c_void_p(lib.zosc_next(self._as_parameter_, byref(char_p.from_param(type))))
+
+    def last(self, type):
+        """
+        Return a pointer to the item at the tail of the OSC message.
+Sets the given char argument to the type tag of the data. If
+the message is empty, returns NULL.
+        """
+        return c_void_p(lib.zosc_last(self._as_parameter_, byref(char_p.from_param(type))))
 
     @staticmethod
     def test(verbose):

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -9515,6 +9515,22 @@ lib.zosc_next.restype = c_void_p
 lib.zosc_next.argtypes = [zosc_p, POINTER(char_p)]
 lib.zosc_last.restype = c_void_p
 lib.zosc_last.argtypes = [zosc_p, POINTER(char_p)]
+lib.zosc_pop_int32.restype = c_int
+lib.zosc_pop_int32.argtypes = [zosc_p, POINTER(c_int)]
+lib.zosc_pop_int64.restype = c_int
+lib.zosc_pop_int64.argtypes = [zosc_p, POINTER(msecs_p)]
+lib.zosc_pop_float.restype = c_int
+lib.zosc_pop_float.argtypes = [zosc_p, POINTER(c_float)]
+lib.zosc_pop_double.restype = c_int
+lib.zosc_pop_double.argtypes = [zosc_p, POINTER(c_double)]
+lib.zosc_pop_string.restype = c_int
+lib.zosc_pop_string.argtypes = [zosc_p, POINTER(c_char_p)]
+lib.zosc_pop_char.restype = c_int
+lib.zosc_pop_char.argtypes = [zosc_p, POINTER(char_p)]
+lib.zosc_pop_bool.restype = c_int
+lib.zosc_pop_bool.argtypes = [zosc_p, POINTER(c_bool)]
+lib.zosc_pop_midi.restype = c_int
+lib.zosc_pop_midi.argtypes = [zosc_p, POINTER(c_int)]
 lib.zosc_test.restype = None
 lib.zosc_test.argtypes = [c_bool]
 
@@ -9740,6 +9756,70 @@ Sets the given char argument to the type tag of the data. If
 the message is empty, returns NULL.
         """
         return c_void_p(lib.zosc_last(self._as_parameter_, byref(char_p.from_param(type))))
+
+    def pop_int32(self, val):
+        """
+        Set the provided 32 bit integer from value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_int32(self._as_parameter_, byref(c_int.from_param(val)))
+
+    def pop_int64(self, val):
+        """
+        Set the provided 64 bit integer from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_int64(self._as_parameter_, byref(msecs_p.from_param(val)))
+
+    def pop_float(self, val):
+        """
+        Set the provided float from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_float(self._as_parameter_, byref(c_float.from_param(val)))
+
+    def pop_double(self, val):
+        """
+        Set the provided double from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_double(self._as_parameter_, byref(c_double.from_param(val)))
+
+    def pop_string(self, val):
+        """
+        Set the provided string from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success. Caller owns the string!
+        """
+        return lib.zosc_pop_string(self._as_parameter_, byref(c_char_p.from_param(val)))
+
+    def pop_char(self, val):
+        """
+        Set the provided char from the value at the current cursor position in the message.
+If the type tag at the current position does not correspond it will fail and
+return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_char(self._as_parameter_, byref(char_p.from_param(val)))
+
+    def pop_bool(self, val):
+        """
+        Set the provided boolean from the type tag in the message. Booleans are not represented
+in the data in the message, only in the type tag. If the type tag at the current
+position does not correspond it will fail and return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_bool(self._as_parameter_, byref(c_bool.from_param(val)))
+
+    def pop_midi(self, val):
+        """
+        Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+cursor position in the message. If the type tag at the current position does
+not correspond it will fail and return -1. Returns 0 on success.
+        """
+        return lib.zosc_pop_midi(self._as_parameter_, byref(c_int.from_param(val)))
 
     @staticmethod
     def test(verbose):

--- a/bindings/python_cffi/czmq_cffi/Zosc.py
+++ b/bindings/python_cffi/czmq_cffi/Zosc.py
@@ -199,6 +199,70 @@ See the class's test method for more examples how to use the class.
         """
         return utils.lib.zosc_last(self._p, utils.ffi.new("char_t **", type._p))
 
+    def pop_int32(self, val):
+        """
+        Set the provided 32 bit integer from value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_int32(self._p, val)
+
+    def pop_int64(self, val):
+        """
+        Set the provided 64 bit integer from the value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_int64(self._p, utils.ffi.new("msecs_t **", val._p))
+
+    def pop_float(self, val):
+        """
+        Set the provided float from the value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_float(self._p, val)
+
+    def pop_double(self, val):
+        """
+        Set the provided double from the value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_double(self._p, val)
+
+    def pop_string(self, val):
+        """
+        Set the provided string from the value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success. Caller owns the string!
+        """
+        return utils.lib.zosc_pop_string(self._p, utils.to_bytes(val))
+
+    def pop_char(self, val):
+        """
+        Set the provided char from the value at the current cursor position in the message.
+        If the type tag at the current position does not correspond it will fail and
+        return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_char(self._p, utils.ffi.new("char_t **", val._p))
+
+    def pop_bool(self, val):
+        """
+        Set the provided boolean from the type tag in the message. Booleans are not represented
+        in the data in the message, only in the type tag. If the type tag at the current
+        position does not correspond it will fail and return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_bool(self._p, val)
+
+    def pop_midi(self, val):
+        """
+        Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+        cursor position in the message. If the type tag at the current position does
+        not correspond it will fail and return -1. Returns 0 on success.
+        """
+        return utils.lib.zosc_pop_midi(self._p, val)
+
     @staticmethod
     def test(verbose):
         """

--- a/bindings/python_cffi/czmq_cffi/Zosc.py
+++ b/bindings/python_cffi/czmq_cffi/Zosc.py
@@ -175,6 +175,30 @@ See the class's test method for more examples how to use the class.
         """
         return utils.lib.zosc_is(self._p)
 
+    def first(self, type):
+        """
+        Return a pointer to the item at the head of the OSC data.
+        Sets the given char argument to the type tag of the data.
+        If the message is empty, returns NULL and the sets the
+        given char to NULL.
+        """
+        return utils.lib.zosc_first(self._p, utils.ffi.new("char_t **", type._p))
+
+    def next(self, type):
+        """
+        Return the next item of the OSC message. If the list is empty, returns
+        NULL. To move to the start of the OSC message call zosc_first ().
+        """
+        return utils.lib.zosc_next(self._p, utils.ffi.new("char_t **", type._p))
+
+    def last(self, type):
+        """
+        Return a pointer to the item at the tail of the OSC message.
+        Sets the given char argument to the type tag of the data. If
+        the message is empty, returns NULL.
+        """
+        return utils.lib.zosc_last(self._p, utils.ffi.new("char_t **", type._p))
+
     @staticmethod
     def test(verbose):
         """

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4703,19 +4703,67 @@ bool
 // Sets the given char argument to the type tag of the data.
 // If the message is empty, returns NULL and the sets the
 // given char to NULL.
-void *
+const void *
     zosc_first (zosc_t *self, char *type);
 
 // Return the next item of the OSC message. If the list is empty, returns
 // NULL. To move to the start of the OSC message call zosc_first ().
-void *
+const void *
     zosc_next (zosc_t *self, char *type);
 
 // Return a pointer to the item at the tail of the OSC message.
 // Sets the given char argument to the type tag of the data. If
 // the message is empty, returns NULL.
-void *
+const void *
     zosc_last (zosc_t *self, char *type);
+
+// Set the provided 32 bit integer from value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int32 (zosc_t *self, int *val);
+
+// Set the provided 64 bit integer from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_int64 (zosc_t *self, int64_t *val);
+
+// Set the provided float from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_float (zosc_t *self, float *val);
+
+// Set the provided double from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_double (zosc_t *self, double *val);
+
+// Set the provided string from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success. Caller owns the string!
+int
+    zosc_pop_string (zosc_t *self, char **val);
+
+// Set the provided char from the value at the current cursor position in the message.
+// If the type tag at the current position does not correspond it will fail and
+// return -1. Returns 0 on success.
+int
+    zosc_pop_char (zosc_t *self, char *val);
+
+// Set the provided boolean from the type tag in the message. Booleans are not represented
+// in the data in the message, only in the type tag. If the type tag at the current
+// position does not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_bool (zosc_t *self, bool *val);
+
+// Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+// cursor position in the message. If the type tag at the current position does
+// not correspond it will fail and return -1. Returns 0 on success.
+int
+    zosc_pop_midi (zosc_t *self, uint32_t *val);
 
 // Self test of this class.
 void

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4699,6 +4699,24 @@ void
 bool
     zosc_is (void *self);
 
+// Return a pointer to the item at the head of the OSC data.
+// Sets the given char argument to the type tag of the data.
+// If the message is empty, returns NULL and the sets the
+// given char to NULL.
+void *
+    zosc_first (zosc_t *self, char *type);
+
+// Return the next item of the OSC message. If the list is empty, returns
+// NULL. To move to the start of the OSC message call zosc_first ().
+void *
+    zosc_next (zosc_t *self, char *type);
+
+// Return a pointer to the item at the tail of the OSC message.
+// Sets the given char argument to the type tag of the data. If
+// the message is empty, returns NULL.
+void *
+    zosc_last (zosc_t *self, char *type);
+
 // Self test of this class.
 void
     zosc_test (bool verbose);

--- a/bindings/qml/src/QmlZosc.cpp
+++ b/bindings/qml/src/QmlZosc.cpp
@@ -82,6 +82,30 @@ void QmlZosc::print () {
     zosc_print (self);
 };
 
+///
+//  Return a pointer to the item at the head of the OSC data.
+//  Sets the given char argument to the type tag of the data.
+//  If the message is empty, returns NULL and the sets the
+//  given char to NULL.
+void *QmlZosc::first (char *type) {
+    return zosc_first (self, type);
+};
+
+///
+//  Return the next item of the OSC message. If the list is empty, returns
+//  NULL. To move to the start of the OSC message call zosc_first ().
+void *QmlZosc::next (char *type) {
+    return zosc_next (self, type);
+};
+
+///
+//  Return a pointer to the item at the tail of the OSC message.
+//  Sets the given char argument to the type tag of the data. If
+//  the message is empty, returns NULL.
+void *QmlZosc::last (char *type) {
+    return zosc_last (self, type);
+};
+
 
 QObject* QmlZosc::qmlAttachedProperties(QObject* object) {
     return new QmlZoscAttached(object);

--- a/bindings/qml/src/QmlZosc.cpp
+++ b/bindings/qml/src/QmlZosc.cpp
@@ -87,14 +87,14 @@ void QmlZosc::print () {
 //  Sets the given char argument to the type tag of the data.
 //  If the message is empty, returns NULL and the sets the
 //  given char to NULL.
-void *QmlZosc::first (char *type) {
+const void *QmlZosc::first (char *type) {
     return zosc_first (self, type);
 };
 
 ///
 //  Return the next item of the OSC message. If the list is empty, returns
 //  NULL. To move to the start of the OSC message call zosc_first ().
-void *QmlZosc::next (char *type) {
+const void *QmlZosc::next (char *type) {
     return zosc_next (self, type);
 };
 
@@ -102,8 +102,72 @@ void *QmlZosc::next (char *type) {
 //  Return a pointer to the item at the tail of the OSC message.
 //  Sets the given char argument to the type tag of the data. If
 //  the message is empty, returns NULL.
-void *QmlZosc::last (char *type) {
+const void *QmlZosc::last (char *type) {
     return zosc_last (self, type);
+};
+
+///
+//  Set the provided 32 bit integer from value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QmlZosc::popInt32 (int *val) {
+    return zosc_pop_int32 (self, val);
+};
+
+///
+//  Set the provided 64 bit integer from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QmlZosc::popInt64 (int64_t *val) {
+    return zosc_pop_int64 (self, val);
+};
+
+///
+//  Set the provided float from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QmlZosc::popFloat (float *val) {
+    return zosc_pop_float (self, val);
+};
+
+///
+//  Set the provided double from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QmlZosc::popDouble (double *val) {
+    return zosc_pop_double (self, val);
+};
+
+///
+//  Set the provided string from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success. Caller owns the string!
+int QmlZosc::popString (QString val) {
+    return zosc_pop_string (self, val.toUtf8().data());
+};
+
+///
+//  Set the provided char from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QmlZosc::popChar (char *val) {
+    return zosc_pop_char (self, val);
+};
+
+///
+//  Set the provided boolean from the type tag in the message. Booleans are not represented
+//  in the data in the message, only in the type tag. If the type tag at the current
+//  position does not correspond it will fail and return -1. Returns 0 on success.
+int QmlZosc::popBool (bool *val) {
+    return zosc_pop_bool (self, val);
+};
+
+///
+//  Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+//  cursor position in the message. If the type tag at the current position does
+//  not correspond it will fail and return -1. Returns 0 on success.
+int QmlZosc::popMidi (uint32_t *val) {
+    return zosc_pop_midi (self, val);
 };
 
 

--- a/bindings/qml/src/QmlZosc.h
+++ b/bindings/qml/src/QmlZosc.h
@@ -78,16 +78,56 @@ public slots:
     //  Sets the given char argument to the type tag of the data.
     //  If the message is empty, returns NULL and the sets the
     //  given char to NULL.
-    void *first (char *type);
+    const void *first (char *type);
 
     //  Return the next item of the OSC message. If the list is empty, returns
     //  NULL. To move to the start of the OSC message call zosc_first ().
-    void *next (char *type);
+    const void *next (char *type);
 
     //  Return a pointer to the item at the tail of the OSC message.
     //  Sets the given char argument to the type tag of the data. If
     //  the message is empty, returns NULL.
-    void *last (char *type);
+    const void *last (char *type);
+
+    //  Set the provided 32 bit integer from value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popInt32 (int *val);
+
+    //  Set the provided 64 bit integer from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popInt64 (int64_t *val);
+
+    //  Set the provided float from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popFloat (float *val);
+
+    //  Set the provided double from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popDouble (double *val);
+
+    //  Set the provided string from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success. Caller owns the string!
+    int popString (QString val);
+
+    //  Set the provided char from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popChar (char *val);
+
+    //  Set the provided boolean from the type tag in the message. Booleans are not represented
+    //  in the data in the message, only in the type tag. If the type tag at the current
+    //  position does not correspond it will fail and return -1. Returns 0 on success.
+    int popBool (bool *val);
+
+    //  Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+    //  cursor position in the message. If the type tag at the current position does
+    //  not correspond it will fail and return -1. Returns 0 on success.
+    int popMidi (uint32_t *val);
 };
 
 class QmlZoscAttached : public QObject

--- a/bindings/qml/src/QmlZosc.h
+++ b/bindings/qml/src/QmlZosc.h
@@ -73,6 +73,21 @@ public slots:
 
     //  Dump OSC message to stdout, for debugging and tracing.
     void print ();
+
+    //  Return a pointer to the item at the head of the OSC data.
+    //  Sets the given char argument to the type tag of the data.
+    //  If the message is empty, returns NULL and the sets the
+    //  given char to NULL.
+    void *first (char *type);
+
+    //  Return the next item of the OSC message. If the list is empty, returns
+    //  NULL. To move to the start of the OSC message call zosc_first ().
+    void *next (char *type);
+
+    //  Return a pointer to the item at the tail of the OSC message.
+    //  Sets the given char argument to the type tag of the data. If
+    //  the message is empty, returns NULL.
+    void *last (char *type);
 };
 
 class QmlZoscAttached : public QObject

--- a/bindings/qt/src/qzosc.cpp
+++ b/bindings/qt/src/qzosc.cpp
@@ -143,6 +143,36 @@ bool QZosc::is (void *self)
 }
 
 ///
+//  Return a pointer to the item at the head of the OSC data.
+//  Sets the given char argument to the type tag of the data.
+//  If the message is empty, returns NULL and the sets the
+//  given char to NULL.
+void * QZosc::first (char *type)
+{
+    void * rv = zosc_first (self, type);
+    return rv;
+}
+
+///
+//  Return the next item of the OSC message. If the list is empty, returns
+//  NULL. To move to the start of the OSC message call zosc_first ().
+void * QZosc::next (char *type)
+{
+    void * rv = zosc_next (self, type);
+    return rv;
+}
+
+///
+//  Return a pointer to the item at the tail of the OSC message.
+//  Sets the given char argument to the type tag of the data. If
+//  the message is empty, returns NULL.
+void * QZosc::last (char *type)
+{
+    void * rv = zosc_last (self, type);
+    return rv;
+}
+
+///
 //  Self test of this class.
 void QZosc::test (bool verbose)
 {

--- a/bindings/qt/src/qzosc.cpp
+++ b/bindings/qt/src/qzosc.cpp
@@ -147,18 +147,18 @@ bool QZosc::is (void *self)
 //  Sets the given char argument to the type tag of the data.
 //  If the message is empty, returns NULL and the sets the
 //  given char to NULL.
-void * QZosc::first (char *type)
+const void * QZosc::first (char *type)
 {
-    void * rv = zosc_first (self, type);
+    const void * rv = zosc_first (self, type);
     return rv;
 }
 
 ///
 //  Return the next item of the OSC message. If the list is empty, returns
 //  NULL. To move to the start of the OSC message call zosc_first ().
-void * QZosc::next (char *type)
+const void * QZosc::next (char *type)
 {
-    void * rv = zosc_next (self, type);
+    const void * rv = zosc_next (self, type);
     return rv;
 }
 
@@ -166,9 +166,79 @@ void * QZosc::next (char *type)
 //  Return a pointer to the item at the tail of the OSC message.
 //  Sets the given char argument to the type tag of the data. If
 //  the message is empty, returns NULL.
-void * QZosc::last (char *type)
+const void * QZosc::last (char *type)
 {
-    void * rv = zosc_last (self, type);
+    const void * rv = zosc_last (self, type);
+    return rv;
+}
+
+///
+//  Set the provided 32 bit integer from value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QZosc::popInt32 (int *val)
+{
+    int rv = zosc_pop_int32 (self, val);
+    return rv;
+}
+
+///
+//  Set the provided 64 bit integer from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QZosc::popInt64 (int64_t *val)
+{
+    int rv = zosc_pop_int64 (self, val);
+    return rv;
+}
+
+///
+//  Set the provided float from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QZosc::popFloat (float *val)
+{
+    int rv = zosc_pop_float (self, val);
+    return rv;
+}
+
+///
+//  Set the provided double from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QZosc::popDouble (double *val)
+{
+    int rv = zosc_pop_double (self, val);
+    return rv;
+}
+
+///
+//  Set the provided char from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+int QZosc::popChar (char *val)
+{
+    int rv = zosc_pop_char (self, val);
+    return rv;
+}
+
+///
+//  Set the provided boolean from the type tag in the message. Booleans are not represented
+//  in the data in the message, only in the type tag. If the type tag at the current
+//  position does not correspond it will fail and return -1. Returns 0 on success.
+int QZosc::popBool (bool *val)
+{
+    int rv = zosc_pop_bool (self, val);
+    return rv;
+}
+
+///
+//  Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+//  cursor position in the message. If the type tag at the current position does
+//  not correspond it will fail and return -1. Returns 0 on success.
+int QZosc::popMidi (quint32 val)
+{
+    int rv = zosc_pop_midi (self, (uint32_t *) val);
     return rv;
 }
 

--- a/bindings/qt/src/qzosc.h
+++ b/bindings/qt/src/qzosc.h
@@ -78,6 +78,21 @@ public:
     //  Probe the supplied object, and report if it looks like a zosc_t.
     static bool is (void *self);
 
+    //  Return a pointer to the item at the head of the OSC data.
+    //  Sets the given char argument to the type tag of the data.
+    //  If the message is empty, returns NULL and the sets the
+    //  given char to NULL.
+    void * first (char *type);
+
+    //  Return the next item of the OSC message. If the list is empty, returns
+    //  NULL. To move to the start of the OSC message call zosc_first ().
+    void * next (char *type);
+
+    //  Return a pointer to the item at the tail of the OSC message.
+    //  Sets the given char argument to the type tag of the data. If
+    //  the message is empty, returns NULL.
+    void * last (char *type);
+
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/qt/src/qzosc.h
+++ b/bindings/qt/src/qzosc.h
@@ -82,16 +82,51 @@ public:
     //  Sets the given char argument to the type tag of the data.
     //  If the message is empty, returns NULL and the sets the
     //  given char to NULL.
-    void * first (char *type);
+    const void * first (char *type);
 
     //  Return the next item of the OSC message. If the list is empty, returns
     //  NULL. To move to the start of the OSC message call zosc_first ().
-    void * next (char *type);
+    const void * next (char *type);
 
     //  Return a pointer to the item at the tail of the OSC message.
     //  Sets the given char argument to the type tag of the data. If
     //  the message is empty, returns NULL.
-    void * last (char *type);
+    const void * last (char *type);
+
+    //  Set the provided 32 bit integer from value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popInt32 (int *val);
+
+    //  Set the provided 64 bit integer from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popInt64 (int64_t *val);
+
+    //  Set the provided float from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popFloat (float *val);
+
+    //  Set the provided double from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popDouble (double *val);
+
+    //  Set the provided char from the value at the current cursor position in the message.
+    //  If the type tag at the current position does not correspond it will fail and
+    //  return -1. Returns 0 on success.
+    int popChar (char *val);
+
+    //  Set the provided boolean from the type tag in the message. Booleans are not represented
+    //  in the data in the message, only in the type tag. If the type tag at the current
+    //  position does not correspond it will fail and return -1. Returns 0 on success.
+    int popBool (bool *val);
+
+    //  Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+    //  cursor position in the message. If the type tag at the current position does
+    //  not correspond it will fail and return -1. Returns 0 on success.
+    int popMidi (quint32 val);
 
     //  Self test of this class.
     static void test (bool verbose);

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -997,6 +997,14 @@ module CZMQ
       attach_function :zosc_first, [:pointer, :pointer], :pointer, **opts
       attach_function :zosc_next, [:pointer, :pointer], :pointer, **opts
       attach_function :zosc_last, [:pointer, :pointer], :pointer, **opts
+      attach_function :zosc_pop_int32, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_int64, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_float, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_double, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_string, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_char, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_bool, [:pointer, :pointer], :int, **opts
+      attach_function :zosc_pop_midi, [:pointer, :pointer], :int, **opts
       attach_function :zosc_test, [:bool], :void, **opts
 
       require_relative 'ffi/zosc'

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -994,6 +994,9 @@ module CZMQ
       attach_function :zosc_unpack, [:pointer], :pointer, **opts
       attach_function :zosc_print, [:pointer], :void, **opts
       attach_function :zosc_is, [:pointer], :bool, **opts
+      attach_function :zosc_first, [:pointer, :pointer], :pointer, **opts
+      attach_function :zosc_next, [:pointer, :pointer], :pointer, **opts
+      attach_function :zosc_last, [:pointer, :pointer], :pointer, **opts
       attach_function :zosc_test, [:bool], :void, **opts
 
       require_relative 'ffi/zosc'

--- a/bindings/ruby/lib/czmq/ffi/zosc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zosc.rb
@@ -335,6 +335,110 @@ module CZMQ
         result
       end
 
+      # Set the provided 32 bit integer from value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_int32(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_int32(self_p, val)
+        result
+      end
+
+      # Set the provided 64 bit integer from the value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_int64(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_int64(self_p, val)
+        result
+      end
+
+      # Set the provided float from the value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_float(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_float(self_p, val)
+        result
+      end
+
+      # Set the provided double from the value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_double(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_double(self_p, val)
+        result
+      end
+
+      # Set the provided string from the value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success. Caller owns the string!
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_string(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_string(self_p, val)
+        result
+      end
+
+      # Set the provided char from the value at the current cursor position in the message.
+      # If the type tag at the current position does not correspond it will fail and
+      # return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_char(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_char(self_p, val)
+        result
+      end
+
+      # Set the provided boolean from the type tag in the message. Booleans are not represented
+      # in the data in the message, only in the type tag. If the type tag at the current
+      # position does not correspond it will fail and return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_bool(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_bool(self_p, val)
+        result
+      end
+
+      # Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+      # cursor position in the message. If the type tag at the current position does
+      # not correspond it will fail and return -1. Returns 0 on success.
+      #
+      # @param val [::FFI::Pointer, #to_ptr]
+      # @return [Integer]
+      def pop_midi(val)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_pop_midi(self_p, val)
+        result
+      end
+
       # Self test of this class.
       #
       # @param verbose [Boolean]

--- a/bindings/ruby/lib/czmq/ffi/zosc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zosc.rb
@@ -296,6 +296,45 @@ module CZMQ
         result
       end
 
+      # Return a pointer to the item at the head of the OSC data.
+      # Sets the given char argument to the type tag of the data.
+      # If the message is empty, returns NULL and the sets the
+      # given char to NULL.
+      #
+      # @param type [::FFI::Pointer, #to_ptr]
+      # @return [::FFI::Pointer]
+      def first(type)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_first(self_p, type)
+        result
+      end
+
+      # Return the next item of the OSC message. If the list is empty, returns
+      # NULL. To move to the start of the OSC message call zosc_first ().
+      #
+      # @param type [::FFI::Pointer, #to_ptr]
+      # @return [::FFI::Pointer]
+      def next(type)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_next(self_p, type)
+        result
+      end
+
+      # Return a pointer to the item at the tail of the OSC message.
+      # Sets the given char argument to the type tag of the data. If
+      # the message is empty, returns NULL.
+      #
+      # @param type [::FFI::Pointer, #to_ptr]
+      # @return [::FFI::Pointer]
+      def last(type)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_last(self_p, type)
+        result
+      end
+
       # Self test of this class.
       #
       # @param verbose [Boolean]

--- a/include/zosc.h
+++ b/include/zosc.h
@@ -154,21 +154,77 @@ CZMQ_EXPORT bool
 //  Sets the given char argument to the type tag of the data.
 //  If the message is empty, returns NULL and the sets the
 //  given char to NULL.
-CZMQ_EXPORT void *
+CZMQ_EXPORT const void *
     zosc_first (zosc_t *self, char *type);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Return the next item of the OSC message. If the list is empty, returns
 //  NULL. To move to the start of the OSC message call zosc_first ().
-CZMQ_EXPORT void *
+CZMQ_EXPORT const void *
     zosc_next (zosc_t *self, char *type);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Return a pointer to the item at the tail of the OSC message.
 //  Sets the given char argument to the type tag of the data. If
 //  the message is empty, returns NULL.
-CZMQ_EXPORT void *
+CZMQ_EXPORT const void *
     zosc_last (zosc_t *self, char *type);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided 32 bit integer from value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_int32 (zosc_t *self, int *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided 64 bit integer from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_int64 (zosc_t *self, int64_t *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided float from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_float (zosc_t *self, float *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided double from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_double (zosc_t *self, double *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided string from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success. Caller owns the string!
+CZMQ_EXPORT int
+    zosc_pop_string (zosc_t *self, char **val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided char from the value at the current cursor position in the message.
+//  If the type tag at the current position does not correspond it will fail and
+//  return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_char (zosc_t *self, char *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided boolean from the type tag in the message. Booleans are not represented
+//  in the data in the message, only in the type tag. If the type tag at the current
+//  position does not correspond it will fail and return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_bool (zosc_t *self, bool *val);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the provided 4 bytes (unsigned 32bit int) from the value at the current
+//  cursor position in the message. If the type tag at the current position does
+//  not correspond it will fail and return -1. Returns 0 on success.
+CZMQ_EXPORT int
+    zosc_pop_midi (zosc_t *self, uint32_t *val);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Self test of this class.

--- a/include/zosc.h
+++ b/include/zosc.h
@@ -150,6 +150,27 @@ CZMQ_EXPORT bool
     zosc_is (void *self);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Return a pointer to the item at the head of the OSC data.
+//  Sets the given char argument to the type tag of the data.
+//  If the message is empty, returns NULL and the sets the
+//  given char to NULL.
+CZMQ_EXPORT void *
+    zosc_first (zosc_t *self, char *type);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Return the next item of the OSC message. If the list is empty, returns
+//  NULL. To move to the start of the OSC message call zosc_first ().
+CZMQ_EXPORT void *
+    zosc_next (zosc_t *self, char *type);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Return a pointer to the item at the tail of the OSC message.
+//  Sets the given char argument to the type tag of the data. If
+//  the message is empty, returns NULL.
+CZMQ_EXPORT void *
+    zosc_last (zosc_t *self, char *type);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Self test of this class.
 CZMQ_EXPORT void
     zosc_test (bool verbose);

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -596,7 +596,7 @@ s_require_indexes(zosc_t *self)
     assert(self);
     assert(self->data_begin);
     if (self->data_indexes) return;
-    self->data_indexes = zmalloc( sizeof(size_t) * (strlen(self->format)+1) );
+    self->data_indexes = (size_t *)zmalloc( sizeof(size_t) * (strlen(self->format)+1) );
     self->data_indexes[0] = self->data_begin;
     // generate the indexes
     size_t needle = self->data_begin;
@@ -776,7 +776,7 @@ zosc_pop_string(zosc_t *self, char **val)
         return -1; //  wrong type
 
     void *data = zchunk_data(self->chunk) + self->data_indexes[self->cursor_index];
-    *val = strdup(data);
+    *val = strdup((char *)data);
     return 0;
 }
 


### PR DESCRIPTION
Problem: It's difficult to get values from zosc message dynamically.
Solution: Implement an iterator and pop_<type> methods.

Also fixes a problem with printing floats and doubles!
Regenerate from zproject.


