### PR TITLE
Problem: More invalid links to git://github.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Build and test czmq
           command: |
             $Env:PATH += ";$Env:CMAKE_DIR"
-            git clone --depth 1 --quiet git://github.com/sappo/czmq.git "$Env:CZMQ_DIR"
+            git clone --depth 1 --quiet https://github.com/sappo/czmq.git "$Env:CZMQ_DIR"
             cd "$Env:CZMQ_DIR"
             mkdir build
             cd build

--- a/builds/stable_zmq/ci_build.sh
+++ b/builds/stable_zmq/ci_build.sh
@@ -19,7 +19,7 @@ CONFIG_OPTS+=("--quiet")
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list libsodium-dev >/dev/null 2>&1) || \
        (command -v brew >/dev/null 2>&1 && brew ls --versions libsodium >/dev/null 2>&1)); then
-    git clone --quiet --depth 1 -b stable git://github.com/jedisct1/libsodium.git
+    git clone --quiet --depth 1 -b stable https://github.com/jedisct1/libsodium.git
     ( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make -j4 install) || exit 1
 fi
 

--- a/doc/czmq.txt
+++ b/doc/czmq.txt
@@ -100,7 +100,7 @@ Building and Installing
 
 CZMQ uses autotools for packaging. To build from git (all example commands are for Linux):
 ----
-    git clone git://github.com/zeromq/czmq.git
+    git clone https://github.com/zeromq/czmq.git
     cd czmq
     sh autogen.sh
     ./configure


### PR DESCRIPTION
Following https://github.com/zeromq/czmq/pull/2235, I checked deeper and found some more such references:
```
prompt> cd czmq
prompt> find . -type f | grep -v '/.git/' | xargs grep 'git://github.com'
./.circleci/config.yml:            git clone --depth 1 --quiet git://github.com/sappo/czmq.git "$Env:CZMQ_DIR"
./builds/stable_zmq/ci_build.sh:    git clone --quiet --depth 1 -b stable git://github.com/jedisct1/libsodium.git
./doc/czmq.txt:    git clone git://github.com/zeromq/czmq.git
prompt>
```

Solution: Fix invalid `git://github.com` URLs.

Note: Similar task in progress in ZYRE.

# Pull Request Notice

Before sending a pull request make sure each commit solves one clear, minimal,
plausible problem. Further each commit should have the following format:

```
Problem: X is broken

Solution: do Y and Z to fix X
```

Please avoid sending a pull request with recursive merge nodes, as they
are impossible to fix once merged. Please rebase your branch on
zeromq/czmq master instead of merging it.

git remote add upstream git@github.com:zeromq/czmq.git
git fetch upstream
git rebase upstream/master
git push -f

In case you already merged instead of rebasing you can drop the merge commit.

git rebase -i HEAD~10

Now, find your merge commit and mark it as drop and save. Finally rebase!

If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING.md](https://github.com/zeromq/czmq/blob/master/CONTRIBUTING.md)
