### PR TITLE
problem: corrupted zframes called in zmsg_decode create a crash instead of returning NULL

### DIFF
--- a/src/zframe.c
+++ b/src/zframe.c
@@ -57,7 +57,7 @@ zframe_new (const void *data, size_t size)
     if (size) {
         //  Catch heap exhaustion in this specific case
         if (zmq_msg_init_size (&self->zmsg, size)) {
-            zframe_destroy (&self);
+            freen (self);
             return NULL;
         }
         if (data)

--- a/src/zmsg.c
+++ b/src/zmsg.c
@@ -701,7 +701,10 @@ zmsg_decode (zframe_t *frame)
             break;
         }
         zframe_t *decoded = zframe_new (source, frame_size);
-        assert (decoded);
+        if (!decoded) {
+            zmsg_destroy (&self);
+            break;
+        }
         zmsg_append (self, &decoded);
         source += frame_size;
     }


### PR DESCRIPTION
Solution:
- in zframe, use freen instead of zframe_destroy when frame init fails (heap exhaustion which may be due to message corruption) to avoid a bad memory access on the still unallocated self->zmsg
- in zmsg, break and return NULL instead of asserting after trying to initiate the zmsg from the decoded frame if the frame is NULL
