### PR TITLE
Problem: zhttp_client does not support authentication

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -4539,6 +4539,14 @@ void
 void
     zhttp_request_reset_content (zhttp_request_t *self);
 
+// Set the request username
+void
+    zhttp_request_set_username (zhttp_request_t *self, const char *username);
+
+// Set the request password
+void
+    zhttp_request_set_password (zhttp_request_t *self, const char *password);
+
 // Match the path of the request.
 // Support wildcards with '%s' symbol inside the match string.
 // Matching wildcards until the next '/', '?' or '\0'.

--- a/api/zhttp_request.api
+++ b/api/zhttp_request.api
@@ -112,6 +112,16 @@
         Set the content to NULL
     </method>
 
+    <method name = "set username">
+        Set the request username
+        <argument name = "username" type = "string" />
+    </method>
+
+    <method name = "set password">
+        Set the request password
+        <argument name = "password" type = "string" />
+    </method>
+
     <method name = "match">
         Match the path of the request.
         Support wildcards with '%s' symbol inside the match string.

--- a/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_ZhttpRequest.c
+++ b/bindings/jni/czmq-jni/src/main/c/org_zeromq_czmq_ZhttpRequest.c
@@ -132,6 +132,22 @@ Java_org_zeromq_czmq_ZhttpRequest__1_1resetContent (JNIEnv *env, jclass c, jlong
     zhttp_request_reset_content ((zhttp_request_t *) (intptr_t) self);
 }
 
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_ZhttpRequest__1_1setUsername (JNIEnv *env, jclass c, jlong self, jstring username)
+{
+    char *username_ = (char *) (*env)->GetStringUTFChars (env, username, NULL);
+    zhttp_request_set_username ((zhttp_request_t *) (intptr_t) self, username_);
+    (*env)->ReleaseStringUTFChars (env, username, username_);
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_czmq_ZhttpRequest__1_1setPassword (JNIEnv *env, jclass c, jlong self, jstring password)
+{
+    char *password_ = (char *) (*env)->GetStringUTFChars (env, password, NULL);
+    zhttp_request_set_password ((zhttp_request_t *) (intptr_t) self, password_);
+    (*env)->ReleaseStringUTFChars (env, password, password_);
+}
+
 JNIEXPORT jboolean JNICALL
 Java_org_zeromq_czmq_ZhttpRequest__1_1match (JNIEnv *env, jclass c, jlong self, jstring method, jstring path)
 {

--- a/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpRequest.java
+++ b/bindings/jni/czmq-jni/src/main/java/org/zeromq/czmq/ZhttpRequest.java
@@ -154,6 +154,20 @@ public class ZhttpRequest implements AutoCloseable {
         __resetContent (self);
     }
     /*
+    Set the request username
+    */
+    native static void __setUsername (long self, String username);
+    public void setUsername (String username) {
+        __setUsername (self, username);
+    }
+    /*
+    Set the request password
+    */
+    native static void __setPassword (long self, String password);
+    public void setPassword (String password) {
+        __setPassword (self, password);
+    }
+    /*
     Match the path of the request.
     Support wildcards with '%s' symbol inside the match string.
     Matching wildcards until the next '/', '?' or '\0'.

--- a/bindings/lua_ffi/czmq_ffi.lua
+++ b/bindings/lua_ffi/czmq_ffi.lua
@@ -4534,6 +4534,14 @@ void
 void
     zhttp_request_reset_content (zhttp_request_t *self);
 
+// Set the request username
+void
+    zhttp_request_set_username (zhttp_request_t *self, const char *username);
+
+// Set the request password
+void
+    zhttp_request_set_password (zhttp_request_t *self, const char *password);
+
 // Match the path of the request.
 // Support wildcards with '%s' symbol inside the match string.
 // Matching wildcards until the next '/', '?' or '\0'.

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -4953,6 +4953,18 @@ nothing my_zhttp_request.resetContent ()
 Set the content to NULL
 
 ```
+nothing my_zhttp_request.setUsername (String)
+```
+
+Set the request username
+
+```
+nothing my_zhttp_request.setPassword (String)
+```
+
+Set the request password
+
+```
 boolean my_zhttp_request.match (String, String)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -9249,6 +9249,8 @@ NAN_MODULE_INIT (ZhttpRequest::Init) {
     Nan::SetPrototypeMethod (tpl, "setContent", _set_content);
     Nan::SetPrototypeMethod (tpl, "setContentConst", _set_content_const);
     Nan::SetPrototypeMethod (tpl, "resetContent", _reset_content);
+    Nan::SetPrototypeMethod (tpl, "setUsername", _set_username);
+    Nan::SetPrototypeMethod (tpl, "setPassword", _set_password);
     Nan::SetPrototypeMethod (tpl, "match", _match);
     Nan::SetPrototypeMethod (tpl, "test", _test);
 
@@ -9414,6 +9416,36 @@ NAN_METHOD (ZhttpRequest::_set_content_const) {
 NAN_METHOD (ZhttpRequest::_reset_content) {
     ZhttpRequest *zhttp_request = Nan::ObjectWrap::Unwrap <ZhttpRequest> (info.Holder ());
     zhttp_request_reset_content (zhttp_request->self);
+}
+
+NAN_METHOD (ZhttpRequest::_set_username) {
+    ZhttpRequest *zhttp_request = Nan::ObjectWrap::Unwrap <ZhttpRequest> (info.Holder ());
+    char *username;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `username`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`username` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String username_utf8 (info [0].As<String>());
+    username = *username_utf8;
+         //} //bjornw end
+    zhttp_request_set_username (zhttp_request->self, (const char *)username);
+}
+
+NAN_METHOD (ZhttpRequest::_set_password) {
+    ZhttpRequest *zhttp_request = Nan::ObjectWrap::Unwrap <ZhttpRequest> (info.Holder ());
+    char *password;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `password`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`password` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String password_utf8 (info [0].As<String>());
+    password = *password_utf8;
+         //} //bjornw end
+    zhttp_request_set_password (zhttp_request->self, (const char *)password);
 }
 
 NAN_METHOD (ZhttpRequest::_match) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -1076,6 +1076,8 @@ class ZhttpRequest: public Nan::ObjectWrap {
     static NAN_METHOD (_set_content);
     static NAN_METHOD (_set_content_const);
     static NAN_METHOD (_reset_content);
+    static NAN_METHOD (_set_username);
+    static NAN_METHOD (_set_password);
     static NAN_METHOD (_match);
     static NAN_METHOD (_test);
 };

--- a/bindings/python/czmq/_czmq_ctypes.py
+++ b/bindings/python/czmq/_czmq_ctypes.py
@@ -9190,6 +9190,10 @@ lib.zhttp_request_set_content_const.restype = None
 lib.zhttp_request_set_content_const.argtypes = [zhttp_request_p, c_char_p]
 lib.zhttp_request_reset_content.restype = None
 lib.zhttp_request_reset_content.argtypes = [zhttp_request_p]
+lib.zhttp_request_set_username.restype = None
+lib.zhttp_request_set_username.argtypes = [zhttp_request_p, c_char_p]
+lib.zhttp_request_set_password.restype = None
+lib.zhttp_request_set_password.argtypes = [zhttp_request_p, c_char_p]
 lib.zhttp_request_match.restype = c_bool
 lib.zhttp_request_match.argtypes = [zhttp_request_p, c_char_p, c_char_p]
 lib.zhttp_request_test.restype = None
@@ -9345,6 +9349,18 @@ The content is assumed to be constant-memory and will therefore not be copied or
         Set the content to NULL
         """
         return lib.zhttp_request_reset_content(self._as_parameter_)
+
+    def set_username(self, username):
+        """
+        Set the request username
+        """
+        return lib.zhttp_request_set_username(self._as_parameter_, username)
+
+    def set_password(self, password):
+        """
+        Set the request password
+        """
+        return lib.zhttp_request_set_password(self._as_parameter_, password)
 
     def match(self, method, path, *args):
         """

--- a/bindings/python_cffi/czmq_cffi/ZhttpRequest.py
+++ b/bindings/python_cffi/czmq_cffi/ZhttpRequest.py
@@ -127,6 +127,18 @@ Headers and Content is being destroyed after every send call.
         """
         utils.lib.zhttp_request_reset_content(self._p)
 
+    def set_username(self, username):
+        """
+        Set the request username
+        """
+        utils.lib.zhttp_request_set_username(self._p, utils.to_bytes(username))
+
+    def set_password(self, password):
+        """
+        Set the request password
+        """
+        utils.lib.zhttp_request_set_password(self._p, utils.to_bytes(password))
+
     def match(self, method, path, *path_args):
         """
         Match the path of the request.

--- a/bindings/python_cffi/czmq_cffi/cdefs.py
+++ b/bindings/python_cffi/czmq_cffi/cdefs.py
@@ -4541,6 +4541,14 @@ void
 void
     zhttp_request_reset_content (zhttp_request_t *self);
 
+// Set the request username
+void
+    zhttp_request_set_username (zhttp_request_t *self, const char *username);
+
+// Set the request password
+void
+    zhttp_request_set_password (zhttp_request_t *self, const char *password);
+
 // Match the path of the request.
 // Support wildcards with '%s' symbol inside the match string.
 // Matching wildcards until the next '/', '?' or '\0'.

--- a/bindings/qml/src/QmlZhttpRequest.cpp
+++ b/bindings/qml/src/QmlZhttpRequest.cpp
@@ -115,6 +115,18 @@ void QmlZhttpRequest::resetContent () {
 };
 
 ///
+//  Set the request username
+void QmlZhttpRequest::setUsername (const QString &username) {
+    zhttp_request_set_username (self, username.toUtf8().data());
+};
+
+///
+//  Set the request password
+void QmlZhttpRequest::setPassword (const QString &password) {
+    zhttp_request_set_password (self, password.toUtf8().data());
+};
+
+///
 //  Match the path of the request.
 //  Support wildcards with '%s' symbol inside the match string.
 //  Matching wildcards until the next '/', '?' or '\0'.

--- a/bindings/qml/src/QmlZhttpRequest.h
+++ b/bindings/qml/src/QmlZhttpRequest.h
@@ -84,6 +84,12 @@ public slots:
     //  Set the content to NULL
     void resetContent ();
 
+    //  Set the request username
+    void setUsername (const QString &username);
+
+    //  Set the request password
+    void setPassword (const QString &password);
+
     //  Match the path of the request.
     //  Support wildcards with '%s' symbol inside the match string.
     //  Matching wildcards until the next '/', '?' or '\0'.

--- a/bindings/qt/src/qzhttprequest.cpp
+++ b/bindings/qt/src/qzhttprequest.cpp
@@ -153,6 +153,22 @@ void QZhttpRequest::resetContent ()
 }
 
 ///
+//  Set the request username
+void QZhttpRequest::setUsername (const QString &username)
+{
+    zhttp_request_set_username (self, username.toUtf8().data());
+
+}
+
+///
+//  Set the request password
+void QZhttpRequest::setPassword (const QString &password)
+{
+    zhttp_request_set_password (self, password.toUtf8().data());
+
+}
+
+///
 //  Self test of this class.
 void QZhttpRequest::test (bool verbose)
 {

--- a/bindings/qt/src/qzhttprequest.h
+++ b/bindings/qt/src/qzhttprequest.h
@@ -74,6 +74,12 @@ public:
     //  Set the content to NULL
     void resetContent ();
 
+    //  Set the request username
+    void setUsername (const QString &username);
+
+    //  Set the request password
+    void setPassword (const QString &password);
+
     //  Self test of this class.
     static void test (bool verbose);
 

--- a/bindings/ruby/lib/czmq/ffi.rb
+++ b/bindings/ruby/lib/czmq/ffi.rb
@@ -962,6 +962,8 @@ module CZMQ
       attach_function :zhttp_request_set_content, [:pointer, :pointer], :void, **opts
       attach_function :zhttp_request_set_content_const, [:pointer, :string], :void, **opts
       attach_function :zhttp_request_reset_content, [:pointer], :void, **opts
+      attach_function :zhttp_request_set_username, [:pointer, :string], :void, **opts
+      attach_function :zhttp_request_set_password, [:pointer, :string], :void, **opts
       attach_function :zhttp_request_match, [:pointer, :string, :string, :varargs], :bool, **opts
       attach_function :zhttp_request_test, [:bool], :void, **opts
 

--- a/bindings/ruby/lib/czmq/ffi/zhttp_request.rb
+++ b/bindings/ruby/lib/czmq/ffi/zhttp_request.rb
@@ -269,6 +269,28 @@ module CZMQ
         result
       end
 
+      # Set the request username
+      #
+      # @param username [String, #to_s, nil]
+      # @return [void]
+      def set_username(username)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zhttp_request_set_username(self_p, username)
+        result
+      end
+
+      # Set the request password
+      #
+      # @param password [String, #to_s, nil]
+      # @return [void]
+      def set_password(password)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::CZMQ::FFI.zhttp_request_set_password(self_p, password)
+        result
+      end
+
       # Match the path of the request.
       # Support wildcards with '%s' symbol inside the match string.
       # Matching wildcards until the next '/', '?' or '\0'.

--- a/include/zhttp_request.h
+++ b/include/zhttp_request.h
@@ -125,6 +125,16 @@ CZMQ_EXPORT void
     zhttp_request_reset_content (zhttp_request_t *self);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Set the request username
+CZMQ_EXPORT void
+    zhttp_request_set_username (zhttp_request_t *self, const char *username);
+
+//  *** Draft method, for development use, may change without warning ***
+//  Set the request password
+CZMQ_EXPORT void
+    zhttp_request_set_password (zhttp_request_t *self, const char *password);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Match the path of the request.
 //  Support wildcards with '%s' symbol inside the match string.
 //  Matching wildcards until the next '/', '?' or '\0'.

--- a/src/zhttp_client.c
+++ b/src/zhttp_client.c
@@ -183,10 +183,12 @@ static void zhttp_client_actor (zsock_t *pipe, void *args) {
                 char *url;
                 zhash_t *headers;
                 byte free_content;
-                char* content;
+                char *content;
+                char *username;
+                char *password;
 
-                int rc = zsock_brecv (pipe, "4ppSp1p", &timeout, &arg, &arg2,
-                        &url, &headers, &free_content, &content);
+                int rc = zsock_brecv (pipe, "4ppSp1pss", &timeout, &arg, &arg2,
+                        &url, &headers, &free_content, &content, &username, &password);
                 assert (rc == 0);
 
                 struct curl_slist *curl_headers = zhash_to_slist (headers);
@@ -215,6 +217,12 @@ static void zhttp_client_actor (zsock_t *pipe, void *args) {
                 curl_easy_setopt (curl, CURLOPT_HEADERFUNCTION, header_callback);
                 curl_easy_setopt (curl, CURLOPT_HEADERDATA, request);
                 curl_easy_setopt (curl, CURLOPT_PRIVATE, request);
+
+                if (*username)
+                    curl_easy_setopt (curl, CURLOPT_USERNAME, username);
+
+                if (*password)
+                    curl_easy_setopt (curl, CURLOPT_PASSWORD, password);
 
                 if (streq (command, "POST") || streq (command, "PUT") ||
                       streq (command, "PATCH")) {


### PR DESCRIPTION
Solution: Add functions to zhttp_request to set username and password, and send these to the client.
