### PR TITLE
Fix for compilation on BSD and mingw

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -18,11 +18,17 @@
 @end
 */
 
-#ifdef WIN32
-#include <winsock2.h>           //  needed for ntohll/htonll
-#endif
 #include "czmq_classes.h"
-#if __unix__ && !__APPLE__
+#if defined( __WINDOWS__ )
+#include <winsock2.h>           //  needed for ntohll/htonll
+#elif defined(__UTYPE_FREEBSD) || defined(__UTYPE_NETBSD)
+#include <sys/endian.h>
+#define htonll(x) htobe64(x)
+#define ntohll(x) be64toh(x)
+#elif defined(__MINGW32__)
+#define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
+#define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
+#elif defined(__UNIX__)
 #include <endian.h>
 #define htonll(x) htobe64(x)
 #define ntohll(x) be64toh(x)

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -21,13 +21,14 @@
 #include "czmq_classes.h"
 #if defined( __WINDOWS__ )
 #include <winsock2.h>           //  needed for ntohll/htonll
+#endif
+#if defined(__MINGW32__)
+#define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
+#define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
 #elif defined(__UTYPE_FREEBSD) || defined(__UTYPE_NETBSD)
 #include <sys/endian.h>
 #define htonll(x) htobe64(x)
 #define ntohll(x) be64toh(x)
-#elif defined(__MINGW32__)
-#define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
-#define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
 #elif defined(__UNIX__)
 #include <endian.h>
 #define htonll(x) htobe64(x)

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -18,21 +18,21 @@
 @end
 */
 
-#include "czmq_classes.h"
-#if defined( __WINDOWS__ )
-#include <winsock2.h>           //  needed for ntohll/htonll
+#if defined( WIN32 )
+  #include <winsock2.h>           //  needed for ntohll/htonll
 #endif
+#include "czmq_classes.h"
 #if defined(__MINGW32__)
-#define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
-#define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
+  #define htonll(x) ((((uint64_t)htonl(x&0xFFFFFFFF)) << 32) + htonl(x >> 32))
+  #define ntohll(x) ((((uint64_t)ntohl(x&0xFFFFFFFF)) << 32) + ntohl(x >> 32))
 #elif defined(__UTYPE_FREEBSD) || defined(__UTYPE_NETBSD)
-#include <sys/endian.h>
-#define htonll(x) htobe64(x)
-#define ntohll(x) be64toh(x)
+  #include <sys/endian.h>
+  #define htonll(x) htobe64(x)
+  #define ntohll(x) be64toh(x)
 #elif defined(__UNIX__)
-#include <endian.h>
-#define htonll(x) htobe64(x)
-#define ntohll(x) be64toh(x)
+  #include <endian.h>
+  #define htonll(x) htobe64(x)
+  #define ntohll(x) be64toh(x)
 #endif
 //  Structure of our class
 


### PR DESCRIPTION
Problem: As mentioned in #2163 czmq doesn't want to build on BSD and mingw. The provided patch however created new issues. 
Solution: add correct precompiler statements for mentioned platforms

This supersedes #2163 so it can be closed @vchuravy @giordano