### PR TITLE
Feature: adding macaddress to ziflist items

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ Michal Hrusecky
 Alena Chernikava
 Stephen Procter
 Wes Young
+Arnaud Loonstra

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -1625,6 +1625,10 @@ const char *
 const char *
     ziflist_netmask (ziflist_t *self);
 
+// Return the current interface MAC address as a printable string
+const char *
+    ziflist_mac (ziflist_t *self);
+
 // Return the list of interfaces.
 void
     ziflist_print (ziflist_t *self);

--- a/api/ziflist.api
+++ b/api/ziflist.api
@@ -52,7 +52,7 @@
         <return type = "string" />
     </method>
 
-    <method name = "mac">
+    <method name = "mac" state = "draft">
         Return the current interface MAC address as a printable string
         <return type = "string" />
     </method>

--- a/api/ziflist.api
+++ b/api/ziflist.api
@@ -52,6 +52,11 @@
         <return type = "string" />
     </method>
 
+    <method name = "mac">
+        Return the current interface MAC address as a printable string
+        <return type = "string" />
+    </method>
+
     <method name = "print">
         Return the list of interfaces.
     </method>

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -892,6 +892,9 @@ uses
     // Return the current interface network mask as a printable string
     function Netmask: string;
 
+    // Return the current interface MAC address as a printable string
+    function Mac: string;
+
     // Return the list of interfaces.
     procedure Print;
 
@@ -3616,6 +3619,9 @@ uses
 
     // Return the current interface network mask as a printable string
     function Netmask: string;
+
+    // Return the current interface MAC address as a printable string
+    function Mac: string;
 
     // Return the list of interfaces.
     procedure Print;
@@ -7659,6 +7665,11 @@ end;
   function TZiflist.Netmask: string;
   begin
     Result := string(UTF8String(ziflist_netmask(FHandle)));
+  end;
+
+  function TZiflist.Mac: string;
+  begin
+    Result := string(UTF8String(ziflist_mac(FHandle)));
   end;
 
   procedure TZiflist.Print;

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -1315,6 +1315,9 @@ type
   // Return the current interface network mask as a printable string
   function ziflist_netmask(self: PZiflist): PAnsiChar; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
+  // Return the current interface MAC address as a printable string
+  function ziflist_mac(self: PZiflist): PAnsiChar; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
   // Return the list of interfaces.
   procedure ziflist_print(self: PZiflist); cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ziflist.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Ziflist.c
@@ -78,6 +78,14 @@ Java_org_zeromq_czmq_Ziflist__1_1netmask (JNIEnv *env, jclass c, jlong self)
     return return_string_;
 }
 
