### PR TITLE
Zosc: remove unnecessary print statements

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -955,7 +955,9 @@ zosc_test (bool verbose)
     const void *data = zosc_first(conm, &type);
     while ( data )
     {
-        zsys_info("type tag is %c", type);
+        if (verbose)
+            zsys_info("type tag is %c", type);
+
         switch (type)
         {
         case('i'):

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -664,7 +664,6 @@ s_require_indexes(zosc_t *self)
         // save current element bytearray index
         stridx++;
         self->data_indexes[stridx] = needle;
-        zsys_info("stridx: %i, strlen format: %i", stridx, strlen(self->format));
     }
 }
 


### PR DESCRIPTION
Problem: Zosc is being too verbose
Solution: remove unnecessary print statements or condition it
