### PR TITLE
OSX is failing on missing endian.h, prevent flooding logs

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -139,12 +139,19 @@ s_append_data(zchunk_t *chunk, const char *format, va_list argptr)
         }
         format++;
     }
-    if ( size > 8192 )
-        zsys_debug("The packet size exceeds 8192 bytes. It's fine for ZMTP but for DGRAM(UDP) it only works on rare networks");
+    static bool warn_jumbo_once = false;
+    static bool warn_ether_once = false;
+    if ( size > 8192 && !warn_jumbo_once )
+    {
+        warn_jumbo_once = true;
+        zsys_debug("The packet size exceeds 8192 bytes. It's fine for ZMTP but for DGRAM(UDP) it only works on rare networks. This warning is only echoed once");
+    }
     else
-    if ( size > 508 )
-        zsys_debug("The packet size exceeds 508 bytes. It's fine for ZMTP but for DGRAM(UDP) it might not work");
-
+    if ( size > 508 && !warn_ether_once )
+    {
+        warn_ether_once = true;
+        zsys_debug("The packet size exceeds 508 bytes. It's fine for ZMTP but for DGRAM(UDP) it might not work. This warning is only echoed once");
+    }
     return size;
 }
 

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -29,6 +29,8 @@
   #include <sys/endian.h>
   #define htonll(x) htobe64(x)
   #define ntohll(x) be64toh(x)
+#elif defined(__UTYPE_OSX)
+  #include <machine/endian.h>
 #elif defined(__UNIX__)
   #include <endian.h>
   #define htonll(x) htobe64(x)


### PR DESCRIPTION
Problem: OSX is failing to build because of missing endian.h
Solution: add correct include for OSX specifically

additional problem: large zosc message are flooding the logs
solution: only warn for large messages once.
