### PR TITLE
Fixed issue 2278, loop->terminated == true when restarting a loop

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -709,6 +709,7 @@ zloop_start (zloop_t *self)
 {
     assert (self);
     int rc = 0;
+    self->terminated = false;
 
     //  Main reactor loop
     while (!zsys_interrupted || self->nonstop) {


### PR DESCRIPTION
Problem: Issue 2278; loop->terminated == true when restarting a loop allowing timer callbacks to update loop->timers in place.

Solution: Set loop->terminated = false at beginning of zloop_start. Add test to both demonstrate the issue and test the fix.