### PR TITLE
Change zuuid HAVE_UUID defined check order to fix broken compilation on OpenBSD

### DIFF
--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -63,11 +63,6 @@ zuuid_new (void)
     assert (sizeof (uuid) == ZUUID_LEN);
     UuidCreate (&uuid);
     zuuid_set (self, (byte *) &uuid);
-#elif defined (HAVE_UUID)
-    uuid_t uuid;
-    assert (sizeof (uuid) == ZUUID_LEN);
-    uuid_generate (uuid);
-    zuuid_set (self, (byte *) uuid);
 #elif defined (__UTYPE_OPENBSD) || defined (__UTYPE_FREEBSD) || defined (__UTYPE_NETBSD)
     uuid_t uuid;
     uint32_t status = 0;
@@ -79,6 +74,11 @@ zuuid_new (void)
     byte buffer [ZUUID_LEN];
     uuid_enc_be (&buffer, &uuid);
     zuuid_set (self, buffer);
+#elif defined (HAVE_UUID)
+    uuid_t uuid;
+    assert (sizeof (uuid) == ZUUID_LEN);
+    uuid_generate (uuid);
+    zuuid_set (self, (byte *) uuid);
 #else
     //  No UUID system calls, so generate a random string
     byte uuid [ZUUID_LEN];


### PR DESCRIPTION
**Problem**: Compilation on OpenBSD is broken as the "defined" checks on OpenBSD short-circuit at HAVE_UUID and does not reach __UTYPE_OPENBSD, resulting in the error:
```
src/zuuid.c:70:31: error: operand of type 'uuid_t' (aka 'struct uuid') where arithmetic or pointer type is required
    zuuid_set (self, (byte *) uuid);
```
**Solution**: Reorder the HAVE_UUID defined checks so that the BSD-specific UTYPEs can be found first. Tested on OpenBSD 6.9.