### PR TITLE
Problem: Out of date zproject

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -2358,19 +2358,19 @@ void
 
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The writable one is then accessbile via zproc_stdin method.
+// sockets.  The writable one is then accessible via zproc_stdin method.
 void
     zproc_set_stdin (zproc_t *self, void *socket);
 
 // Connects process stdout with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stdout method.
+// sockets.  The readable one is then accessible via zproc_stdout method.
 void
     zproc_set_stdout (zproc_t *self, void *socket);
 
 // Connects process stderr with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stderr method.
+// sockets.  The readable one is then accessible via zproc_stderr method.
 void
     zproc_set_stderr (zproc_t *self, void *socket);
 

--- a/api/zproc.api
+++ b/api/zproc.api
@@ -46,21 +46,21 @@
     <method name = "set stdin" >
         Connects process stdin with a readable ('>', connect) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The writable one is then accessbile via zproc_stdin method.
+        sockets.  The writable one is then accessible via zproc_stdin method.
         <argument name = "socket" type = "anything" />
     </method>
 
     <method name = "set stdout" >
         Connects process stdout with a writable ('@', bind) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The readable one is then accessbile via zproc_stdout method.
+        sockets.  The readable one is then accessible via zproc_stdout method.
         <argument name = "socket" type = "anything" />
     </method>
 
     <method name = "set stderr" >
         Connects process stderr with a writable ('@', bind) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The readable one is then accessbile via zproc_stderr method.
+        sockets.  The readable one is then accessible via zproc_stderr method.
         <argument name = "socket" type = "anything" />
     </method>
 

--- a/bindings/delphi/CZMQ.pas
+++ b/bindings/delphi/CZMQ.pas
@@ -3781,12 +3781,12 @@ uses
 
     // Add an item to the head of the list. Calls the item duplicator, if any,
     // on the item. Resets cursor to list head. Returns an item handle on
-    // success, NULL if memory was exhausted.
+    // success.
     function AddStart(Item: Pointer): Pointer;
 
     // Add an item to the tail of the list. Calls the item duplicator, if any,
     // on the item. Resets cursor to list head. Returns an item handle on
-    // success, NULL if memory was exhausted.
+    // success.
     function AddEnd(Item: Pointer): Pointer;
 
     // Return the number of items in the list
@@ -3868,8 +3868,7 @@ uses
     // duplicator, if any, on the item. If low_value is true, starts searching
     // from the start of the list, otherwise searches from the end. Use the item
     // comparator, if any, to find where to place the new node. Returns a handle
