### PR TITLE
Problem: ziflist crashes on aliased iface

### DIFF
--- a/src/ziflist.c
+++ b/src/ziflist.c
@@ -260,11 +260,13 @@ s_reload (ziflist_t *self, bool ipv6)
                     ipv6 && (interface->ifa_addr->sa_family == AF_INET6)))
             {
                 const char *mac = zhash_lookup(mactable, interface->ifa_name);
-                interface_t *item = s_interface_new (interface->ifa_name,
-                        interface->ifa_addr, interface->ifa_netmask,
-                        interface->ifa_broadaddr, mac);
-                if (item)
-                    zlistx_add_end (list, item);
+                if (mac){
+                    interface_t *item = s_interface_new (interface->ifa_name,
+                            interface->ifa_addr, interface->ifa_netmask,
+                            interface->ifa_broadaddr, mac);
+                    if (item)
+                        zlistx_add_end (list, item);
+                }
             }
             interface = interface->ifa_next;
         }


### PR DESCRIPTION
Solution: NULL-check the `mac` variable before using it
