### PR TITLE
Problem: [zhashx] rehash does not increase chain limit

### DIFF
--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -329,6 +329,7 @@ s_item_lookup (zhashx_t *self, const void *key)
         assert (s_zhashx_rehash (self, new_prime_index) == 0);
         limit = primes [self->prime_index];
         self->cached_index = self->hasher (key) % limit;
+        self->chain_limit += CHAIN_GROWS;
     }
     return item;
 }


### PR DESCRIPTION
When rehashing in s_item_lookup(), the chain limit was not increased.
Therefore, the chain limit stayed at its default value of 1.  By staying
at the default value of 1, a single hash collision could increase the
limit of the hash.  This increase could be well beyond what would be
reasonable.

Solution: Increase the chain limit by the growth factor after a rehash.

Fixes #2173

