### PR TITLE
zloop: ignore EINTR from poll if nonstop is enabled

### DIFF
--- a/src/zsock.c
+++ b/src/zsock.c
@@ -942,7 +942,7 @@ zsock_vsend (void *self, const char *picture, va_list argptr)
             zframe_t *frame = zlistx_pack (list);
             zmsg_append (msg, &frame);
         }
-#endif	
+#endif
         else
         if (*picture == 'm') {
             zframe_t *frame;
@@ -1171,7 +1171,7 @@ zsock_vrecv (void *self, const char *picture, va_list argptr)
             }
             zframe_destroy (&frame);
         }
-#ifdef CZMQ_BUILD_DRAFT_API	
+#ifdef CZMQ_BUILD_DRAFT_API
         else
         if (*picture == 'l') {
             zframe_t *frame = zmsg_pop (msg);
@@ -2205,7 +2205,7 @@ zsock_test (bool verbose)
 #ifdef ZMQ_STREAM
     zsock_t *streamrecv = zsock_new(ZMQ_STREAM);
     assert (streamrecv);
-    port = zsock_bind(streamrecv, "tcp://*:*");
+    port = zsock_bind(streamrecv, "tcp://127.0.0.1:*");
     assert(port > 0);
 
     zsock_t *streamsender = zsock_new(ZMQ_STREAM);
@@ -2398,7 +2398,7 @@ zsock_test (bool verbose)
     char* message;
     message = zstr_recv (gather);
     assert (streq(message, "HELLO"));
-    zstr_free (&message);    
+    zstr_free (&message);
 
     zsock_destroy (&gather);
     zsock_destroy (&scatter);


### PR DESCRIPTION
If SIGINT signal arrives while poll is blocking, regardless of attached signal handler it will cause the poll to return with errno EINTR. Currently, this causes zloop to return from the event loop. For nonstop mode to work as intended, we have to ignore EINTR in this case.

Added test cases that verify the functionality when catching an actual SIGINT signal with and without nonstop mode. Tested in Linux and Windows.

Fixes #2284