### PR TITLE
fixup invalid XML entities in document

### DIFF
--- a/api/zhttp_request.api
+++ b/api/zhttp_request.api
@@ -9,7 +9,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
     -->
     Http request that can be received from zhttp_server or sent to zhttp_client.
-    Class can be reused between send & recv calls.
+    Class can be reused between send &amp; recv calls.
     Headers and Content is being destroyed after every send call.
 
     <constructor>
@@ -125,7 +125,7 @@
         To use the percent symbol, just double it, e.g "%%something".
 
         Example:
-        if (zhttp_request_match (request, "POST", "/send/%s/%s", &name, &id))
+        if (zhttp_request_match (request, "POST", "/send/%s/%s", &amp;name, &amp;id))
 
         <argument name = "method" type = "string" />
         <argument name = "path" type = "string" variadic = "1" />

--- a/api/zhttp_response.api
+++ b/api/zhttp_response.api
@@ -9,7 +9,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
     -->
     Http response that can be received from zhttp_client or sent to zhttp_server.
-    Class can be reused between send & recv calls.
+    Class can be reused between send &amp; recv calls.
     Headers and Content is being destroyed after every send call.
 
     <constructor>

--- a/api/zhttp_server.api
+++ b/api/zhttp_server.api
@@ -19,7 +19,7 @@
     You can connect as many dealers as you want.
     The Server is using simple dealer socket to route the requests.
 
-    NOTE: when using libmicrohttpd << 0.9.34 the application might experience
+    NOTE: when using libmicrohttpd &lt;&lt; 0.9.34 the application might experience
     high CPU usage due to the lack of MHD_suspend_connection and
     MHD_resume_connection APIs. It is recommended to use this class only with
     libmicrohttpd at least 0.9.34 in production.

--- a/api/zosc.api
+++ b/api/zosc.api
@@ -26,8 +26,8 @@
 
     Decoding a message:
 
-        int rc = zosc_retr(oscmsg, "iihfdscF", &intx, &inty, &intz, &floatz, 
-                            &doublez, &strings, &charq, &someBool);
+        int rc = zosc_retr(oscmsg, "iihfdscF", &amp;intx, &amp;inty, &amp;intz, &amp;floatz, 
+                            &amp;doublez, &amp;strings, &amp;charq, &amp;someBool);
 
     See the class's test method for more examples how to use the class.
 


### PR DESCRIPTION
Problem: Invalid XML entities in document

Solution: use XML entity or warp document in `<![CDATA[]>`

