### PR TITLE
Update zlist/zlistx header comments to indicate memory exhaustion not possible error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5138,13 +5138,13 @@ This is the class interface:
         zlist_item (zlist_t *self);
     
     //  Append an item to the end of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     CZMQ_EXPORT int
         zlist_append (zlist_t *self, void *item);
     
     //  Push an item to the start of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     CZMQ_EXPORT int
         zlist_push (zlist_t *self, void *item);

--- a/README.md
+++ b/README.md
@@ -5389,13 +5389,13 @@ This is the class interface:
     
     //  Add an item to the head of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     CZMQ_EXPORT void *
         zlistx_add_start (zlistx_t *self, void *item);
     
     //  Add an item to the tail of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     CZMQ_EXPORT void *
         zlistx_add_end (zlistx_t *self, void *item);
     
@@ -5500,8 +5500,7 @@ This is the class interface:
     //  duplicator, if any, on the item. If low_value is true, starts searching
     //  from the start of the list, otherwise searches from the end. Use the item
     //  comparator, if any, to find where to place the new node. Returns a handle
-    //  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    //  list head.
+    //  to the new node. Resets the cursor to the list head.
     CZMQ_EXPORT void *
         zlistx_insert (zlistx_t *self, void *item, bool low_value);
     

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -1785,13 +1785,13 @@ zlistx_t *
 
 // Add an item to the head of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_start (zlistx_t *self, void *item);
 
 // Add an item to the tail of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_end (zlistx_t *self, void *item);
 
@@ -1896,8 +1896,7 @@ void
 // duplicator, if any, on the item. If low_value is true, starts searching
 // from the start of the list, otherwise searches from the end. Use the item
 // comparator, if any, to find where to place the new node. Returns a handle
-// to the new node, or NULL if memory was exhausted. Resets the cursor to the
-// list head.
+// to the new node. Resets the cursor to the list head.
 void *
     zlistx_insert (zlistx_t *self, void *item, bool low_value);
 

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -1688,13 +1688,13 @@ void *
     zlist_item (zlist_t *self);
 
 // Append an item to the end of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_append (zlist_t *self, void *item);
 
 // Push an item to the start of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_push (zlist_t *self, void *item);

--- a/api/zlist.api
+++ b/api/zlist.api
@@ -66,7 +66,7 @@
 
     <method name = "append">
         Append an item to the end of the list, return 0 if OK or -1 if this
-        failed for some reason (out of memory). Note that if a duplicator has
+        failed for some reason (invalid input). Note that if a duplicator has
         been set, this method will also duplicate the item.
         <argument name = "item" type = "anything" />
         <return type = "integer" />
@@ -74,7 +74,7 @@
 
     <method name = "push">
         Push an item to the start of the list, return 0 if OK or -1 if this
-        failed for some reason (out of memory). Note that if a duplicator has
+        failed for some reason (invalid input). Note that if a duplicator has
         been set, this method will also duplicate the item.
         <argument name = "item" type = "anything" />
         <return type = "integer" />

--- a/api/zlistx.api
+++ b/api/zlistx.api
@@ -40,7 +40,7 @@
     <method name = "add_start">
         Add an item to the head of the list. Calls the item duplicator, if any,
         on the item. Resets cursor to list head. Returns an item handle on
-        success, NULL if memory was exhausted.
+        success.
         <argument name = "item" type = "anything" mutable = "1" />
         <return type = "anything" mutable = "1" />
     </method>
@@ -48,7 +48,7 @@
     <method name = "add_end">
         Add an item to the tail of the list. Calls the item duplicator, if any,
         on the item. Resets cursor to list head. Returns an item handle on
-        success, NULL if memory was exhausted.
+        success.
         <argument name = "item" type = "anything" mutable = "1" />
         <return type = "anything" mutable = "1" />
     </method>
@@ -175,8 +175,7 @@
         duplicator, if any, on the item. If low_value is true, starts searching
         from the start of the list, otherwise searches from the end. Use the item
         comparator, if any, to find where to place the new node. Returns a handle
