### PR TITLE
Appending data calculates the new osc format string incorrect

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -345,7 +345,7 @@ zosc_append(zosc_t *self, const char *format, ...)
     assert(format);
 
     // create new format string (format_cur + format)
-    unsigned long formatlen = strlen(format)+ strlen(self->format);
+    unsigned long formatlen = strlen(format)+ strlen(self->format) + 1; // +1 for the 0 byte
     unsigned int aligned = (unsigned)(((int)formatlen + 3) &~0x03);
     // for safety we'd better do this on the heap??? which is slower.
 #ifdef _MSC_VER


### PR DESCRIPTION
Problem: When appending data the length of the new format string is calculated wrong when it is 4 byte aligned
Solution: include a byte for the terminating null byte when calculating the new string length
