### PR TITLE
Problem: Sync with zproject (Android build fails if linkname is different than prefix).

### DIFF
--- a/bindings/jni/czmq-jni-native/build.gradle
+++ b/bindings/jni/czmq-jni-native/build.gradle
@@ -50,7 +50,7 @@ task copyLibs(type: Copy) {
             include '*uuid*.dll'
             include 'libsystemd.so'
             include 'libsystemd.dylib'
-            include '*libsystemd*.dll'
+            include '*systemd*.dll'
             include 'liblz4.so'
             include 'liblz4.dylib'
             include '*lz4*.dll'

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zarmour.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zarmour.java
@@ -16,7 +16,7 @@ public class Zarmour implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zcert.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zcert.java
@@ -16,7 +16,7 @@ public class Zcert implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zcertstore.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zcertstore.java
@@ -16,7 +16,7 @@ public class Zcertstore implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zchunk.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zchunk.java
@@ -16,7 +16,7 @@ public class Zchunk implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zclock.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zclock.java
@@ -16,7 +16,7 @@ public class Zclock {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zconfig.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zconfig.java
@@ -16,7 +16,7 @@ public class Zconfig implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdigest.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdigest.java
@@ -16,7 +16,7 @@ public class Zdigest implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
@@ -16,7 +16,7 @@ public class Zdir implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZdirPatch.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZdirPatch.java
@@ -16,7 +16,7 @@ public class ZdirPatch implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zfile.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zfile.java
@@ -16,7 +16,7 @@ public class Zfile implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zframe.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zframe.java
@@ -16,7 +16,7 @@ public class Zframe implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zhash.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zhash.java
@@ -16,7 +16,7 @@ public class Zhash implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zhashx.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zhashx.java
@@ -16,7 +16,7 @@ public class Zhashx implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpClient.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpClient.java
@@ -16,7 +16,7 @@ public class ZhttpClient implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpRequest.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpRequest.java
@@ -16,7 +16,7 @@ public class ZhttpRequest implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpResponse.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpResponse.java
@@ -16,7 +16,7 @@ public class ZhttpResponse implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpServer.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpServer.java
@@ -16,7 +16,7 @@ public class ZhttpServer implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpServerOptions.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpServerOptions.java
@@ -16,7 +16,7 @@ public class ZhttpServerOptions implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ziflist.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ziflist.java
@@ -16,7 +16,7 @@ public class Ziflist implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlist.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlist.java
@@ -16,7 +16,7 @@ public class Zlist implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlistx.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlistx.java
@@ -16,7 +16,7 @@ public class Zlistx implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zloop.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zloop.java
@@ -16,7 +16,7 @@ public class Zloop implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zmsg.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zmsg.java
@@ -16,7 +16,7 @@ public class Zmsg implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
@@ -16,7 +16,7 @@ public class Zosc implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zpoller.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zpoller.java
@@ -16,7 +16,7 @@ public class Zpoller implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -16,7 +16,7 @@ public class Zproc implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsock.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsock.java
@@ -16,7 +16,7 @@ public class Zsock implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zstr.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zstr.java
@@ -16,7 +16,7 @@ public class Zstr {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zsys.java
@@ -16,7 +16,7 @@ public class Zsys {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ztimerset.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ztimerset.java
@@ -16,7 +16,7 @@ public class Ztimerset implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ztrie.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ztrie.java
@@ -16,7 +16,7 @@ public class Ztrie implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zuuid.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zuuid.java
@@ -16,7 +16,7 @@ public class Zuuid implements AutoCloseable {
         Map<String, Boolean> libraries = new LinkedHashMap<>();
         libraries.put("zmq", false);
         libraries.put("uuid", true);
-        libraries.put("libsystemd", true);
+        libraries.put("systemd", true);
         libraries.put("lz4", true);
         libraries.put("curl", true);
         libraries.put("nss", true);


### PR DESCRIPTION
Solution: Regenerate CZMQ with this commit.

Note:

There are many modified files, because of:

    libraries.put("libsystemd", true);          # buggy

being replaced by:

    libraries.put("systemd", true);             # correct form

in each generated .java files (and there are many classes in CZMQ ...)

