### PR TITLE
Create an OSC message from a string

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4647,6 +4647,11 @@ zosc_t *
 zosc_t *
     zosc_frommem (char *data, size_t size);
 
+// Create a new zosc message from a string. This the same syntax as
+// zosc_create but written as a single line string.
+zosc_t *
+    zosc_fromstring (const char *oscstring);
+
 // Create a new zosc message from the given format and arguments.
 // The format type tags are as follows:
 //   i - 32bit integer
@@ -4749,6 +4754,10 @@ zframe_t *
 // Transform a zframe into a zosc.
 zosc_t *
     zosc_unpack (zframe_t *frame);
+
+// Return a string describing the the OSC message. The returned string must be freed by the caller.
+char *
+    zosc_dump (zosc_t *self);
 
 // Dump OSC message to stdout, for debugging and tracing.
 void

--- a/api/zosc.api
+++ b/api/zosc.api
@@ -49,6 +49,12 @@
         <argument name = "size" type = "size" />
     </constructor>
 
+    <constructor name = "fromstring" state = "draft">
+        Create a new zosc message from a string. This the same syntax as
+        zosc_create but written as a single line string.
+        <argument name = "oscstring" type = "string" />
+    </constructor>
+
     <constructor name = "create">
         Create a new zosc message from the given format and arguments.
         The format type tags are as follows:
@@ -166,6 +172,11 @@
         Transform a zframe into a zosc.
         <argument name = "frame" type = "zframe" mutable = "1" />
         <return type = "zosc" fresh = "1" />
+    </method>
+
+    <method name = "dump">
+        Return a string describing the the OSC message. The returned string must be freed by the caller.
+        <return type = "string" fresh="1" />
     </method>
 
     <method name = "print">

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_Zosc.c
@@ -38,6 +38,15 @@ Java_org_zeromq_czmq_Zosc__1_1frommem (JNIEnv *env, jclass c, jbyteArray data, j
 }
 
 JNIEXPORT jlong JNICALL
