### PR TITLE
Problem: Gradle version of JNI bindings is not updated automatically

### DIFF
--- a/bindings/jni/gradle/wrapper/gradle-wrapper.properties
+++ b/bindings/jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Feb 21 16:27:49 CET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Solution: Manually update the gradle version from gradle-wrapper.properties