+JNIEXPORT jstring JNICALL
+Java_org_zeromq_czmq_Ziflist__1_1mac (JNIEnv *env, jclass c, jlong self)
+{
+    char *mac_ = (char *) ziflist_mac ((ziflist_t *) (intptr_t) self);
+    jstring return_string_ = (*env)->NewStringUTF (env, mac_);
+    return return_string_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Ziflist__1_1print (JNIEnv *env, jclass c, jlong self)
 {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ziflist.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Ziflist.java
@@ -96,6 +96,13 @@ public class Ziflist implements AutoCloseable {
         return __netmask (self);
     }
     /*
+    Return the current interface MAC address as a printable string
+    */
+    native static String __mac (long self);
+    public String mac () {
+        return __mac (self);
+    }
+    /*
     Return the list of interfaces.
     */
     native static void __print (long self);

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1620,6 +1620,10 @@ const char *
 const char *
     ziflist_netmask (ziflist_t *self);
 
+// Return the current interface MAC address as a printable string
+const char *
+    ziflist_mac (ziflist_t *self);
+
 // Return the list of interfaces.
 void
     ziflist_print (ziflist_t *self);

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1692,6 +1692,12 @@ string my_ziflist.netmask ()
 Return the current interface network mask as a printable string
 
 ```
+string my_ziflist.mac ()
+```
+
+Return the current interface MAC address as a printable string
+
+```
 nothing my_ziflist.print ()
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -3261,6 +3261,7 @@ NAN_MODULE_INIT (Ziflist::Init) {
     Nan::SetPrototypeMethod (tpl, "address", _address);
     Nan::SetPrototypeMethod (tpl, "broadcast", _broadcast);
     Nan::SetPrototypeMethod (tpl, "netmask", _netmask);
+    Nan::SetPrototypeMethod (tpl, "mac", _mac);
     Nan::SetPrototypeMethod (tpl, "print", _print);
     Nan::SetPrototypeMethod (tpl, "newIpv6", _new_ipv6);
     Nan::SetPrototypeMethod (tpl, "reloadIpv6", _reload_ipv6);
@@ -3341,6 +3342,12 @@ NAN_METHOD (Ziflist::_broadcast) {
 NAN_METHOD (Ziflist::_netmask) {
     Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
     char *result = (char *) ziflist_netmask (ziflist->self);
+    info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
+}
+
+NAN_METHOD (Ziflist::_mac) {
+    Ziflist *ziflist = Nan::ObjectWrap::Unwrap <Ziflist> (info.Holder ());
+    char *result = (char *) ziflist_mac (ziflist->self);
     info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
 }
 

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -445,6 +445,7 @@ class Ziflist: public Nan::ObjectWrap {
     static NAN_METHOD (_address);
     static NAN_METHOD (_broadcast);
     static NAN_METHOD (_netmask);
+    static NAN_METHOD (_mac);
     static NAN_METHOD (_print);
     static NAN_METHOD (_new_ipv6);
     static NAN_METHOD (_reload_ipv6);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -3451,6 +3451,8 @@ lib.ziflist_broadcast.restype = c_char_p
 lib.ziflist_broadcast.argtypes = [ziflist_p]
 lib.ziflist_netmask.restype = c_char_p
 lib.ziflist_netmask.argtypes = [ziflist_p]
+lib.ziflist_mac.restype = c_char_p
+lib.ziflist_mac.argtypes = [ziflist_p]
 lib.ziflist_print.restype = None
 lib.ziflist_print.argtypes = [ziflist_p]
 lib.ziflist_new_ipv6.restype = ziflist_p
@@ -3551,6 +3553,12 @@ class Ziflist(object):
         Return the current interface network mask as a printable string
         """
         return lib.ziflist_netmask(self._as_parameter_)
+
+    def mac(self):
+        """
+        Return the current interface MAC address as a printable string
+        """
+        return lib.ziflist_mac(self._as_parameter_)
 
     def print(self):
         """

--- a/bindings/python_cffi/czmq_cffi/Ziflist.py
+++ b/bindings/python_cffi/czmq_cffi/Ziflist.py
@@ -66,6 +66,12 @@ class Ziflist(object):
         """
         return utils.lib.ziflist_netmask(self._p)
 
+    def mac(self):
+        """
+        Return the current interface MAC address as a printable string
+        """
+        return utils.lib.ziflist_mac(self._p)
+
     def print_py(self):
         """
         Return the list of interfaces.

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -1627,6 +1627,10 @@ const char *
 const char *
     ziflist_netmask (ziflist_t *self);
 
+// Return the current interface MAC address as a printable string
+const char *
+    ziflist_mac (ziflist_t *self);
+
 // Return the list of interfaces.
 void
     ziflist_print (ziflist_t *self);

--- a/bindings/qml/src/QmlZiflist.cpp
+++ b/bindings/qml/src/QmlZiflist.cpp
@@ -51,6 +51,12 @@ const QString QmlZiflist::netmask () {
 };
 
 ///
+//  Return the current interface MAC address as a printable string
+const QString QmlZiflist::mac () {
+    return QString (ziflist_mac (self));
+};
+
+///
 //  Return the list of interfaces.
 void QmlZiflist::print () {
     ziflist_print (self);

--- a/bindings/qml/src/QmlZiflist.h
+++ b/bindings/qml/src/QmlZiflist.h
@@ -49,6 +49,9 @@ public slots:
     //  Return the current interface network mask as a printable string
     const QString netmask ();
 
+    //  Return the current interface MAC address as a printable string
+    const QString mac ();
+
     //  Return the list of interfaces.
     void print ();
 

--- a/bindings/qt/src/qziflist.cpp
+++ b/bindings/qt/src/qziflist.cpp
@@ -86,6 +86,14 @@ const QString QZiflist::netmask ()
 }
 
 ///
+//  Return the current interface MAC address as a printable string
+const QString QZiflist::mac ()
+{
+    const QString rv = QString (ziflist_mac (self));
+    return rv;
+}
+
+///
 //  Return the list of interfaces.
 void QZiflist::print ()
 {

--- a/bindings/qt/src/qziflist.h
+++ b/bindings/qt/src/qziflist.h
@@ -44,6 +44,9 @@ public:
     //  Return the current interface network mask as a printable string
     const QString netmask ();
 
+    //  Return the current interface MAC address as a printable string
+    const QString mac ();
+
     //  Return the list of interfaces.
     void print ();
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -383,6 +383,7 @@ module CZMQ
       attach_function :ziflist_address, [:pointer], :string, **opts
       attach_function :ziflist_broadcast, [:pointer], :string, **opts
       attach_function :ziflist_netmask, [:pointer], :string, **opts
+      attach_function :ziflist_mac, [:pointer], :string, **opts
       attach_function :ziflist_print, [:pointer], :void, **opts
       attach_function :ziflist_new_ipv6, [], :pointer, **opts
       attach_function :ziflist_reload_ipv6, [:pointer], :void, **opts

--- a/bindings/ruby/lib/czmq/ffi/ziflist.rb
+++ b/bindings/ruby/lib/czmq/ffi/ziflist.rb
@@ -160,6 +160,16 @@ module CZMQ
         result
       end
 
+      # Return the current interface MAC address as a printable string
+      #
+      # @return [String]
+      def mac()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.ziflist_mac(self_p)
+        result
+      end
+
       # Return the list of interfaces.
       #
       # @return [void]

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -328,7 +328,13 @@
 #       include <systemd/sd-daemon.h>
 #   endif
 #   if (defined (HAVE_GETIFADDRS))
-#       include <netpacket/packet.h>
+#       if (defined (__UTYPE_OSX))
+#           include <net/ethernet.h>     //  For struct sockaddr_dl
+#           include <net/if_dl.h>
+#           include <net/if_types.h>
+#       else
+#           include <netpacket/packet.h> //  For struct sockaddr_ll
+#       endif
 #   endif
 #endif
 

--- a/include/czmq_prelude.h
+++ b/include/czmq_prelude.h
@@ -327,6 +327,9 @@
 #   if (defined (__UTYPE_LINUX) && defined (HAVE_LIBSYSTEMD))
 #       include <systemd/sd-daemon.h>
 #   endif
+#   if (defined (HAVE_GETIFADDRS))
+#       include <netpacket/packet.h>
+#   endif
 #endif
 
 #if (defined (__VMS__))

--- a/include/ziflist.h
+++ b/include/ziflist.h
@@ -61,10 +61,6 @@ CZMQ_EXPORT const char *
 CZMQ_EXPORT const char *
     ziflist_netmask (ziflist_t *self);
 
-//  Return the current interface MAC address as a printable string
-CZMQ_EXPORT const char *
-    ziflist_mac (ziflist_t *self);
-
 //  Return the list of interfaces.
 CZMQ_EXPORT void
     ziflist_print (ziflist_t *self);
@@ -74,6 +70,11 @@ CZMQ_EXPORT void
     ziflist_test (bool verbose);
 
 #ifdef CZMQ_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Return the current interface MAC address as a printable string
+CZMQ_EXPORT const char *
+    ziflist_mac (ziflist_t *self);
+
 //  *** Draft method, for development use, may change without warning ***
 //  Get a list of network interfaces currently defined on the system
 //  Includes IPv6 interfaces

--- a/include/ziflist.h
+++ b/include/ziflist.h
@@ -61,6 +61,10 @@ CZMQ_EXPORT const char *
 CZMQ_EXPORT const char *
     ziflist_netmask (ziflist_t *self);
 
+//  Return the current interface MAC address as a printable string
+CZMQ_EXPORT const char *
+    ziflist_mac (ziflist_t *self);
+
 //  Return the list of interfaces.
 CZMQ_EXPORT void
     ziflist_print (ziflist_t *self);

--- a/src/czmq_classes.h
+++ b/src/czmq_classes.h
@@ -213,6 +213,11 @@ CZMQ_PRIVATE zhashx_t *
     zhashx_unpack_own (zframe_t *frame, zhashx_deserializer_fn deserializer);
 
 //  *** Draft method, defined for internal use only ***
+//  Return the current interface MAC address as a printable string
+CZMQ_PRIVATE const char *
+    ziflist_mac (ziflist_t *self);
+
+//  *** Draft method, defined for internal use only ***
 //  Get a list of network interfaces currently defined on the system
 //  Includes IPv6 interfaces
 //  Caller owns return value and must destroy it when done.

--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -372,11 +372,11 @@ s_reload (ziflist_t *self, bool ipv6)
             broadcast.sin_addr.s_addr |= ~(netmask.sin_addr.s_addr);
             // Retrieve the MAC address from the PIP_ADAPTER_ADDRESSES structure
             unsigned char *mac_address = cur_address->PhysicalAddress;
-            unsigned char mac[18] = "NA";
+            char mac[18] = "NA";
             if (mac_address != NULL && cur_address->PhysicalAddressLength == 6) {
                 int len = 0;
-                for (i = 0; i < 6; i++) {
-                    len += snprintf(mac+len, 18, "%02X%s", mac_address[i], i < 5 ? ":":"" );
+                for (int i = 0; i < 6; i++) {
+                    len += snprintf( mac+len, 18, "%02X%s", mac_address[i], i < 5 ? ":":"" );
                 }
             }
             interface_t *item = s_interface_new (asciiFriendlyName,


### PR DESCRIPTION
Problem: The ziflist class doesn't expose macaddresses of interfaces
Solution: add the macaddress to the ziflist items
