### PR TITLE
Update README.md with iOS static compilation link. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 *  [Using CMake](#using-cmake)
 *  [Using MSBuild (Out of date, may not work now!)](#using-msbuild-out-of-date-may-not-work-now)
 
+**[Building for iOS](#building-for-ios)**
+
 **[Linking with an Application](#linking-with-an-application)**
 
 **[Use from Other Languages](#use-from-other-languages)**
@@ -327,6 +329,9 @@ Let's test by running `czmq_selftest`:
     :: select your choice and run it
     czmq\builds\msvc\vs2013\x64\ReleaseDEXE\czmq_selftest.exe
 ```
+### Building for iOS
+
+Static libraries can be compiled for iOS, some scripts to do so can be found at: https://github.com/crcunningham/zeromq_ios_libraries.
 
 ### Linking with an Application
 


### PR DESCRIPTION
Add link to iOS static compilation scripts. @sappo mentioned doing so in https://github.com/zeromq/czmq/issues/2148. 

If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING.md](https://github.com/zeromq/czmq/blob/master/CONTRIBUTING.md)
