### PR TITLE
Fix ntohll/htonll handling

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -18,14 +18,22 @@
 @end
 */
 
-#ifdef WIN32
-#include <winsock2.h>           //  needed for ntohll/htonll
-#endif
 #include "czmq_classes.h"
-#if __unix__ && !__APPLE__
+
+// ntohll/htonll is not standard
+#if defined(__linux__)
 #include <endian.h>
 #define htonll(x) htobe64(x)
 #define ntohll(x) be64toh(x)
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#include <sys/endian.h>
+#define htonll(x) htobe64(x)
+#define ntohll(x) be64toh(x)
+#elif defined(__MINGW32__)
+#define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
+#define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
+#elif defined(WIN32)
+#include <winsock2.h>
 #endif
 //  Structure of our class
 


### PR DESCRIPTION
`ntohll` and `htonll` are not standard and apparently everyone disagrees about it.
`mingw32-w64` is lacking the definition and FreeBSD/NetBSD require a different header.

This hampers cross-compilation of czmq. For the alternative implementations, see https://stackoverflow.com/a/49167531/2442087.

cc: @giordano