-        to the new node, or NULL if memory was exhausted. Resets the cursor to the
-        list head.
+        to the new node. Resets the cursor to the list head.
         <argument name = "item" type = "anything" mutable = "1" />
         <argument name = "low_value" type = "boolean" />
         <return type = "anything" mutable = "1" />

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -1000,12 +1000,12 @@ uses
 
     // Add an item to the head of the list. Calls the item duplicator, if any,
     // on the item. Resets cursor to list head. Returns an item handle on
-    // success, NULL if memory was exhausted.
+    // success.
     function AddStart(Item: Pointer): Pointer;
 
     // Add an item to the tail of the list. Calls the item duplicator, if any,
     // on the item. Resets cursor to list head. Returns an item handle on
-    // success, NULL if memory was exhausted.
+    // success.
     function AddEnd(Item: Pointer): Pointer;
 
     // Return the number of items in the list
@@ -1087,8 +1087,7 @@ uses
     // duplicator, if any, on the item. If low_value is true, starts searching
     // from the start of the list, otherwise searches from the end. Use the item
     // comparator, if any, to find where to place the new node. Returns a handle
-    // to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    // list head.
+    // to the new node. Resets the cursor to the list head.
     function Insert(Item: Pointer; LowValue: Boolean): Pointer;
 
     // Move an item, specified by handle, into position in a sorted list. Uses

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -931,12 +931,12 @@ uses
     function Item: Pointer;
 
     // Append an item to the end of the list, return 0 if OK or -1 if this
-    // failed for some reason (out of memory). Note that if a duplicator has
+    // failed for some reason (invalid input). Note that if a duplicator has
     // been set, this method will also duplicate the item.
     function Append(Item: Pointer): Integer;
 
     // Push an item to the start of the list, return 0 if OK or -1 if this
-    // failed for some reason (out of memory). Note that if a duplicator has
+    // failed for some reason (invalid input). Note that if a duplicator has
     // been set, this method will also duplicate the item.
     function Push(Item: Pointer): Integer;
 
@@ -3677,12 +3677,12 @@ uses
     function Item: Pointer;
 
     // Append an item to the end of the list, return 0 if OK or -1 if this
-    // failed for some reason (out of memory). Note that if a duplicator has
+    // failed for some reason (invalid input). Note that if a duplicator has
     // been set, this method will also duplicate the item.
     function Append(Item: Pointer): Integer;
 
     // Push an item to the start of the list, return 0 if OK or -1 if this
-    // failed for some reason (out of memory). Note that if a duplicator has
+    // failed for some reason (invalid input). Note that if a duplicator has
     // been set, this method will also duplicate the item.
     function Push(Item: Pointer): Integer;
 

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -1376,12 +1376,12 @@ type
   function zlist_item(self: PZlist): Pointer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Append an item to the end of the list, return 0 if OK or -1 if this
-  // failed for some reason (out of memory). Note that if a duplicator has
+  // failed for some reason (invalid input). Note that if a duplicator has
   // been set, this method will also duplicate the item.
   function zlist_append(self: PZlist; Item: Pointer): Integer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Push an item to the start of the list, return 0 if OK or -1 if this
-  // failed for some reason (out of memory). Note that if a duplicator has
+  // failed for some reason (invalid input). Note that if a duplicator has
   // been set, this method will also duplicate the item.
   function zlist_push(self: PZlist; Item: Pointer): Integer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -1473,12 +1473,12 @@ type
 
   // Add an item to the head of the list. Calls the item duplicator, if any,
   // on the item. Resets cursor to list head. Returns an item handle on
-  // success, NULL if memory was exhausted.
+  // success.
   function zlistx_add_start(self: PZlistx; Item: Pointer): Pointer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Add an item to the tail of the list. Calls the item duplicator, if any,
   // on the item. Resets cursor to list head. Returns an item handle on
