### PR TITLE
New binding language: Zig

### DIFF
--- a/bindings/zig/Readme.md
+++ b/bindings/zig/Readme.md
@@ -1,0 +1,16 @@
+# CZMQ - Zig bindings (**Experimental**)
+
+## Require
+
+- Zig version: [0.11 or higher - download](https://ziglang.org/download)
+
+### How to build library
+
+```bash
+$> zig build -Doptimize=ReleaseFast
+# output: $PWD/zig-out/lib
+```
+### Test
+```bash
+$> zig build test
+```

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -1,0 +1,55 @@
+//! Works only Zig version: 0.11.0 or higher
+
+const std = @import("std");
+
+// Although this function looks imperative, note that its job is to
+// declaratively construct a build graph that will be executed by an external
+// runner.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-czmq",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.addIncludePath("../../include");
+    lib.addLibraryPath("../../build");
+    lib.linkSystemLibrary("czmq");
+    lib.linkSystemLibrary("zmq");
+    lib.linkLibC();
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    lib.install();
+
+    // Creates a step for unit testing.
+    const libtest = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    libtest.addIncludePath("../../include");
+    libtest.addLibraryPath("../../build");
+    libtest.linkSystemLibrary("czmq");
+    libtest.linkSystemLibrary("zmq");
+    libtest.linkLibC();
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build test`
+    // This will evaluate the `test` step rather than the default, which is "install".
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&libtest.step);
+}

--- a/bindings/zig/src/main.zig
+++ b/bindings/zig/src/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const czmq = @cImport(@cInclude("czmq.h"));
+const testing = std.testing;
+
+test "Reference all decls" {
+    _ = czmq;
+    testing.refAllDecls(@This());
+}
+
+test "Hello 0MQ" {
+    var publisher: ?*czmq.zsock_t = czmq.zsock_new(czmq.ZMQ_PUB);
+    czmq.zsock_set_curve_server(publisher, @boolToInt(true));
+    std.debug.print("\nHello, Curves!{s}", .{"\n"});
+    czmq.zsock_destroy(&publisher);
+}


### PR DESCRIPTION
Currently the has only been tested on Linux (wsl2).
The purpose to use version 0.11 because of initial support for zig pkg manager.

**TODO:** add libzmq module to build all deps, on single build.

## Current test

https://github.com/zeromq/czmq/blob/d23621a55e13888786922f205f0de32d1aa1464d/bindings/zig/src/main.zig#L10-L15
```bash
$> zig build test
Test [2/2] test.Hello 0MQ...
Hello, Curves!
All 2 tests passed.
```

## References
- https://github.com/ziglang/zig/pull/14265
- https://github.com/ziglang/zig/issues/14307