### PR TITLE
docs: fix simple typo, milticast -> multicast

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -4319,7 +4319,7 @@ Return IPv6 address to use for zbeacon reception, or "" if none was set.
 nothing my_zsys.setIpv6McastAddress (String)
 ```
 
-Set IPv6 milticast address to use for sending zbeacon messages. This needs
+Set IPv6 multicast address to use for sending zbeacon messages. This needs
 to be set if IPv6 is enabled. If the environment variable
 ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 address.

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -8217,7 +8217,7 @@ use that as the default IPv6 address.
     @staticmethod
     def set_ipv6_mcast_address(value):
         """
-        Set IPv6 milticast address to use for sending zbeacon messages. This needs
+        Set IPv6 multicast address to use for sending zbeacon messages. This needs
 to be set if IPv6 is enabled. If the environment variable
 ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 address.

--- a/bindings/python_cffi/czmq_cffi/Zsys.py
+++ b/bindings/python_cffi/czmq_cffi/Zsys.py
@@ -566,7 +566,7 @@ class Zsys(object):
     @staticmethod
     def set_ipv6_mcast_address(value):
         """
-        Set IPv6 milticast address to use for sending zbeacon messages. This needs
+        Set IPv6 multicast address to use for sending zbeacon messages. This needs
         to be set if IPv6 is enabled. If the environment variable
         ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
         address.

--- a/bindings/qml/src/QmlZsys.cpp
+++ b/bindings/qml/src/QmlZsys.cpp
@@ -510,7 +510,7 @@ const QString QmlZsysAttached::ipv6Address () {
 };
 
 ///
-//  Set IPv6 milticast address to use for sending zbeacon messages. This needs
+//  Set IPv6 multicast address to use for sending zbeacon messages. This needs
 //  to be set if IPv6 is enabled. If the environment variable
 //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 //  address.

--- a/bindings/qml/src/QmlZsys.h
+++ b/bindings/qml/src/QmlZsys.h
@@ -348,7 +348,7 @@ public slots:
     //  Return IPv6 address to use for zbeacon reception, or "" if none was set.
     const QString ipv6Address ();
 
-    //  Set IPv6 milticast address to use for sending zbeacon messages. This needs
+    //  Set IPv6 multicast address to use for sending zbeacon messages. This needs
     //  to be set if IPv6 is enabled. If the environment variable
     //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
     //  address.

--- a/bindings/qt/src/qzsys.cpp
+++ b/bindings/qt/src/qzsys.cpp
@@ -590,7 +590,7 @@ const QString QZsys::ipv6Address ()
 }
 
 ///
-//  Set IPv6 milticast address to use for sending zbeacon messages. This needs
+//  Set IPv6 multicast address to use for sending zbeacon messages. This needs
 //  to be set if IPv6 is enabled. If the environment variable
 //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 //  address.

--- a/bindings/qt/src/qzsys.h
+++ b/bindings/qt/src/qzsys.h
@@ -306,7 +306,7 @@ public:
     //  Return IPv6 address to use for zbeacon reception, or "" if none was set.
     static const QString ipv6Address ();
 
-    //  Set IPv6 milticast address to use for sending zbeacon messages. This needs
+    //  Set IPv6 multicast address to use for sending zbeacon messages. This needs
     //  to be set if IPv6 is enabled. If the environment variable
     //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
     //  address.

--- a/include/zsys.h
+++ b/include/zsys.h
@@ -350,7 +350,7 @@ CZMQ_EXPORT void
 CZMQ_EXPORT const char *
     zsys_ipv6_address (void);
 
-//  Set IPv6 milticast address to use for sending zbeacon messages. This needs
+//  Set IPv6 multicast address to use for sending zbeacon messages. This needs
 //  to be set if IPv6 is enabled. If the environment variable
 //  ZSYS_IPV6_MCAST_ADDRESS is set, use that as the default IPv6 multicast
 //  address.


### PR DESCRIPTION
There is a small typo in bindings/nodejs/README.md, bindings/python/czmq/_czmq_ctypes.py, bindings/python_cffi/czmq_cffi/Zsys.py, bindings/qml/src/QmlZsys.cpp, bindings/qml/src/QmlZsys.h, bindings/qt/src/qzsys.cpp, bindings/qt/src/qzsys.h, include/zsys.h.

Should read `multicast` rather than `milticast`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md