-  // success, NULL if memory was exhausted.
+  // success.
   function zlistx_add_end(self: PZlistx; Item: Pointer): Pointer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Return the number of items in the list
@@ -1564,8 +1564,7 @@ type
   // duplicator, if any, on the item. If low_value is true, starts searching
   // from the start of the list, otherwise searches from the end. Use the item
   // comparator, if any, to find where to place the new node. Returns a handle
-  // to the new node, or NULL if memory was exhausted. Resets the cursor to the
-  // list head.
+  // to the new node. Resets the cursor to the list head.
   function zlistx_insert(self: PZlistx; Item: Pointer; LowValue: Boolean): Pointer; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Move an item, specified by handle, into position in a sorted list. Uses

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlist.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlist.java
@@ -94,7 +94,7 @@ public class Zlist implements AutoCloseable {
     }
     /*
     Append an item to the end of the list, return 0 if OK or -1 if this
-    failed for some reason (out of memory). Note that if a duplicator has
+    failed for some reason (invalid input). Note that if a duplicator has
     been set, this method will also duplicate the item.
     */
     native static int __append (long self, long item);
@@ -103,7 +103,7 @@ public class Zlist implements AutoCloseable {
     }
     /*
     Push an item to the start of the list, return 0 if OK or -1 if this
-    failed for some reason (out of memory). Note that if a duplicator has
+    failed for some reason (invalid input). Note that if a duplicator has
     been set, this method will also duplicate the item.
     */
     native static int __push (long self, long item);

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlistx.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zlistx.java
@@ -59,7 +59,7 @@ public class Zlistx implements AutoCloseable {
     /*
     Add an item to the head of the list. Calls the item duplicator, if any,
     on the item. Resets cursor to list head. Returns an item handle on
-    success, NULL if memory was exhausted.
+    success.
     */
     native static long __addStart (long self, long item);
     public long addStart (long item) {
@@ -68,7 +68,7 @@ public class Zlistx implements AutoCloseable {
     /*
     Add an item to the tail of the list. Calls the item duplicator, if any,
     on the item. Resets cursor to list head. Returns an item handle on
-    success, NULL if memory was exhausted.
+    success.
     */
     native static long __addEnd (long self, long item);
     public long addEnd (long item) {
@@ -230,8 +230,7 @@ public class Zlistx implements AutoCloseable {
     duplicator, if any, on the item. If low_value is true, starts searching
     from the start of the list, otherwise searches from the end. Use the item
     comparator, if any, to find where to place the new node. Returns a handle
-    to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    list head.
+    to the new node. Resets the cursor to the list head.
     */
     native static long __insert (long self, long item, boolean lowValue);
     public long insert (long item, boolean lowValue) {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1780,13 +1780,13 @@ zlistx_t *
 
 // Add an item to the head of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_start (zlistx_t *self, void *item);
 
 // Add an item to the tail of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_end (zlistx_t *self, void *item);
 
@@ -1891,8 +1891,7 @@ void
 // duplicator, if any, on the item. If low_value is true, starts searching
 // from the start of the list, otherwise searches from the end. Use the item
 // comparator, if any, to find where to place the new node. Returns a handle
-// to the new node, or NULL if memory was exhausted. Resets the cursor to the
-// list head.
+// to the new node. Resets the cursor to the list head.
 void *
     zlistx_insert (zlistx_t *self, void *item, bool low_value);
 

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -1683,13 +1683,13 @@ void *
     zlist_item (zlist_t *self);
 
 // Append an item to the end of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_append (zlist_t *self, void *item);
 
 // Push an item to the start of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_push (zlist_t *self, void *item);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -3965,7 +3965,7 @@ unpacks to an empty list.
         """
         Add an item to the head of the list. Calls the item duplicator, if any,
 on the item. Resets cursor to list head. Returns an item handle on
-success, NULL if memory was exhausted.
+success.
         """
         return c_void_p(lib.zlistx_add_start(self._as_parameter_, item))
 
@@ -3973,7 +3973,7 @@ success, NULL if memory was exhausted.
         """
         Add an item to the tail of the list. Calls the item duplicator, if any,
 on the item. Resets cursor to list head. Returns an item handle on
-success, NULL if memory was exhausted.
+success.
         """
         return c_void_p(lib.zlistx_add_end(self._as_parameter_, item))
 
@@ -4117,8 +4117,7 @@ reorder equal items.
 duplicator, if any, on the item. If low_value is true, starts searching
 from the start of the list, otherwise searches from the end. Use the item
 comparator, if any, to find where to place the new node. Returns a handle
-to the new node, or NULL if memory was exhausted. Resets the cursor to the
-list head.
+to the new node. Resets the cursor to the list head.
         """
         return c_void_p(lib.zlistx_insert(self._as_parameter_, item, low_value))
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -3731,7 +3731,7 @@ Leaves cursor pointing at the current item, or NULL if the list is empty.
     def append(self, item):
         """
         Append an item to the end of the list, return 0 if OK or -1 if this
-failed for some reason (out of memory). Note that if a duplicator has
+failed for some reason (invalid input). Note that if a duplicator has
 been set, this method will also duplicate the item.
         """
         return lib.zlist_append(self._as_parameter_, item)
@@ -3739,7 +3739,7 @@ been set, this method will also duplicate the item.
     def push(self, item):
         """
         Push an item to the start of the list, return 0 if OK or -1 if this
-failed for some reason (out of memory). Note that if a duplicator has
+failed for some reason (invalid input). Note that if a duplicator has
 been set, this method will also duplicate the item.
         """
         return lib.zlist_push(self._as_parameter_, item)

--- a/bindings/python_cffi/czmq_cffi/Zlist.py
+++ b/bindings/python_cffi/czmq_cffi/Zlist.py
@@ -67,7 +67,7 @@ class Zlist(object):
     def append(self, item):
         """
         Append an item to the end of the list, return 0 if OK or -1 if this
-        failed for some reason (out of memory). Note that if a duplicator has
+        failed for some reason (invalid input). Note that if a duplicator has
         been set, this method will also duplicate the item.
         """
         return utils.lib.zlist_append(self._p, item._p)
@@ -75,7 +75,7 @@ class Zlist(object):
     def push(self, item):
         """
         Push an item to the start of the list, return 0 if OK or -1 if this
-        failed for some reason (out of memory). Note that if a duplicator has
+        failed for some reason (invalid input). Note that if a duplicator has
         been set, this method will also duplicate the item.
         """
         return utils.lib.zlist_push(self._p, item._p)

--- a/bindings/python_cffi/czmq_cffi/Zlistx.py
+++ b/bindings/python_cffi/czmq_cffi/Zlistx.py
@@ -37,7 +37,7 @@ class Zlistx(object):
         """
         Add an item to the head of the list. Calls the item duplicator, if any,
         on the item. Resets cursor to list head. Returns an item handle on
-        success, NULL if memory was exhausted.
+        success.
         """
         return utils.lib.zlistx_add_start(self._p, item._p)
 
@@ -45,7 +45,7 @@ class Zlistx(object):
         """
         Add an item to the tail of the list. Calls the item duplicator, if any,
         on the item. Resets cursor to list head. Returns an item handle on
-        success, NULL if memory was exhausted.
+        success.
         """
         return utils.lib.zlistx_add_end(self._p, item._p)
 
@@ -189,8 +189,7 @@ class Zlistx(object):
         duplicator, if any, on the item. If low_value is true, starts searching
         from the start of the list, otherwise searches from the end. Use the item
         comparator, if any, to find where to place the new node. Returns a handle
-        to the new node, or NULL if memory was exhausted. Resets the cursor to the
-        list head.
+        to the new node. Resets the cursor to the list head.
         """
         return utils.lib.zlistx_insert(self._p, item._p, low_value)
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -1690,13 +1690,13 @@ void *
     zlist_item (zlist_t *self);
 
 // Append an item to the end of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_append (zlist_t *self, void *item);
 
 // Push an item to the start of the list, return 0 if OK or -1 if this
-// failed for some reason (out of memory). Note that if a duplicator has
+// failed for some reason (invalid input). Note that if a duplicator has
 // been set, this method will also duplicate the item.
 int
     zlist_push (zlist_t *self, void *item);

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -1787,13 +1787,13 @@ zlistx_t *
 
 // Add an item to the head of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_start (zlistx_t *self, void *item);
 
 // Add an item to the tail of the list. Calls the item duplicator, if any,
 // on the item. Resets cursor to list head. Returns an item handle on
-// success, NULL if memory was exhausted.
+// success.
 void *
     zlistx_add_end (zlistx_t *self, void *item);
 
@@ -1898,8 +1898,7 @@ void
 // duplicator, if any, on the item. If low_value is true, starts searching
 // from the start of the list, otherwise searches from the end. Use the item
 // comparator, if any, to find where to place the new node. Returns a handle
-// to the new node, or NULL if memory was exhausted. Resets the cursor to the
-// list head.
+// to the new node. Resets the cursor to the list head.
 void *
     zlistx_insert (zlistx_t *self, void *item, bool low_value);
 

--- a/bindings/qml/src/QmlZlist.cpp
+++ b/bindings/qml/src/QmlZlist.cpp
@@ -50,7 +50,7 @@ void *QmlZlist::item () {
 
 ///
 //  Append an item to the end of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 int QmlZlist::append (void *item) {
     return zlist_append (self, item);
@@ -58,7 +58,7 @@ int QmlZlist::append (void *item) {
 
 ///
 //  Push an item to the start of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 int QmlZlist::push (void *item) {
     return zlist_push (self, item);

--- a/bindings/qml/src/QmlZlist.h
+++ b/bindings/qml/src/QmlZlist.h
@@ -51,12 +51,12 @@ public slots:
     void *item ();
 
     //  Append an item to the end of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     int append (void *item);
 
     //  Push an item to the start of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     int push (void *item);
 

--- a/bindings/qml/src/QmlZlistx.cpp
+++ b/bindings/qml/src/QmlZlistx.cpp
@@ -11,7 +11,7 @@
 ///
 //  Add an item to the head of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 void *QmlZlistx::addStart (void *item) {
     return zlistx_add_start (self, item);
 };
@@ -19,7 +19,7 @@ void *QmlZlistx::addStart (void *item) {
 ///
 //  Add an item to the tail of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 void *QmlZlistx::addEnd (void *item) {
     return zlistx_add_end (self, item);
 };
@@ -155,8 +155,7 @@ void QmlZlistx::sort () {
 //  duplicator, if any, on the item. If low_value is true, starts searching
 //  from the start of the list, otherwise searches from the end. Use the item
 //  comparator, if any, to find where to place the new node. Returns a handle
-//  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-//  list head.
+//  to the new node. Resets the cursor to the list head.
 void *QmlZlistx::insert (void *item, bool lowValue) {
     return zlistx_insert (self, item, lowValue);
 };

--- a/bindings/qml/src/QmlZlistx.h
+++ b/bindings/qml/src/QmlZlistx.h
@@ -30,12 +30,12 @@ public:
 public slots:
     //  Add an item to the head of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     void *addStart (void *item);
 
     //  Add an item to the tail of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     void *addEnd (void *item);
 
     //  Return the number of items in the list
@@ -117,8 +117,7 @@ public slots:
     //  duplicator, if any, on the item. If low_value is true, starts searching
     //  from the start of the list, otherwise searches from the end. Use the item
     //  comparator, if any, to find where to place the new node. Returns a handle
-    //  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    //  list head.
+    //  to the new node. Resets the cursor to the list head.
     void *insert (void *item, bool lowValue);
 
     //  Move an item, specified by handle, into position in a sorted list. Uses

--- a/bindings/qt/src/qzlist.cpp
+++ b/bindings/qt/src/qzlist.cpp
@@ -83,7 +83,7 @@ void * QZlist::item ()
 
 ///
 //  Append an item to the end of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 int QZlist::append (void *item)
 {
@@ -93,7 +93,7 @@ int QZlist::append (void *item)
 
 ///
 //  Push an item to the start of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 int QZlist::push (void *item)
 {

--- a/bindings/qt/src/qzlist.h
+++ b/bindings/qt/src/qzlist.h
@@ -46,12 +46,12 @@ public:
     void * item ();
 
     //  Append an item to the end of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     int append (void *item);
 
     //  Push an item to the start of the list, return 0 if OK or -1 if this
-    //  failed for some reason (out of memory). Note that if a duplicator has
+    //  failed for some reason (invalid input). Note that if a duplicator has
     //  been set, this method will also duplicate the item.
     int push (void *item);
 

--- a/bindings/qt/src/qzlistx.cpp
+++ b/bindings/qt/src/qzlistx.cpp
@@ -42,7 +42,7 @@ QZlistx::~QZlistx ()
 ///
 //  Add an item to the head of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 void * QZlistx::addStart (void *item)
 {
     void * rv = zlistx_add_start (self, item);
@@ -52,7 +52,7 @@ void * QZlistx::addStart (void *item)
 ///
 //  Add an item to the tail of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 void * QZlistx::addEnd (void *item)
 {
     void * rv = zlistx_add_end (self, item);
@@ -233,8 +233,7 @@ void QZlistx::sort ()
 //  duplicator, if any, on the item. If low_value is true, starts searching
 //  from the start of the list, otherwise searches from the end. Use the item
 //  comparator, if any, to find where to place the new node. Returns a handle
-//  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-//  list head.
+//  to the new node. Resets the cursor to the list head.
 void * QZlistx::insert (void *item, bool lowValue)
 {
     void * rv = zlistx_insert (self, item, lowValue);

--- a/bindings/qt/src/qzlistx.h
+++ b/bindings/qt/src/qzlistx.h
@@ -31,12 +31,12 @@ public:
 
     //  Add an item to the head of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     void * addStart (void *item);
 
     //  Add an item to the tail of the list. Calls the item duplicator, if any,
     //  on the item. Resets cursor to list head. Returns an item handle on
-    //  success, NULL if memory was exhausted.
+    //  success.
     void * addEnd (void *item);
 
     //  Return the number of items in the list
@@ -122,8 +122,7 @@ public:
     //  duplicator, if any, on the item. If low_value is true, starts searching
     //  from the start of the list, otherwise searches from the end. Use the item
     //  comparator, if any, to find where to place the new node. Returns a handle
-    //  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    //  list head.
+    //  to the new node. Resets the cursor to the list head.
     void * insert (void *item, bool lowValue);
 
     //  Move an item, specified by handle, into position in a sorted list. Uses

--- a/bindings/ruby/lib/czmq/ffi/zlist.rb
+++ b/bindings/ruby/lib/czmq/ffi/zlist.rb
@@ -189,7 +189,7 @@ module CZMQ
       end
 
       # Append an item to the end of the list, return 0 if OK or -1 if this
-      # failed for some reason (out of memory). Note that if a duplicator has
+      # failed for some reason (invalid input). Note that if a duplicator has
       # been set, this method will also duplicate the item.
       #
       # @param item [::FFI::Pointer, #to_ptr]
@@ -202,7 +202,7 @@ module CZMQ
       end
 
       # Push an item to the start of the list, return 0 if OK or -1 if this
-      # failed for some reason (out of memory). Note that if a duplicator has
+      # failed for some reason (invalid input). Note that if a duplicator has
       # been set, this method will also duplicate the item.
       #
       # @param item [::FFI::Pointer, #to_ptr]

--- a/bindings/ruby/lib/czmq/ffi/zlistx.rb
+++ b/bindings/ruby/lib/czmq/ffi/zlistx.rb
@@ -154,7 +154,7 @@ module CZMQ
 
       # Add an item to the head of the list. Calls the item duplicator, if any,
       # on the item. Resets cursor to list head. Returns an item handle on
-      # success, NULL if memory was exhausted.
+      # success.
       #
       # @param item [::FFI::Pointer, #to_ptr]
       # @return [::FFI::Pointer]
@@ -167,7 +167,7 @@ module CZMQ
 
       # Add an item to the tail of the list. Calls the item duplicator, if any,
       # on the item. Resets cursor to list head. Returns an item handle on
-      # success, NULL if memory was exhausted.
+      # success.
       #
       # @param item [::FFI::Pointer, #to_ptr]
       # @return [::FFI::Pointer]
@@ -391,8 +391,7 @@ module CZMQ
       # duplicator, if any, on the item. If low_value is true, starts searching
       # from the start of the list, otherwise searches from the end. Use the item
       # comparator, if any, to find where to place the new node. Returns a handle
-      # to the new node, or NULL if memory was exhausted. Resets the cursor to the
-      # list head.
+      # to the new node. Resets the cursor to the list head.
       #
       # @param item [::FFI::Pointer, #to_ptr]
       # @param low_value [Boolean]

--- a/include/zlist.h
+++ b/include/zlist.h
@@ -68,13 +68,13 @@ CZMQ_EXPORT void *
     zlist_item (zlist_t *self);
 
 //  Append an item to the end of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 CZMQ_EXPORT int
     zlist_append (zlist_t *self, void *item);
 
 //  Push an item to the start of the list, return 0 if OK or -1 if this
-//  failed for some reason (out of memory). Note that if a duplicator has
+//  failed for some reason (invalid input). Note that if a duplicator has
 //  been set, this method will also duplicate the item.
 CZMQ_EXPORT int
     zlist_push (zlist_t *self, void *item);

--- a/include/zlistx.h
+++ b/include/zlistx.h
@@ -48,13 +48,13 @@ CZMQ_EXPORT void
 
 //  Add an item to the head of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 CZMQ_EXPORT void *
     zlistx_add_start (zlistx_t *self, void *item);
 
 //  Add an item to the tail of the list. Calls the item duplicator, if any,
 //  on the item. Resets cursor to list head. Returns an item handle on
-//  success, NULL if memory was exhausted.
+//  success.
 CZMQ_EXPORT void *
     zlistx_add_end (zlistx_t *self, void *item);
 
@@ -159,8 +159,7 @@ CZMQ_EXPORT void
 //  duplicator, if any, on the item. If low_value is true, starts searching
 //  from the start of the list, otherwise searches from the end. Use the item
 //  comparator, if any, to find where to place the new node. Returns a handle
-//  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-//  list head.
+//  to the new node. Resets the cursor to the list head.
 CZMQ_EXPORT void *
     zlistx_insert (zlistx_t *self, void *item, bool low_value);
 

--- a/src/zlistx.c
+++ b/src/zlistx.c
@@ -509,8 +509,7 @@ zlistx_sort (zlistx_t *self)
 //  duplicator, if any, on the item. If low_value is true, starts searching
 //  from the start of the list, otherwise searches from the end. Use the item
 //  comparator, if any, to find where to place the new node. Returns a handle
-//  to the new node, or NULL if memory was exhausted. Resets the cursor to the
-//  list head.
+//  to the new node. Resets the cursor to the list head.
 
 void *
 zlistx_insert (zlistx_t *self, void *item, bool low_value)


### PR DESCRIPTION
I noticed a few comments in the headers for zlist/zlistx that mention errors are returned on out of memory conditions.  I believe those errors are no longer possible, as czmq is built with asserts to bail if any internal memory allocation fails.  Apologies if I'm wrong about this.

For `zlist`, I just changed the example error of "out of memory" to "invalid input", which is a real possible error.  For `zlistx`, I just removed the offending text.