### PR TITLE
zsys_sockname is missing DGRAM sockets

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -2349,6 +2349,7 @@ zsock_test (bool verbose)
     // ZMQ_DGRAM ipv4 unicast test
     zsock_t* dgramr = zsock_new_dgram ("udp://*:7777");
     assert (dgramr);
+    assert ( streq( "DGRAM", zsys_sockname(ZMQ_DGRAM)) );
     //zsock_t* dgrams = zsock_new_dgram ("udp://*:*");
     zsock_t* dgrams = zsock_new (ZMQ_DGRAM);
     zsock_bind (dgrams, "udp://127.0.0.1:7778" );

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -564,11 +564,13 @@ zsys_sockname (int socktype)
         "XPUB", "XSUB", "STREAM",
         "SERVER", "CLIENT",
         "RADIO", "DISH",
-        "SCATTER", "GATHER"
+        "SCATTER", "GATHER", "DGRAM"
     };
     //  This array matches ZMQ_XXX type definitions
     assert (ZMQ_PAIR == 0);
-#if defined (ZMQ_SCATTER)
+#if defined (ZMQ_DGRAM)
+    assert (socktype >= 0 && socktype <= ZMQ_DGRAM);
+#elif defined (ZMQ_SCATTER)
     assert (socktype >= 0 && socktype <= ZMQ_SCATTER);
 #elif defined (ZMQ_DISH)
     assert (socktype >= 0 && socktype <= ZMQ_DISH);


### PR DESCRIPTION
Problem: zsys_sockname is missing DGRAM sockets

Solution: add DGRAM sockets to zsys_sockname

Also add it to the test.