### PR TITLE
zloop: ensure zsys_init() when creating zloop

### DIFF
--- a/src/zloop.c
+++ b/src/zloop.c
@@ -313,6 +313,8 @@ s_tickless (zloop_t *self)
 zloop_t *
 zloop_new (void)
 {
+    zsys_init ();
+
     zloop_t *self = (zloop_t *) zmalloc (sizeof (zloop_t));
     assert (self);
 


### PR DESCRIPTION
If no sockets or actors are used in zloop, `zsys_init()` does not get run and zsys interrupt handler does not get initialized. This means that interrupts will not work correctly in zloop if, for example, only timers are used. `zsys_init()` is safe to call multiple times, so we ensure that it's called when new zloop instance is created.