### PR TITLE
Problem: zdir_flatten pushes subdirs at the end causing problems with patches computation in zdir_diff

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -341,7 +341,7 @@ zdir_flatten (zdir_t *self)
         zlist_append (sorted, files[i]);
     zlist_sort (sorted, s_file_compare);
     for (size_t i = 0; i < self->count; i++)
-        files[i] = zlist_pop (sorted);
+        files[i] = (zfile_t *) zlist_pop (sorted);
     zlist_destroy (&sorted);
     
     return files;

--- a/src/zdir.c
+++ b/src/zdir.c
@@ -334,6 +334,16 @@ zdir_flatten (zdir_t *self)
     uint index = 0;
     if (self)
         index = s_dir_flatten (self, files, index);
+    
+    //sort flattened list for proper patches computation
+    zlist_t *sorted = zlist_new ();
+    for (size_t i = 0; i < self->count; i++)
+        zlist_append (sorted, files[i]);
+    zlist_sort (sorted, s_file_compare);
+    for (size_t i = 0; i < self->count; i++)
+        files[i] = zlist_pop (sorted);
+    zlist_destroy (&sorted);
+    
     return files;
 }
 


### PR DESCRIPTION
Problem: zdir_flatten pushes subdirs at the end causing problems with patches computation in zdir_diff
For example, when a file is added in the root directory and alphabetically placed between two subdirs, zdir_diff generates false create/delete patches for all the files in the subdirs.

Solution: sort the whole flat list generated by zdir_flatten after all recursions are over.
