### PR TITLE
Adding zoscdump utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,30 @@ install(TARGETS zmakecert
     RUNTIME DESTINATION bin
 )
 add_executable(
+    zoscdump
+    "${SOURCE_DIR}/src/zoscdump.c"
+)
+if (TARGET czmq)
+target_link_libraries(
+    zoscdump
+    czmq
+    ${LIBZMQ_LIBRARIES}
+    ${OPTIONAL_LIBRARIES}
+)
+endif()
+if (NOT TARGET czmq AND TARGET czmq-static)
+target_link_libraries(
+    zoscdump
+    czmq-static
+    ${LIBZMQ_LIBRARIES}
+    ${OPTIONAL_LIBRARIES}
+    ${OPTIONAL_LIBRARIES_STATIC}
+)
+endif()
+install(TARGETS zoscdump
+    RUNTIME DESTINATION bin
+)
+add_executable(
     zsp
     "${SOURCE_DIR}/src/zsp.c"
 )
@@ -764,6 +788,7 @@ set(cmake_generated ${PROJECT_BINARY_DIR}/CMakeCache.txt
                     ${PROJECT_BINARY_DIR}/src/libczmq.so
                     ${PROJECT_BINARY_DIR}/src/czmq_selftest
                     ${PROJECT_BINARY_DIR}/src/zmakecert
+                    ${PROJECT_BINARY_DIR}/src/zoscdump
                     ${PROJECT_BINARY_DIR}/src/zsp
                     ${PROJECT_BINARY_DIR}/src/test_randof
                     ${PROJECT_BINARY_DIR}/src/czmq_selftest

--- a/bindings/jni/msvc/configure.bat
+++ b/bindings/jni/msvc/configure.bat
@@ -13,6 +13,7 @@ IF %1.==--help. (
     ECHO    --enable-drafts         from zip package, enables DRAFT API
     ECHO    --disable-drafts        from git repository, disables DRAFT API
     ECHO    --without-zmakecert     do not build zmakecert.exe
+    ECHO    --without-zoscdump      do not build zoscdump.exe
     ECHO    --without-zsp           do not build zsp.exe
     ECHO    --without-test_randof   do not build test_randof.exe
     ECHO    --without-czmq_selftest  do not build czmq_selftest.exe

--- a/builds/gyp/project.gyp
+++ b/builds/gyp/project.gyp
@@ -174,6 +174,16 @@
       ]
     },
     {
+      'target_name': 'zoscdump',
+      'type': 'executable',
+      'sources': [
+        '../../src/zoscdump.c'
+      ],
+      'dependencies': [
+        'libczmq'
+      ]
+    },
+    {
       'target_name': 'zsp',
       'type': 'executable',
       'sources': [

--- a/builds/msvc/configure.bat
+++ b/builds/msvc/configure.bat
@@ -13,6 +13,7 @@ IF %1.==--help. (
     ECHO    --enable-drafts         from zip package, enables DRAFT API
     ECHO    --disable-drafts        from git repository, disables DRAFT API
     ECHO    --without-zmakecert     do not build zmakecert.exe
+    ECHO    --without-zoscdump      do not build zoscdump.exe
     ECHO    --without-zsp           do not build zsp.exe
     ECHO    --without-test_randof   do not build test_randof.exe
     ECHO    --without-czmq_selftest  do not build czmq_selftest.exe

--- a/builds/msvc/vs2010/czmq.sln
+++ b/builds/msvc/vs2010/czmq.sln
@@ -4,6 +4,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libczmq", "libczmq\libczmq.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zmakecert", "zmakecert\zmakecert.vcxproj", "{A5497C4B-1CD1-4779-9458-135994788}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zoscdump", "zoscdump\zoscdump.vcxproj", "{A5497C4B-1CD1-4779-9458-110736464}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zsp", "zsp\zsp.vcxproj", "{A5497C4B-1CD1-4779-9458-33184}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_randof", "test_randof\test_randof.vcxproj", "{A5497C4B-1CD1-4779-9458-117342710}"
@@ -74,6 +76,30 @@ Global
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|x64.ActiveCfg = DebugDEXE|x64

--- a/builds/msvc/vs2012/czmq.sln
+++ b/builds/msvc/vs2012/czmq.sln
@@ -4,6 +4,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libczmq", "libczmq\libczmq.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zmakecert", "zmakecert\zmakecert.vcxproj", "{A5497C4B-1CD1-4779-9458-135994788}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zoscdump", "zoscdump\zoscdump.vcxproj", "{A5497C4B-1CD1-4779-9458-110736464}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zsp", "zsp\zsp.vcxproj", "{A5497C4B-1CD1-4779-9458-33184}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_randof", "test_randof\test_randof.vcxproj", "{A5497C4B-1CD1-4779-9458-117342710}"
@@ -74,6 +76,30 @@ Global
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|x64.ActiveCfg = DebugDEXE|x64

--- a/builds/msvc/vs2013/czmq.sln
+++ b/builds/msvc/vs2013/czmq.sln
@@ -4,6 +4,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libczmq", "libczmq\libczmq.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zmakecert", "zmakecert\zmakecert.vcxproj", "{A5497C4B-1CD1-4779-9458-135994788}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zoscdump", "zoscdump\zoscdump.vcxproj", "{A5497C4B-1CD1-4779-9458-110736464}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zsp", "zsp\zsp.vcxproj", "{A5497C4B-1CD1-4779-9458-33184}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_randof", "test_randof\test_randof.vcxproj", "{A5497C4B-1CD1-4779-9458-117342710}"
@@ -74,6 +76,30 @@ Global
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|x64.ActiveCfg = DebugDEXE|x64

--- a/builds/msvc/vs2015/czmq.sln
+++ b/builds/msvc/vs2015/czmq.sln
@@ -4,6 +4,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libczmq", "libczmq\libczmq.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zmakecert", "zmakecert\zmakecert.vcxproj", "{A5497C4B-1CD1-4779-9458-135994788}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zoscdump", "zoscdump\zoscdump.vcxproj", "{A5497C4B-1CD1-4779-9458-110736464}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zsp", "zsp\zsp.vcxproj", "{A5497C4B-1CD1-4779-9458-33184}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_randof", "test_randof\test_randof.vcxproj", "{A5497C4B-1CD1-4779-9458-117342710}"
@@ -74,6 +76,30 @@ Global
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|x64.ActiveCfg = DebugDEXE|x64

--- a/builds/msvc/vs2017/czmq.sln
+++ b/builds/msvc/vs2017/czmq.sln
@@ -4,6 +4,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libczmq", "libczmq\libczmq.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zmakecert", "zmakecert\zmakecert.vcxproj", "{A5497C4B-1CD1-4779-9458-135994788}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zoscdump", "zoscdump\zoscdump.vcxproj", "{A5497C4B-1CD1-4779-9458-110736464}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zsp", "zsp\zsp.vcxproj", "{A5497C4B-1CD1-4779-9458-33184}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_randof", "test_randof\test_randof.vcxproj", "{A5497C4B-1CD1-4779-9458-117342710}"
@@ -74,6 +76,30 @@ Global
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-135994788}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.ActiveCfg = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynDebug|x64.Build.0 = DebugDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.ActiveCfg = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|Win32.Build.0 = ReleaseDEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.ActiveCfg = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.DynRelease|x64.Build.0 = ReleaseDEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.ActiveCfg = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|Win32.Build.0 = DebugLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.ActiveCfg = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgDebug|x64.Build.0 = DebugLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.ActiveCfg = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|Win32.Build.0 = ReleaseLEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.ActiveCfg = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.LtcgRelease|x64.Build.0 = ReleaseLEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.ActiveCfg = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|Win32.Build.0 = DebugSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.ActiveCfg = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticDebug|x64.Build.0 = DebugSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.ActiveCfg = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|Win32.Build.0 = ReleaseSEXE|Win32
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.ActiveCfg = ReleaseSEXE|x64
+		{A5497C4B-1CD1-4779-9458-110736464}.StaticRelease|x64.Build.0 = ReleaseSEXE|x64
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.ActiveCfg = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|Win32.Build.0 = DebugDEXE|Win32
 		{A5497C4B-1CD1-4779-9458-33184}.DynDebug|x64.ActiveCfg = DebugDEXE|x64

--- a/configure.ac
+++ b/configure.ac
@@ -947,6 +947,16 @@ AC_ARG_ENABLE([zmakecert],
 AM_CONDITIONAL([ENABLE_ZMAKECERT], [test x$enable_zmakecert != xno])
 AM_COND_IF([ENABLE_ZMAKECERT], [AC_MSG_NOTICE([ENABLE_ZMAKECERT defined])])
 
+# Check for zoscdump intent
+AC_ARG_ENABLE([zoscdump],
+    AS_HELP_STRING([--enable-zoscdump],
+        [Compile and install 'zoscdump' [default=yes]]),
+    [enable_zoscdump=$enableval],
+    [enable_zoscdump=yes])
+
+AM_CONDITIONAL([ENABLE_ZOSCDUMP], [test x$enable_zoscdump != xno])
+AM_COND_IF([ENABLE_ZOSCDUMP], [AC_MSG_NOTICE([ENABLE_ZOSCDUMP defined])])
+
 # Check for zsp intent
 AC_ARG_ENABLE([zsp],
     AS_HELP_STRING([--enable-zsp],

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -93,6 +93,8 @@ zrex.txt
 zrex.doc
 zmakecert.txt
 zmakecert.doc
+zoscdump.txt
+zoscdump.doc
 
 # Make sure to track the manually maintained project description
 !*.adoc

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,7 +6,7 @@
 all-local: doc
 
 # Public programs ("main" tags in project.xml), auto-regenerated:
-MAN1 = zmakecert.1
+MAN1 = zmakecert.1 zoscdump.1
 # Public classes ("class" tags in project.xml), auto-regenerated:
 MAN3 = zactor.3 zargs.3 zarmour.3 zcert.3 zcertstore.3 zchunk.3 zclock.3 zconfig.3 zdigest.3 zdir.3 zdir_patch.3 zfile.3 zframe.3 zhash.3 zhashx.3 ziflist.3 zlist.3 zlistx.3 zloop.3 zmsg.3 zpoller.3 zproc.3 zsock.3 zstr.3 zsys.3 ztimerset.3 ztrie.3 zuuid.3 zhttp_client.3 zhttp_server.3 zhttp_server_options.3 zhttp_request.3 zhttp_response.3 zosc.3 zauth.3 zbeacon.3 zgossip.3 zmonitor.3 zproxy.3 zrex.3
 # Project overview, written by a human after initial skeleton:
@@ -231,6 +231,11 @@ GENERATED_DOCS += zmakecert.txt zmakecert.doc
 zmakecert.txt: $(top_srcdir)/src/zmakecert.c
 	mkdir -p "$(builddir)/$(@D)"
 	"$(srcdir)/mkman" "zmakecert" "$(builddir)/zmakecert.txt" "$(srcdir)/.."
+
+GENERATED_DOCS += zoscdump.txt zoscdump.doc
+zoscdump.txt: $(top_srcdir)/src/zoscdump.c
+	mkdir -p "$(builddir)/$(@D)"
+	"$(srcdir)/mkman" "zoscdump" "$(builddir)/zoscdump.txt" "$(srcdir)/.."
 
 
 clean-local:

--- a/packaging/debian/czmq.install
+++ b/packaging/debian/czmq.install
@@ -1,2 +1,3 @@
 usr/bin/zmakecert
+usr/bin/zoscdump
 

--- a/packaging/debian/czmq.manpages
+++ b/packaging/debian/czmq.manpages
@@ -1,1 +1,2 @@
 debian/tmp/usr/share/man/man1/zmakecert.1
+debian/tmp/usr/share/man/man1/zoscdump.1

--- a/packaging/redhat/czmq.spec
+++ b/packaging/redhat/czmq.spec
@@ -201,5 +201,7 @@ python3 setup.py install --root=%{buildroot} --skip-build --prefix %{_prefix}
 %doc README.txt
 %{_bindir}/zmakecert
 %{_mandir}/man1/zmakecert*
+%{_bindir}/zoscdump
+%{_mandir}/man1/zoscdump*
 
 %changelog

--- a/project.xml
+++ b/project.xml
@@ -88,7 +88,8 @@
 
     <!-- Command-line utilities -->
     <main name = "zmakecert" />
-
+    <main name = "zoscdump" />
+    
     <!-- Private command-line utilities -->
     <main name = "zsp" private = "1" />
     <main name = "test_randof" private = "1" />

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -102,6 +102,13 @@ src_zmakecert_LDADD = ${program_libs}
 src_zmakecert_SOURCES = src/zmakecert.c
 endif #ENABLE_ZMAKECERT
 
+if ENABLE_ZOSCDUMP
+bin_PROGRAMS += src/zoscdump
+src_zoscdump_CPPFLAGS = ${AM_CPPFLAGS}
+src_zoscdump_LDADD = ${program_libs}
+src_zoscdump_SOURCES = src/zoscdump.c
+endif #ENABLE_ZOSCDUMP
+
 if ENABLE_ZSP
 noinst_PROGRAMS += src/zsp
 src_zsp_CPPFLAGS = ${AM_CPPFLAGS}
@@ -168,6 +175,7 @@ dist_api_DATA = \
 # define custom target for all products of /src
 src: \
 		src/zmakecert \
+		src/zoscdump \
 		src/zsp \
 		src/test_randof \
 		src/czmq_selftest \

--- a/src/zosc.c
+++ b/src/zosc.c
@@ -638,7 +638,7 @@ zosc_print (zosc_t *self)
             {
                 //  not sure if the double pointer is the way to go
                 char *str = (char*)(zchunk_data( self->chunk ) + needle);
-                fprintf(stdout, " %s", str);
+                fprintf(stdout, " \"%s\"", str);
                 size_t l = strlen((char*)(zchunk_data( self->chunk ) + needle));
                 needle += l + 1;
                 needle = (needle + 3) & (size_t)~0x03;

--- a/src/zoscdump.c
+++ b/src/zoscdump.c
@@ -1,0 +1,199 @@
+/*  =========================================================================
+    zoscdump [options] <url>...
+
+    A command line utility for receiving OSC messages similar to liblo's
+    oscdump.
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+/*
+@header
+    zoscdump -
+@discuss
+@end
+*/
+
+#include "czmq_classes.h"
+
+static bool verbose = false;
+
+static int
+print_help()
+{
+    puts ("zoscdump [options] <url>...");
+    puts ("  --verbose / -v         verbose output");
+    puts ("  --help / -h            this information");
+    puts ("  <url>                  url to listen on, i.e udp://127.0.0.1:1234");
+    return 0;
+}
+
+zsock_t *
+determine_socket( const char *bind)
+{
+    zsock_t *retsock = NULL;
+    zrex_t *rex = zrex_new (NULL);
+    // determine transport
+    if (zrex_eq(rex, bind, "^(.+)://.*") )
+    {
+        const char *transport = zrex_hit(rex, 1);
+        if ( streq(transport, "udp") )
+             retsock = zsock_new_dgram(bind);
+
+        else if ( streq(transport, "tcp") )
+        {
+            retsock = zsock_new(ZMQ_STREAM);
+            zsock_bind(retsock, bind);
+        }
+
+        else if ( streq(transport, "ipc") )
+            retsock = zsock_new_pull( bind );
+
+        else
+            zsys_error("Not a valid transport in %s", transport);
+
+        if (retsock == NULL)
+            zsys_error("can't bind socket to %s", bind);
+
+        return retsock;
+    }
+    else
+        zsys_error("can't determine transport from %s", bind);
+
+    return NULL;
+}
+
+void
+recv_dgram(zmsg_t *msg)
+{
+    char *sender = zmsg_popstr(msg);
+    printf("%s ", sender);
+    zframe_t *frame = zmsg_pop(msg);
+    assert(frame);
+    if (zframe_size(frame) > 0 )
+    {
+        zosc_t *oscmsg = zosc_fromframe(frame);
+        assert(oscmsg);
+        zosc_print(oscmsg);
+    }
+    else
+    {
+        zframe_destroy(&frame);
+    }
+
+    zstr_free(&sender);
+}
+
+void
+recv_stream(zmsg_t *msg)
+{
+    zframe_t *senderid = zmsg_pop(msg);
+    assert( zframe_size(senderid) == 5);
+    zframe_t *frame = zmsg_pop(msg);
+    assert(frame);
+    if (zframe_size(frame) > 0 ) // on connection we receive a zero payload
+    {
+        zosc_t *oscmsg = zosc_fromframe(frame);
+        assert(oscmsg);
+        printf("%s ", zframe_strhex (senderid));
+        zosc_print(oscmsg);
+    }
+    else
+    {
+        zsys_info("host id %s connected", zframe_strhex (senderid));
+        zframe_destroy(&frame);
+    }
+    zframe_destroy(&senderid);
+}
+
+int
+main (int argc, char *argv [])
+{
+    zargs_t *args = zargs_new(argc, argv);
+    assert(args);
+
+    if ( zargs_arguments(args) == 0 )
+        return print_help();
+
+    if ( zargs_hasx (args, "--help", "-h", NULL) )
+        return print_help();
+
+    if (zargs_hasx(args, "--verbose", "-v", NULL) )
+        verbose = true;
+
+    zpoller_t *poller = zpoller_new(NULL);
+    assert(poller);
+    zlist_t *sockets = zlist_new();
+    assert(sockets);
+
+    int ret = 0;
+
+    const char *bind = zargs_first(args);
+    while (bind)
+    {
+        zsock_t *sock = determine_socket(bind);
+        if (sock == NULL)
+        {
+            ret = 1;
+            break;
+        }
+
+        zlist_append(sockets, sock);
+        if (verbose)
+            zsys_info("Listening dgram socket on %s", bind);
+
+        ret = zpoller_add(poller, sock);
+        if (ret != 0 )
+        {
+            zsys_error("can't add bound socket %s to poller", bind);
+            ret = 1;
+            break;
+        }
+
+        bind = zargs_next(args);
+    }
+    zargs_destroy(&args);
+
+    while ( ret == 0)
+    {
+        void *which = (void *) zpoller_wait(poller, -1);
+
+        if (zpoller_terminated( poller ) || zpoller_expired( poller ) )
+            break;
+
+        zmsg_t *msg = zmsg_recv(which);
+        assert(msg);
+
+        switch ( zsock_type(which) )
+        {
+        case ZMQ_DGRAM:
+            recv_dgram(msg);
+            break;
+        case ZMQ_STREAM:
+            recv_stream(msg);
+            break;
+        default:
+            zsys_error("Unsupported socket type");
+            break;
+        }
+        zmsg_destroy(&msg);
+        fflush(stdout);
+    }
+
+    zpoller_destroy(&poller);
+    zsock_t *sock = zlist_first(sockets);
+    while (sock)
+    {
+        zsock_destroy(&sock);
+        sock = zlist_next(sockets);
+    }
+
+    return ret;
+}


### PR DESCRIPTION
This is not so much as fixing a problem but rather adding functionality. 

As a convenience this PR adds the `zoscdump` utility which can receive OSC messages from TCP or UDP transports and prints them to stdout similar to liblo's oscdump. This is often useful for debugging other software and appliances. 