+Java_org_zeromq_czmq_Zosc__1_1fromstring (JNIEnv *env, jclass c, jstring oscstring)
+{
+    char *oscstring_ = (char *) (*env)->GetStringUTFChars (env, oscstring, NULL);
+    jlong fromstring_ = (jlong) (intptr_t) zosc_fromstring (oscstring_);
+    (*env)->ReleaseStringUTFChars (env, oscstring, oscstring_);
+    return fromstring_;
+}
+
+JNIEXPORT jlong JNICALL
 Java_org_zeromq_czmq_Zosc__1_1create (JNIEnv *env, jclass c, jstring address, jstring format)
 {
     char *address_ = (char *) (*env)->GetStringUTFChars (env, address, NULL);
@@ -131,6 +140,15 @@ Java_org_zeromq_czmq_Zosc__1_1unpack (JNIEnv *env, jclass c, jlong frame)
 {
     jlong unpack_ = (jlong) (intptr_t) zosc_unpack ((zframe_t *) (intptr_t) frame);
     return unpack_;
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_zeromq_czmq_Zosc__1_1dump (JNIEnv *env, jclass c, jlong self)
+{
+    char *dump_ = (char *) zosc_dump ((zosc_t *) (intptr_t) self);
+    jstring return_string_ = (*env)->NewStringUTF (env, dump_);
+    zstr_free (&dump_);
+    return return_string_;
 }
 
 JNIEXPORT void JNICALL

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/Zosc.java
@@ -54,6 +54,14 @@ public class Zosc implements AutoCloseable {
         return new Zosc (__frommem (data, size));
     }
     /*
+    Create a new zosc message from a string. This the same syntax as
+    zosc_create but written as a single line string.
+    */
+    native static long __fromstring (String oscstring);
+    public static Zosc fromstring (String oscstring) {
+        return new Zosc (__fromstring (oscstring));
+    }
+    /*
     Create a new zosc message from the given format and arguments.
     The format type tags are as follows:
       i - 32bit integer
@@ -193,6 +201,13 @@ public class Zosc implements AutoCloseable {
     native static long __unpack (long frame);
     public static Zosc unpack (Zframe frame) {
         return new Zosc (__unpack (frame.self));
+    }
+    /*
+    Return a string describing the the OSC message. The returned string must be freed by the caller.
+    */
+    native static String __dump (long self);
+    public String dump () {
+        return __dump (self);
     }
     /*
     Dump OSC message to stdout, for debugging and tracing.

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4642,6 +4642,11 @@ zosc_t *
 zosc_t *
     zosc_frommem (char *data, size_t size);
 
+// Create a new zosc message from a string. This the same syntax as
+// zosc_create but written as a single line string.
+zosc_t *
+    zosc_fromstring (const char *oscstring);
+
 // Create a new zosc message from the given format and arguments.
 // The format type tags are as follows:
 //   i - 32bit integer
@@ -4744,6 +4749,10 @@ zframe_t *
 // Transform a zframe into a zosc.
 zosc_t *
     zosc_unpack (zframe_t *frame);
+
+// Return a string describing the the OSC message. The returned string must be freed by the caller.
+char *
+    zosc_dump (zosc_t *self);
 
 // Dump OSC message to stdout, for debugging and tracing.
 void

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -5209,6 +5209,12 @@ zosc my_zosc.unpack (Zframe)
 Transform a zframe into a zosc.
 
 ```
+string my_zosc.dump ()
+```
+
+Return a string describing the the OSC message. The returned string must be freed by the caller.
+
+```
 nothing my_zosc.print ()
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -9679,6 +9679,7 @@ NAN_MODULE_INIT (Zosc::Init) {
     Nan::SetPrototypeMethod (tpl, "pack", _pack);
     Nan::SetPrototypeMethod (tpl, "packx", _packx);
     Nan::SetPrototypeMethod (tpl, "unpack", _unpack);
+    Nan::SetPrototypeMethod (tpl, "dump", _dump);
     Nan::SetPrototypeMethod (tpl, "print", _print);
     Nan::SetPrototypeMethod (tpl, "popInt32", _pop_int32);
     Nan::SetPrototypeMethod (tpl, "popInt64", _pop_int64);
@@ -9838,6 +9839,12 @@ NAN_METHOD (Zosc::_unpack) {
     //      info.GetReturnValue ().Set (info.This ());
         info.GetReturnValue ().Set (Nan::New<Boolean>(true));
     }
+}
+
+NAN_METHOD (Zosc::_dump) {
+    Zosc *zosc = Nan::ObjectWrap::Unwrap <Zosc> (info.Holder ());
+    char *result = (char *) zosc_dump (zosc->self);
+    info.GetReturnValue ().Set (Nan::New (result).ToLocalChecked ());
 }
 
 NAN_METHOD (Zosc::_print) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -1130,6 +1130,7 @@ class Zosc: public Nan::ObjectWrap {
     static NAN_METHOD (_pack);
     static NAN_METHOD (_packx);
     static NAN_METHOD (_unpack);
+    static NAN_METHOD (_dump);
     static NAN_METHOD (_print);
     static NAN_METHOD (_pop_int32);
     static NAN_METHOD (_pop_int64);

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -9559,6 +9559,8 @@ lib.zosc_fromframe.restype = zosc_p
 lib.zosc_fromframe.argtypes = [zframe_p]
 lib.zosc_frommem.restype = zosc_p
 lib.zosc_frommem.argtypes = [c_void_p, c_size_t]
+lib.zosc_fromstring.restype = zosc_p
+lib.zosc_fromstring.argtypes = [c_char_p]
 lib.zosc_create.restype = zosc_p
 lib.zosc_create.argtypes = [c_char_p, c_char_p]
 lib.zosc_size.restype = c_size_t
@@ -9581,6 +9583,8 @@ lib.zosc_packx.restype = zframe_p
 lib.zosc_packx.argtypes = [POINTER(zosc_p)]
 lib.zosc_unpack.restype = zosc_p
 lib.zosc_unpack.argtypes = [zframe_p]
+lib.zosc_dump.restype = POINTER(c_char)
+lib.zosc_dump.argtypes = [zosc_p]
 lib.zosc_print.restype = None
 lib.zosc_print.argtypes = [zosc_p]
 lib.zosc_is.restype = c_bool
@@ -9694,6 +9698,14 @@ the zframe.
 and calling free on the data after construction.
         """
         return Zosc(lib.zosc_frommem(data, size), True)
+
+    @staticmethod
+    def fromstring(oscstring):
+        """
+        Create a new zosc message from a string. This the same syntax as
+zosc_create but written as a single line string.
+        """
+        return Zosc(lib.zosc_fromstring(oscstring), True)
 
     @staticmethod
     def create(address, format, *args):
@@ -9818,6 +9830,12 @@ Take ownership of the chunk.
         Transform a zframe into a zosc.
         """
         return Zosc(lib.zosc_unpack(frame), True)
+
+    def dump(self):
+        """
+        Return a string describing the the OSC message. The returned string must be freed by the caller.
+        """
+        return return_fresh_string(lib.zosc_dump(self._as_parameter_))
 
     def print(self):
         """

--- a/bindings/python_cffi/czmq_cffi/Zosc.py
+++ b/bindings/python_cffi/czmq_cffi/Zosc.py
@@ -62,6 +62,14 @@ See the class's test method for more examples how to use the class.
         return utils.lib.zosc_frommem(data, size)
 
     @staticmethod
+    def fromstring(oscstring):
+        """
+        Create a new zosc message from a string. This the same syntax as
+        zosc_create but written as a single line string.
+        """
+        return utils.lib.zosc_fromstring(utils.to_bytes(oscstring))
+
+    @staticmethod
     def create(address, format, *format_args):
         """
         Create a new zosc message from the given format and arguments.
@@ -184,6 +192,12 @@ See the class's test method for more examples how to use the class.
         Transform a zframe into a zosc.
         """
         return utils.lib.zosc_unpack(frame._p)
+
+    def dump(self):
+        """
+        Return a string describing the the OSC message. The returned string must be freed by the caller.
+        """
+        return utils.lib.zosc_dump(self._p)
 
     def print_py(self):
         """

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4649,6 +4649,11 @@ zosc_t *
 zosc_t *
     zosc_frommem (char *data, size_t size);
 
+// Create a new zosc message from a string. This the same syntax as
+// zosc_create but written as a single line string.
+zosc_t *
+    zosc_fromstring (const char *oscstring);
+
 // Create a new zosc message from the given format and arguments.
 // The format type tags are as follows:
 //   i - 32bit integer
@@ -4751,6 +4756,10 @@ zframe_t *
 // Transform a zframe into a zosc.
 zosc_t *
     zosc_unpack (zframe_t *frame);
+
+// Return a string describing the the OSC message. The returned string must be freed by the caller.
+char *
+    zosc_dump (zosc_t *self);
 
 // Dump OSC message to stdout, for debugging and tracing.
 void

--- a/bindings/qml/src/QmlZosc.cpp
+++ b/bindings/qml/src/QmlZosc.cpp
@@ -100,6 +100,15 @@ QmlZframe *QmlZosc::pack () {
 };
 
 ///
+//  Return a string describing the the OSC message. The returned string must be freed by the caller.
+QString QmlZosc::dump () {
+    char *retStr_ = zosc_dump (self);
+    QString retQStr_ = QString (retStr_);
+    free (retStr_);
+    return retQStr_;
+};
+
+///
 //  Dump OSC message to stdout, for debugging and tracing.
 void QmlZosc::print () {
     zosc_print (self);
@@ -251,6 +260,15 @@ QmlZosc *QmlZoscAttached::fromframe (QmlZframe *frame) {
 QmlZosc *QmlZoscAttached::frommem (char *data, size_t size) {
     QmlZosc *qmlSelf = new QmlZosc ();
     qmlSelf->self = zosc_frommem (data, size);
+    return qmlSelf;
+};
+
+///
+//  Create a new zosc message from a string. This the same syntax as
+//  zosc_create but written as a single line string.
+QmlZosc *QmlZoscAttached::fromstring (const QString &oscstring) {
+    QmlZosc *qmlSelf = new QmlZosc ();
+    qmlSelf->self = zosc_fromstring (oscstring.toUtf8().data());
     return qmlSelf;
 };
 

--- a/bindings/qml/src/QmlZosc.h
+++ b/bindings/qml/src/QmlZosc.h
@@ -91,6 +91,9 @@ public slots:
     //  Transform zosc into a zframe that can be sent in a message.
     QmlZframe *pack ();
 
+    //  Return a string describing the the OSC message. The returned string must be freed by the caller.
+    QString dump ();
+
     //  Dump OSC message to stdout, for debugging and tracing.
     void print ();
 
@@ -184,6 +187,10 @@ public slots:
     //  Create a new zosc message from memory. Take ownership of the memory
     //  and calling free on the data after construction.
     QmlZosc *frommem (char *data, size_t size);
+
+    //  Create a new zosc message from a string. This the same syntax as
+    //  zosc_create but written as a single line string.
+    QmlZosc *fromstring (const QString &oscstring);
 
     //  Create a new zosc message from the given format and arguments.
     //  The format type tags are as follows:

--- a/bindings/qt/src/qzosc.cpp
+++ b/bindings/qt/src/qzosc.cpp
@@ -39,6 +39,14 @@ QZosc* QZosc::frommem (char *data, size_t size, QObject *qObjParent)
 }
 
 ///
+//  Create a new zosc message from a string. This the same syntax as
+//  zosc_create but written as a single line string.
+QZosc* QZosc::fromstring (const QString &oscstring, QObject *qObjParent)
+{
+    return new QZosc (zosc_fromstring (oscstring.toUtf8().data()), qObjParent);
+}
+
+///
 //  Destroy an OSC message
 QZosc::~QZosc ()
 {
@@ -123,6 +131,16 @@ QZframe * QZosc::packx ()
 QZosc * QZosc::unpack (QZframe *frame)
 {
     QZosc *rv = new QZosc (zosc_unpack (frame->self));
+    return rv;
+}
+
+///
+//  Return a string describing the the OSC message. The returned string must be freed by the caller.
+QString QZosc::dump ()
+{
+    char *retStr_ = zosc_dump (self);
+    QString rv = QString (retStr_);
+    zstr_free (&retStr_);
     return rv;
 }
 

--- a/bindings/qt/src/qzosc.h
+++ b/bindings/qt/src/qzosc.h
@@ -28,6 +28,10 @@ public:
     //  and calling free on the data after construction.
     static QZosc* frommem (char *data, size_t size, QObject *qObjParent = 0);
 
+    //  Create a new zosc message from a string. This the same syntax as
+    //  zosc_create but written as a single line string.
+    static QZosc* fromstring (const QString &oscstring, QObject *qObjParent = 0);
+
     //  Destroy an OSC message
     ~QZosc ();
 
@@ -71,6 +75,9 @@ public:
 
     //  Transform a zframe into a zosc.
     static QZosc * unpack (QZframe *frame);
+
+    //  Return a string describing the the OSC message. The returned string must be freed by the caller.
+    QString dump ();
 
     //  Dump OSC message to stdout, for debugging and tracing.
     void print ();

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -989,6 +989,7 @@ module CZMQ
       attach_function :zosc_new, [:string], :pointer, **opts
       attach_function :zosc_fromframe, [:pointer], :pointer, **opts
       attach_function :zosc_frommem, [:pointer, :size_t], :pointer, **opts
+      attach_function :zosc_fromstring, [:string], :pointer, **opts
       attach_function :zosc_create, [:string, :string, :varargs], :pointer, **opts
       attach_function :zosc_destroy, [:pointer], :void, **opts
       attach_function :zosc_size, [:pointer], :size_t, **opts
@@ -1001,6 +1002,7 @@ module CZMQ
       attach_function :zosc_pack, [:pointer], :pointer, **opts
       attach_function :zosc_packx, [:pointer], :pointer, **opts
       attach_function :zosc_unpack, [:pointer], :pointer, **opts
+      attach_function :zosc_dump, [:pointer], :pointer, **opts
       attach_function :zosc_print, [:pointer], :void, **opts
       attach_function :zosc_is, [:pointer], :bool, **opts
       attach_function :zosc_first, [:pointer, :pointer], :pointer, **opts

--- a/bindings/ruby/lib/czmq/ffi/zosc.rb
+++ b/bindings/ruby/lib/czmq/ffi/zosc.rb
@@ -124,6 +124,15 @@ module CZMQ
         __new ptr
       end
 
+      # Create a new zosc message from a string. This the same syntax as
+      # zosc_create but written as a single line string.
+      # @param oscstring [String, #to_s, nil]
+      # @return [CZMQ::Zosc]
+      def self.fromstring(oscstring)
+        ptr = ::CZMQ::FFI.zosc_fromstring(oscstring)
+        __new ptr
+      end
+
       # Create a new zosc message from the given format and arguments.
       # The format type tags are as follows:
       #   i - 32bit integer
@@ -304,6 +313,17 @@ module CZMQ
         frame = frame.__ptr if frame
         result = ::CZMQ::FFI.zosc_unpack(frame)
         result = Zosc.__new result, true
+        result
+      end
+
+      # Return a string describing the the OSC message. The returned string must be freed by the caller.
+      #
+      # @return [::FFI::AutoPointer]
+      def dump()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zosc_dump(self_p)
+        result = ::FFI::AutoPointer.new(result, LibC.method(:free))
         result
       end
 

--- a/include/zosc.h
+++ b/include/zosc.h
@@ -43,6 +43,12 @@ CZMQ_EXPORT zosc_t *
     zosc_frommem (char *data, size_t size);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Create a new zosc message from a string. This the same syntax as
+//  zosc_create but written as a single line string.
+CZMQ_EXPORT zosc_t *
+    zosc_fromstring (const char *oscstring);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Create a new zosc message from the given format and arguments.
 //  The format type tags are as follows:
 //    i - 32bit integer
@@ -160,6 +166,12 @@ CZMQ_EXPORT zframe_t *
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT zosc_t *
     zosc_unpack (zframe_t *frame);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Return a string describing the the OSC message.
+//  Caller owns return value and must destroy it when done.
+CZMQ_EXPORT char *
+    zosc_dump (zosc_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Dump OSC message to stdout, for debugging and tracing.

--- a/include/zosc.h
+++ b/include/zosc.h
@@ -168,7 +168,7 @@ CZMQ_EXPORT zosc_t *
     zosc_unpack (zframe_t *frame);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Return a string describing the the OSC message.
+//  Return a string describing the the OSC message. The returned string must be freed by the caller.
 //  Caller owns return value and must destroy it when done.
 CZMQ_EXPORT char *
     zosc_dump (zosc_t *self);


### PR DESCRIPTION
Problem: it's not easy to create a message simply by describing it like how a message can be printed as a string
Solution: Add zosc_fromstring method enabling the creation of message from a string

Also added test code.

A message can be constructed as follows:
```c
zosc_t* msg = zosc_fromstring("/stringmsg ihfdscF 32 64 1.100000 3.140000 hello q");
```