-    // to the new node, or NULL if memory was exhausted. Resets the cursor to the
-    // list head.
+    // to the new node. Resets the cursor to the list head.
     function Insert(Item: Pointer; LowValue: Boolean): Pointer;
 
     // Move an item, specified by handle, into position in a sorted list. Uses

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zproc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zproc.java
@@ -82,7 +82,7 @@ public class Zproc implements AutoCloseable {
     /*
     Connects process stdin with a readable ('>', connect) zeromq socket. If
     socket argument is NULL, zproc creates own managed pair of inproc
-    sockets.  The writable one is then accessbile via zproc_stdin method.
+    sockets.  The writable one is then accessible via zproc_stdin method.
     */
     native static void __setStdin (long self, long socket);
     public void setStdin (long socket) {
@@ -91,7 +91,7 @@ public class Zproc implements AutoCloseable {
     /*
     Connects process stdout with a writable ('@', bind) zeromq socket. If
     socket argument is NULL, zproc creates own managed pair of inproc
-    sockets.  The readable one is then accessbile via zproc_stdout method.
+    sockets.  The readable one is then accessible via zproc_stdout method.
     */
     native static void __setStdout (long self, long socket);
     public void setStdout (long socket) {
@@ -100,7 +100,7 @@ public class Zproc implements AutoCloseable {
     /*
     Connects process stderr with a writable ('@', bind) zeromq socket. If
     socket argument is NULL, zproc creates own managed pair of inproc
-    sockets.  The readable one is then accessbile via zproc_stderr method.
+    sockets.  The readable one is then accessible via zproc_stderr method.
     */
     native static void __setStderr (long self, long socket);
     public void setStderr (long socket) {

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -2353,19 +2353,19 @@ void
 
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The writable one is then accessbile via zproc_stdin method.
+// sockets.  The writable one is then accessible via zproc_stdin method.
 void
     zproc_set_stdin (zproc_t *self, void *socket);
 
 // Connects process stdout with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stdout method.
+// sockets.  The readable one is then accessible via zproc_stdout method.
 void
     zproc_set_stdout (zproc_t *self, void *socket);
 
 // Connects process stderr with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stderr method.
+// sockets.  The readable one is then accessible via zproc_stderr method.
 void
     zproc_set_stderr (zproc_t *self, void *socket);
 

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -5081,7 +5081,7 @@ to run. Variadic function, must be NULL terminated.
         """
         Connects process stdin with a readable ('>', connect) zeromq socket. If
 socket argument is NULL, zproc creates own managed pair of inproc
-sockets.  The writable one is then accessbile via zproc_stdin method.
+sockets.  The writable one is then accessible via zproc_stdin method.
         """
         return lib.zproc_set_stdin(self._as_parameter_, socket)
 
@@ -5089,7 +5089,7 @@ sockets.  The writable one is then accessbile via zproc_stdin method.
         """
         Connects process stdout with a writable ('@', bind) zeromq socket. If
 socket argument is NULL, zproc creates own managed pair of inproc
-sockets.  The readable one is then accessbile via zproc_stdout method.
+sockets.  The readable one is then accessible via zproc_stdout method.
         """
         return lib.zproc_set_stdout(self._as_parameter_, socket)
 
@@ -5097,7 +5097,7 @@ sockets.  The readable one is then accessbile via zproc_stdout method.
         """
         Connects process stderr with a writable ('@', bind) zeromq socket. If
 socket argument is NULL, zproc creates own managed pair of inproc
-sockets.  The readable one is then accessbile via zproc_stderr method.
+sockets.  The readable one is then accessible via zproc_stderr method.
         """
         return lib.zproc_set_stderr(self._as_parameter_, socket)
 

--- a/bindings/python_cffi/czmq_cffi/Zproc.py
+++ b/bindings/python_cffi/czmq_cffi/Zproc.py
@@ -64,7 +64,7 @@ class Zproc(object):
         """
         Connects process stdin with a readable ('>', connect) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The writable one is then accessbile via zproc_stdin method.
+        sockets.  The writable one is then accessible via zproc_stdin method.
         """
         utils.lib.zproc_set_stdin(self._p, socket._p)
 
@@ -72,7 +72,7 @@ class Zproc(object):
         """
         Connects process stdout with a writable ('@', bind) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The readable one is then accessbile via zproc_stdout method.
+        sockets.  The readable one is then accessible via zproc_stdout method.
         """
         utils.lib.zproc_set_stdout(self._p, socket._p)
 
@@ -80,7 +80,7 @@ class Zproc(object):
         """
         Connects process stderr with a writable ('@', bind) zeromq socket. If
         socket argument is NULL, zproc creates own managed pair of inproc
-        sockets.  The readable one is then accessbile via zproc_stderr method.
+        sockets.  The readable one is then accessible via zproc_stderr method.
         """
         utils.lib.zproc_set_stderr(self._p, socket._p)
 

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -2360,19 +2360,19 @@ void
 
 // Connects process stdin with a readable ('>', connect) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The writable one is then accessbile via zproc_stdin method.
+// sockets.  The writable one is then accessible via zproc_stdin method.
 void
     zproc_set_stdin (zproc_t *self, void *socket);
 
 // Connects process stdout with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stdout method.
+// sockets.  The readable one is then accessible via zproc_stdout method.
 void
     zproc_set_stdout (zproc_t *self, void *socket);
 
 // Connects process stderr with a writable ('@', bind) zeromq socket. If
 // socket argument is NULL, zproc creates own managed pair of inproc
-// sockets.  The readable one is then accessbile via zproc_stderr method.
+// sockets.  The readable one is then accessible via zproc_stderr method.
 void
     zproc_set_stderr (zproc_t *self, void *socket);
 

--- a/bindings/qml/src/QmlZproc.cpp
+++ b/bindings/qml/src/QmlZproc.cpp
@@ -40,7 +40,7 @@ void QmlZproc::setEnv (QmlZhash *arguments) {
 ///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The writable one is then accessbile via zproc_stdin method.
+//  sockets.  The writable one is then accessible via zproc_stdin method.
 void QmlZproc::setStdin (void *socket) {
     zproc_set_stdin (self, socket);
 };
@@ -48,7 +48,7 @@ void QmlZproc::setStdin (void *socket) {
 ///
 //  Connects process stdout with a writable ('@', bind) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The readable one is then accessbile via zproc_stdout method.
+//  sockets.  The readable one is then accessible via zproc_stdout method.
 void QmlZproc::setStdout (void *socket) {
     zproc_set_stdout (self, socket);
 };
@@ -56,7 +56,7 @@ void QmlZproc::setStdout (void *socket) {
 ///
 //  Connects process stderr with a writable ('@', bind) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The readable one is then accessbile via zproc_stderr method.
+//  sockets.  The readable one is then accessible via zproc_stderr method.
 void QmlZproc::setStderr (void *socket) {
     zproc_set_stderr (self, socket);
 };

--- a/bindings/qml/src/QmlZproc.h
+++ b/bindings/qml/src/QmlZproc.h
@@ -45,17 +45,17 @@ public slots:
 
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The writable one is then accessbile via zproc_stdin method.
+    //  sockets.  The writable one is then accessible via zproc_stdin method.
     void setStdin (void *socket);
 
     //  Connects process stdout with a writable ('@', bind) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The readable one is then accessbile via zproc_stdout method.
+    //  sockets.  The readable one is then accessible via zproc_stdout method.
     void setStdout (void *socket);
 
     //  Connects process stderr with a writable ('@', bind) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The readable one is then accessbile via zproc_stderr method.
+    //  sockets.  The readable one is then accessible via zproc_stderr method.
     void setStderr (void *socket);
 
     //  Return subprocess stdin writable socket. NULL for

--- a/bindings/qt/src/qzproc.cpp
+++ b/bindings/qt/src/qzproc.cpp
@@ -60,7 +60,7 @@ void QZproc::setEnv (QZhash *arguments)
 ///
 //  Connects process stdin with a readable ('>', connect) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The writable one is then accessbile via zproc_stdin method.
+//  sockets.  The writable one is then accessible via zproc_stdin method.
 void QZproc::setStdin (void *socket)
 {
     zproc_set_stdin (self, socket);
@@ -70,7 +70,7 @@ void QZproc::setStdin (void *socket)
 ///
 //  Connects process stdout with a writable ('@', bind) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The readable one is then accessbile via zproc_stdout method.
+//  sockets.  The readable one is then accessible via zproc_stdout method.
 void QZproc::setStdout (void *socket)
 {
     zproc_set_stdout (self, socket);
@@ -80,7 +80,7 @@ void QZproc::setStdout (void *socket)
 ///
 //  Connects process stderr with a writable ('@', bind) zeromq socket. If
 //  socket argument is NULL, zproc creates own managed pair of inproc
-//  sockets.  The readable one is then accessbile via zproc_stderr method.
+//  sockets.  The readable one is then accessible via zproc_stderr method.
 void QZproc::setStderr (void *socket)
 {
     zproc_set_stderr (self, socket);

--- a/bindings/qt/src/qzproc.h
+++ b/bindings/qt/src/qzproc.h
@@ -38,17 +38,17 @@ public:
 
     //  Connects process stdin with a readable ('>', connect) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The writable one is then accessbile via zproc_stdin method.
+    //  sockets.  The writable one is then accessible via zproc_stdin method.
     void setStdin (void *socket);
 
     //  Connects process stdout with a writable ('@', bind) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The readable one is then accessbile via zproc_stdout method.
+    //  sockets.  The readable one is then accessible via zproc_stdout method.
     void setStdout (void *socket);
 
     //  Connects process stderr with a writable ('@', bind) zeromq socket. If
     //  socket argument is NULL, zproc creates own managed pair of inproc
-    //  sockets.  The readable one is then accessbile via zproc_stderr method.
+    //  sockets.  The readable one is then accessible via zproc_stderr method.
     void setStderr (void *socket);
 
     //  Return subprocess stdin writable socket. NULL for

--- a/bindings/ruby/lib/czmq/ffi/zproc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zproc.rb
@@ -145,7 +145,7 @@ module CZMQ
 
       # Connects process stdin with a readable ('>', connect) zeromq socket. If
       # socket argument is NULL, zproc creates own managed pair of inproc
-      # sockets.  The writable one is then accessbile via zproc_stdin method.
+      # sockets.  The writable one is then accessible via zproc_stdin method.
       #
       # @param socket [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -158,7 +158,7 @@ module CZMQ
 
       # Connects process stdout with a writable ('@', bind) zeromq socket. If
       # socket argument is NULL, zproc creates own managed pair of inproc
-      # sockets.  The readable one is then accessbile via zproc_stdout method.
+      # sockets.  The readable one is then accessible via zproc_stdout method.
       #
       # @param socket [::FFI::Pointer, #to_ptr]
       # @return [void]
@@ -171,7 +171,7 @@ module CZMQ
 
       # Connects process stderr with a writable ('@', bind) zeromq socket. If
       # socket argument is NULL, zproc creates own managed pair of inproc
-      # sockets.  The readable one is then accessbile via zproc_stderr method.
+      # sockets.  The readable one is then accessible via zproc_stderr method.
       #
       # @param socket [::FFI::Pointer, #to_ptr]
       # @return [void]


### PR DESCRIPTION
Solution: Run GSL on the project.xml

These changes are potentially superfluous, but since I am running `tstgenbld.sh`, I might as well update most projects to the latest versions while learning zproject.

There were two misspellings that was fixed on czmq that came from zproject generation (and thus regenerating them would bring back the misspellings) via https://github.com/zeromq/czmq/pull/2273. I fixed the one related to the API and I ommitted the one that came from zproject itself, as I will make a pull request to zproject to fix it.