### PR TITLE
Fix for appending to an empty zosc message

### DIFF
--- a/src/zosc.c
+++ b/src/zosc.c
@@ -396,8 +396,9 @@ zosc_append(zosc_t *self, const char *format, ...)
     // save the pointer to where the data starts
     size_t new_data_begin = size;
 
-    // copy current data from data begin to end
-    size = zchunk_extend(newchunk, zchunk_data(self->chunk)+self->data_begin, zchunk_size(self->chunk)-self->data_begin);
+    // copy current data from data begin to end if there is any data
+    if (self->data_begin)
+        size = zchunk_extend(newchunk, zchunk_data(self->chunk)+self->data_begin, zchunk_size(self->chunk)-self->data_begin);
 
     // now append the new data
     va_list argptr;


### PR DESCRIPTION
Problem: appending to an empty zosc message results in invalid message.
Solution: only copy old data if there was any
