### PR TITLE
fix zosc leak by moving address to the chunk

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -150,7 +150,7 @@ zosc_new (const char *address)
     //  Initialize class properties here
     self->format = "";
     self->chunk = zchunk_new(address, strlen(address) + 1);
-    self->address = zchunk_data(self->chunk);
+    self->address = (char *)zchunk_data(self->chunk);
     assert(self->address);
     assert(self->format);
     self->data_begin = 0;

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -148,11 +148,11 @@ zosc_new (const char *address)
     zosc_t *self = (zosc_t *) zmalloc (sizeof (zosc_t));
     assert (self);
     //  Initialize class properties here
-    self->address = strdup(address);
-    self->format = strdup("");
+    self->format = "";
+    self->chunk = zchunk_new(address, strlen(address) + 1);
+    self->address = zchunk_data(self->chunk);
     assert(self->address);
     assert(self->format);
-    self->chunk = zchunk_new(NULL, 0);
     self->data_begin = 0;
     self->data_indexes = NULL;
     return self;


### PR DESCRIPTION
Problem: zosc is leaking its address and format string
Solution: keep format on the stack and move address to the chunk like it should
