### PR TITLE
Problem: zdir_list omits empty subdirectories

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -883,7 +883,6 @@ zlist_t *
 
 // Returns a sorted list of char*; Each entry in the list is a path of a file
 // or directory contained in self.
-// Caller owns return value and must destroy it when done.
 zlist_t *
     zdir_list_paths (zdir_t *self);
 

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -881,6 +881,12 @@ size_t
 zlist_t *
     zdir_list (zdir_t *self);
 
+// Returns a sorted list of char*; Each entry in the list is a path of a file
+// or directory contained in self.
+// Caller owns return value and must destroy it when done.
+zlist_t *
+    zdir_list_paths (zdir_t *self);
+
 // Remove directory, optionally including all files that it contains, at
 // all levels. If force is false, will only remove the directory if empty.
 // If force is true, will remove all files and all subdirectories.

--- a/api/zdir.api
+++ b/api/zdir.api
@@ -53,7 +53,6 @@
     <method name = "list_paths">
         Returns a sorted list of char*; Each entry in the list is a path of a file
         or directory contained in self.
-        Caller owns return value and must destroy it when done.
         <return type = "zlist" fresh = "1" />
     </method>
 

--- a/api/zdir.api
+++ b/api/zdir.api
@@ -49,6 +49,13 @@
         original zdir tree until you are done with this list.
         <return type = "zlist" fresh = "1" />
     </method>
+    
+    <method name = "list_paths">
+        Returns a sorted list of char*; Each entry in the list is a path of a file
+        or directory contained in self.
+        Caller owns return value and must destroy it when done.
+        <return type = "zlist" fresh = "1" />
+    </method>
 
     <method name = "remove">
         Remove directory, optionally including all files that it contains, at

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -398,7 +398,6 @@ uses
 
     // Returns a sorted list of char*; Each entry in the list is a path of a file
     // or directory contained in self.
-    // Caller owns return value and must destroy it when done.
     function ListPaths: IZlist;
 
     // Remove directory, optionally including all files that it contains, at
@@ -2973,7 +2972,6 @@ uses
 
     // Returns a sorted list of char*; Each entry in the list is a path of a file
     // or directory contained in self.
-    // Caller owns return value and must destroy it when done.
     function ListPaths: IZlist;
 
     // Remove directory, optionally including all files that it contains, at

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -396,6 +396,11 @@ uses
     // original zdir tree until you are done with this list.
     function List: IZlist;
 
+    // Returns a sorted list of char*; Each entry in the list is a path of a file
+    // or directory contained in self.
+    // Caller owns return value and must destroy it when done.
+    function ListPaths: IZlist;
+
     // Remove directory, optionally including all files that it contains, at
     // all levels. If force is false, will only remove the directory if empty.
     // If force is true, will remove all files and all subdirectories.
@@ -2965,6 +2970,11 @@ uses
     // to a zfile_t item already allocated in the zdir tree. Do not destroy the
     // original zdir tree until you are done with this list.
     function List: IZlist;
+
+    // Returns a sorted list of char*; Each entry in the list is a path of a file
+    // or directory contained in self.
+    // Caller owns return value and must destroy it when done.
+    function ListPaths: IZlist;
 
     // Remove directory, optionally including all files that it contains, at
     // all levels. If force is false, will only remove the directory if empty.
@@ -6822,6 +6832,11 @@ end;
   function TZdir.List: IZlist;
   begin
     Result := TZlist.Wrap(zdir_list(FHandle), true);
+  end;
+
+  function TZdir.ListPaths: IZlist;
+  begin
+    Result := TZlist.Wrap(zdir_list_paths(FHandle), true);
   end;
 
   procedure TZdir.Remove(Force: Boolean);

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -649,7 +649,6 @@ type
 
   // Returns a sorted list of char*; Each entry in the list is a path of a file
   // or directory contained in self.
-  // Caller owns return value and must destroy it when done.
   function zdir_list_paths(self: PZdir): PZlist; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
   // Remove directory, optionally including all files that it contains, at

