### PR TITLE
Problem: [zhashx] zhashx_dup() does not copy callbacks

### DIFF
--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -966,6 +966,10 @@ zhashx_dup (zhashx_t *self)
     if (copy) {
         copy->destructor = self->destructor;
         copy->duplicator = self->duplicator;
+        copy->key_duplicator = self->key_duplicator;
+        copy->key_destructor = self->key_destructor;
+        copy->key_comparator = self->key_comparator;
+        copy->hasher = self->hasher;
         uint index;
         size_t limit = primes [self->prime_index];
         for (index = 0; index < limit; index++) {


### PR DESCRIPTION
The zhashx_dup() function does not duplicate the source hash perfectly.
It does not duplicate the source hash's hasher function, as the well as
the key destructor, duplicator, or comparator.  This minimally can lead
to unexpected behavior of the duplicate zhashx.  At worst it can cause
assert/segfault/memory corruption as zhashx defaults access/free unintended
memory.

Solution: Copy the source hasher, key destructor, key duplicator,
and key comparator over to the newly duplicated zhashx.

Fixes #2144
