### PR TITLE
OSX CI build fails due to upstream curl change

### DIFF
--- a/bindings/jni/ci_build.sh
+++ b/bindings/jni/ci_build.sh
@@ -102,7 +102,10 @@ if [ ! -e autogen.sh ] && [ ! -e buildconf ] && [ ! -e ./configure ] && [ -s ./c
     $CI_TIME autoconf || \
     $CI_TIME autoreconf -fiv
 fi
-$CI_TIME ./configure "${CONFIG_OPTS[@]}"
+( # Custom additional options for libcurl
+  CONFIG_OPTS+=("--with-secure-transport")
+  $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+)
 $CI_TIME make -j4
 $CI_TIME make install
 

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -190,13 +190,10 @@ if ! ((command -v dpkg >/dev/null 2>&1 && dpkg -s libcurl4-nss-dev >/dev/null 2>
         $CI_TIME autoconf || \
         $CI_TIME autoreconf -fiv
     fi
-    if [ -e ./configure ]; then
-        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-    else
-        mkdir build
-        cd build
-        $CI_TIME cmake .. -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_PREFIX_PATH=$BUILD_PREFIX
-    fi
+    ( # Custom additional options for libcurl
+      CONFIG_OPTS+=("--with-secure-transport")
+      $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+    )
     if [ -e ./configure ]; then
         $CI_TIME make -j4
         $CI_TIME make install

--- a/builds/rpi/build.sh
+++ b/builds/rpi/build.sh
@@ -176,7 +176,10 @@ if [ ! $INCREMENTAL ]; then
             $CI_TIME autoconf || \
             $CI_TIME autoreconf -fiv
         fi
-        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        ( # Custom additional options for libcurl
+            CONFIG_OPTS+=("--with-secure-transport")
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
         $CI_TIME make -j4
         $CI_TIME make install
     ) || exit 1

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -362,13 +362,10 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
             $CI_TIME autoconf || \
             $CI_TIME autoreconf -fiv
         fi
-        if [ -e ./configure ]; then
+        ( # Custom additional options for libcurl
+            CONFIG_OPTS+=("--with-secure-transport")
             $CI_TIME ./configure "${CONFIG_OPTS[@]}"
-        else
-            mkdir build
-            cd build
-            $CI_TIME cmake .. -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_PREFIX_PATH=$BUILD_PREFIX
-        fi
+        )
         if [ -e ./configure ]; then
             $CI_TIME make -j4
             $CI_TIME make install

--- a/project.xml
+++ b/project.xml
@@ -14,7 +14,9 @@
     <use project = "uuid" optional = "1" implied = "1" />
     <use project = "systemd" optional = "1" implied = "1" min_major = "200" />
     <use project = "lz4" optional = "1" implied = "1" />
-    <use project = "libcurl" optional = "1" implied = "1" min_major = "7" min_minor = "28" />
+    <use project = "libcurl" optional = "1" implied = "1" min_major = "7" min_minor = "28">
+      <add_config_opts>--with-secure-transport</add_config_opts> 
+    </use>
     <use project = "nss" optional = "1" implied = "1" />
     <use project = "libmicrohttpd"
          tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"


### PR DESCRIPTION
Problem: Curl needs a configure option for encryption
Solution: add config option to zproject config