--- a/bindings/delphi/libczmq.pas
+++ b/bindings/delphi/libczmq.pas
@@ -647,6 +647,11 @@ type
   // original zdir tree until you are done with this list.
   function zdir_list(self: PZdir): PZlist; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
 
+  // Returns a sorted list of char*; Each entry in the list is a path of a file
+  // or directory contained in self.
+  // Caller owns return value and must destroy it when done.
+  function zdir_list_paths(self: PZdir): PZlist; cdecl; external lib_czmq {$IFDEF MSWINDOWS}delayed{$ENDIF};
+
   // Remove directory, optionally including all files that it contains, at
   // all levels. If force is false, will only remove the directory if empty.
   // If force is true, will remove all files and all subdirectories.

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zdir.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zdir.c
@@ -65,6 +65,13 @@ Java_org_zeromq_czmq_Zdir__1_1list (JNIEnv *env, jclass c, jlong self)
     return list_;
 }
 
+JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zdir__1_1listPaths (JNIEnv *env, jclass c, jlong self)
+{
+    jlong list_paths_ = (jlong) (intptr_t) zdir_list_paths ((zdir_t *) (intptr_t) self);
+    return list_paths_;
+}
+
 JNIEXPORT void JNICALL
 Java_org_zeromq_czmq_Zdir__1_1remove (JNIEnv *env, jclass c, jlong self, jboolean force)
 {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
@@ -89,7 +89,6 @@ public class Zdir implements AutoCloseable {
     /*
     Returns a sorted list of char*; Each entry in the list is a path of a file
     or directory contained in self.
-    Caller owns return value and must destroy it when done.
     */
     native static long __listPaths (long self);
     public Zlist listPaths () {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zdir.java
@@ -87,6 +87,15 @@ public class Zdir implements AutoCloseable {
         return new Zlist (__list (self));
     }
     /*
+    Returns a sorted list of char*; Each entry in the list is a path of a file
+    or directory contained in self.
+    Caller owns return value and must destroy it when done.
+    */
+    native static long __listPaths (long self);
+    public Zlist listPaths () {
+        return new Zlist (__listPaths (self));
+    }
+    /*
     Remove directory, optionally including all files that it contains, at
     all levels. If force is false, will only remove the directory if empty.
     If force is true, will remove all files and all subdirectories.

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -878,7 +878,6 @@ zlist_t *
 
 // Returns a sorted list of char*; Each entry in the list is a path of a file
 // or directory contained in self.
-// Caller owns return value and must destroy it when done.
 zlist_t *
     zdir_list_paths (zdir_t *self);
 

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -876,6 +876,12 @@ size_t
 zlist_t *
     zdir_list (zdir_t *self);
 
+// Returns a sorted list of char*; Each entry in the list is a path of a file
+// or directory contained in self.
+// Caller owns return value and must destroy it when done.
+zlist_t *
+    zdir_list_paths (zdir_t *self);
+
 // Remove directory, optionally including all files that it contains, at
 // all levels. If force is false, will only remove the directory if empty.
 // If force is true, will remove all files and all subdirectories.

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -952,6 +952,14 @@ to a zfile_t item already allocated in the zdir tree. Do not destroy the
 original zdir tree until you are done with this list.
 
 ```
+zlist my_zdir.listPaths ()
+```
+
+Returns a sorted list of char*; Each entry in the list is a path of a file
+or directory contained in self.
+Caller owns return value and must destroy it when done.
+
+```
 nothing my_zdir.remove (Boolean)
 ```
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -957,7 +957,6 @@ zlist my_zdir.listPaths ()
 
 Returns a sorted list of char*; Each entry in the list is a path of a file
 or directory contained in self.
-Caller owns return value and must destroy it when done.
 
 ```
 nothing my_zdir.remove (Boolean)

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -1834,6 +1834,7 @@ NAN_MODULE_INIT (Zdir::Init) {
     Nan::SetPrototypeMethod (tpl, "cursize", _cursize);
     Nan::SetPrototypeMethod (tpl, "count", _count);
     Nan::SetPrototypeMethod (tpl, "list", _list);
+    Nan::SetPrototypeMethod (tpl, "listPaths", _list_paths);
     Nan::SetPrototypeMethod (tpl, "remove", _remove);
     Nan::SetPrototypeMethod (tpl, "diff", _diff);
     Nan::SetPrototypeMethod (tpl, "resync", _resync);
@@ -1924,6 +1925,18 @@ NAN_METHOD (Zdir::_count) {
 NAN_METHOD (Zdir::_list) {
     Zdir *zdir = Nan::ObjectWrap::Unwrap <Zdir> (info.Holder ());
     zlist_t *result = zdir_list (zdir->self);
+    Zlist *zlist_result = new Zlist (result);
+    if (zlist_result) {
+    //  Don't yet know how to return a new object
+    //      zlist->Wrap (info.This ());
+    //      info.GetReturnValue ().Set (info.This ());
+        info.GetReturnValue ().Set (Nan::New<Boolean>(true));
+    }
+}
+
+NAN_METHOD (Zdir::_list_paths) {
+    Zdir *zdir = Nan::ObjectWrap::Unwrap <Zdir> (info.Holder ());
+    zlist_t *result = zdir_list_paths (zdir->self);
     Zlist *zlist_result = new Zlist (result);
     if (zlist_result) {
     //  Don't yet know how to return a new object

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -269,6 +269,7 @@ class Zdir: public Nan::ObjectWrap {
     static NAN_METHOD (_cursize);
     static NAN_METHOD (_count);
     static NAN_METHOD (_list);
+    static NAN_METHOD (_list_paths);
     static NAN_METHOD (_remove);
     static NAN_METHOD (_diff);
     static NAN_METHOD (_resync);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -1926,6 +1926,8 @@ lib.zdir_count.restype = c_size_t
 lib.zdir_count.argtypes = [zdir_p]
 lib.zdir_list.restype = zlist_p
 lib.zdir_list.argtypes = [zdir_p]
+lib.zdir_list_paths.restype = zlist_p
+lib.zdir_list_paths.argtypes = [zdir_p]
 lib.zdir_remove.restype = None
 lib.zdir_remove.argtypes = [zdir_p, c_bool]
 lib.zdir_diff.restype = zlist_p
@@ -2025,6 +2027,14 @@ to a zfile_t item already allocated in the zdir tree. Do not destroy the
 original zdir tree until you are done with this list.
         """
         return Zlist(lib.zdir_list(self._as_parameter_), True)
+
+    def list_paths(self):
+        """
+        Returns a sorted list of char*; Each entry in the list is a path of a file
+or directory contained in self.
+Caller owns return value and must destroy it when done.
+        """
+        return Zlist(lib.zdir_list_paths(self._as_parameter_), True)
 
     def remove(self, force):
         """

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -2032,7 +2032,6 @@ original zdir tree until you are done with this list.
         """
         Returns a sorted list of char*; Each entry in the list is a path of a file
 or directory contained in self.
-Caller owns return value and must destroy it when done.
         """
         return Zlist(lib.zdir_list_paths(self._as_parameter_), True)
 

--- a/bindings/python_cffi/czmq_cffi/Zdir.py
+++ b/bindings/python_cffi/czmq_cffi/Zdir.py
@@ -63,7 +63,6 @@ class Zdir(object):
         """
         Returns a sorted list of char*; Each entry in the list is a path of a file
         or directory contained in self.
-        Caller owns return value and must destroy it when done.
         """
         return utils.lib.zdir_list_paths(self._p)
 

--- a/bindings/python_cffi/czmq_cffi/Zdir.py
+++ b/bindings/python_cffi/czmq_cffi/Zdir.py
@@ -59,6 +59,14 @@ class Zdir(object):
         """
         return utils.lib.zdir_list(self._p)
 
+    def list_paths(self):
+        """
+        Returns a sorted list of char*; Each entry in the list is a path of a file
+        or directory contained in self.
+        Caller owns return value and must destroy it when done.
+        """
+        return utils.lib.zdir_list_paths(self._p)
+
     def remove(self, force):
         """
         Remove directory, optionally including all files that it contains, at

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -885,7 +885,6 @@ zlist_t *
 
 // Returns a sorted list of char*; Each entry in the list is a path of a file
 // or directory contained in self.
-// Caller owns return value and must destroy it when done.
 zlist_t *
     zdir_list_paths (zdir_t *self);
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -883,6 +883,12 @@ size_t
 zlist_t *
     zdir_list (zdir_t *self);
 
+// Returns a sorted list of char*; Each entry in the list is a path of a file
+// or directory contained in self.
+// Caller owns return value and must destroy it when done.
+zlist_t *
+    zdir_list_paths (zdir_t *self);
+
 // Remove directory, optionally including all files that it contains, at
 // all levels. If force is false, will only remove the directory if empty.
 // If force is true, will remove all files and all subdirectories.

--- a/bindings/qml/src/QmlZdir.cpp
+++ b/bindings/qml/src/QmlZdir.cpp
@@ -46,7 +46,6 @@ QmlZlist *QmlZdir::list () {
 ///
 //  Returns a sorted list of char*; Each entry in the list is a path of a file
 //  or directory contained in self.
-//  Caller owns return value and must destroy it when done.
 QmlZlist *QmlZdir::listPaths () {
     QmlZlist *retQ_ = new QmlZlist ();
     retQ_->self = zdir_list_paths (self);

--- a/bindings/qml/src/QmlZdir.cpp
+++ b/bindings/qml/src/QmlZdir.cpp
@@ -44,6 +44,16 @@ QmlZlist *QmlZdir::list () {
 };
 
 ///
+//  Returns a sorted list of char*; Each entry in the list is a path of a file
+//  or directory contained in self.
+//  Caller owns return value and must destroy it when done.
+QmlZlist *QmlZdir::listPaths () {
+    QmlZlist *retQ_ = new QmlZlist ();
+    retQ_->self = zdir_list_paths (self);
+    return retQ_;
+};
+
+///
 //  Remove directory, optionally including all files that it contains, at
 //  all levels. If force is false, will only remove the directory if empty.
 //  If force is true, will remove all files and all subdirectories.

--- a/bindings/qml/src/QmlZdir.h
+++ b/bindings/qml/src/QmlZdir.h
@@ -46,6 +46,11 @@ public slots:
     //  original zdir tree until you are done with this list.
     QmlZlist *list ();
 
+    //  Returns a sorted list of char*; Each entry in the list is a path of a file
+    //  or directory contained in self.
+    //  Caller owns return value and must destroy it when done.
+    QmlZlist *listPaths ();
+
     //  Remove directory, optionally including all files that it contains, at
     //  all levels. If force is false, will only remove the directory if empty.
     //  If force is true, will remove all files and all subdirectories.

--- a/bindings/qml/src/QmlZdir.h
+++ b/bindings/qml/src/QmlZdir.h
@@ -48,7 +48,6 @@ public slots:
 
     //  Returns a sorted list of char*; Each entry in the list is a path of a file
     //  or directory contained in self.
-    //  Caller owns return value and must destroy it when done.
     QmlZlist *listPaths ();
 
     //  Remove directory, optionally including all files that it contains, at

--- a/bindings/qt/src/qzdir.cpp
+++ b/bindings/qt/src/qzdir.cpp
@@ -77,7 +77,6 @@ QZlist * QZdir::list ()
 ///
 //  Returns a sorted list of char*; Each entry in the list is a path of a file
 //  or directory contained in self.
-//  Caller owns return value and must destroy it when done.
 QZlist * QZdir::listPaths ()
 {
     QZlist *rv = new QZlist (zdir_list_paths (self));

--- a/bindings/qt/src/qzdir.cpp
+++ b/bindings/qt/src/qzdir.cpp
@@ -75,6 +75,16 @@ QZlist * QZdir::list ()
 }
 
 ///
+//  Returns a sorted list of char*; Each entry in the list is a path of a file
+//  or directory contained in self.
+//  Caller owns return value and must destroy it when done.
+QZlist * QZdir::listPaths ()
+{
+    QZlist *rv = new QZlist (zdir_list_paths (self));
+    return rv;
+}
+
+///
 //  Remove directory, optionally including all files that it contains, at
 //  all levels. If force is false, will only remove the directory if empty.
 //  If force is true, will remove all files and all subdirectories.

--- a/bindings/qt/src/qzdir.h
+++ b/bindings/qt/src/qzdir.h
@@ -43,6 +43,11 @@ public:
     //  original zdir tree until you are done with this list.
     QZlist * list ();
 
+    //  Returns a sorted list of char*; Each entry in the list is a path of a file
+    //  or directory contained in self.
+    //  Caller owns return value and must destroy it when done.
+    QZlist * listPaths ();
+
     //  Remove directory, optionally including all files that it contains, at
     //  all levels. If force is false, will only remove the directory if empty.
     //  If force is true, will remove all files and all subdirectories.

--- a/bindings/qt/src/qzdir.h
+++ b/bindings/qt/src/qzdir.h
@@ -45,7 +45,6 @@ public:
 
     //  Returns a sorted list of char*; Each entry in the list is a path of a file
     //  or directory contained in self.
-    //  Caller owns return value and must destroy it when done.
     QZlist * listPaths ();
 
     //  Remove directory, optionally including all files that it contains, at

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -233,6 +233,7 @@ module CZMQ
       attach_function :zdir_cursize, [:pointer], :pointer, **opts
       attach_function :zdir_count, [:pointer], :size_t, **opts
       attach_function :zdir_list, [:pointer], :pointer, **opts
+      attach_function :zdir_list_paths, [:pointer], :pointer, **opts
       attach_function :zdir_remove, [:pointer, :bool], :void, **opts
       attach_function :zdir_diff, [:pointer, :pointer, :string], :pointer, **opts
       attach_function :zdir_resync, [:pointer, :string], :pointer, **opts

--- a/bindings/ruby/lib/czmq/ffi/zdir.rb
+++ b/bindings/ruby/lib/czmq/ffi/zdir.rb
@@ -149,6 +149,19 @@ module CZMQ
         result
       end
 
+      # Returns a sorted list of char*; Each entry in the list is a path of a file
+      # or directory contained in self.
+      # Caller owns return value and must destroy it when done.
+      #
+      # @return [Zlist]
+      def list_paths()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zdir_list_paths(self_p)
+        result = Zlist.__new result, true
+        result
+      end
+
       # Remove directory, optionally including all files that it contains, at
       # all levels. If force is false, will only remove the directory if empty.
       # If force is true, will remove all files and all subdirectories.

--- a/bindings/ruby/lib/czmq/ffi/zdir.rb
+++ b/bindings/ruby/lib/czmq/ffi/zdir.rb
@@ -151,7 +151,6 @@ module CZMQ
 
       # Returns a sorted list of char*; Each entry in the list is a path of a file
       # or directory contained in self.
-      # Caller owns return value and must destroy it when done.
       #
       # @return [Zlist]
       def list_paths()

--- a/include/zdir.h
+++ b/include/zdir.h
@@ -57,6 +57,12 @@ CZMQ_EXPORT size_t
 CZMQ_EXPORT zlist_t *
     zdir_list (zdir_t *self);
 
+//  Returns a sorted list of char*; Each entry in the list is a path of a file
+//  or directory contained in self.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT zlist_t *
+    zdir_list_paths (zdir_t *self);
+
 //  Remove directory, optionally including all files that it contains, at
 //  all levels. If force is false, will only remove the directory if empty.
 //  If force is true, will remove all files and all subdirectories.


### PR DESCRIPTION
Solution: zdir_list_paths return a char* list of all the files and subdirectories of zdir
