### PR TITLE
Problem: Android CI build fails due to LIBMICROHTTPD download failure

### DIFF
--- a/bindings/jni/ci_build.sh
+++ b/bindings/jni/ci_build.sh
@@ -50,7 +50,7 @@ android_init_dependency_root "libmicrohttpd"      # Check or initialize LIBMICRO
 # Fetch required dependencies:
 [ ! -d "${LIBZMQ_ROOT}" ]           && android_clone_library "LIBZMQ" "${LIBZMQ_ROOT}" "https://github.com/zeromq/libzmq.git" ""
 [ ! -d "${LIBCURL_ROOT}" ]          && android_clone_library "LIBCURL" "${LIBCURL_ROOT}" "https://github.com/curl/curl.git" ""
-[ ! -d "${LIBMICROHTTPD_ROOT}" ]    && android_download_library "LIBMICROHTTPD" "${LIBMICROHTTPD_ROOT}" "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
+[ ! -d "${LIBMICROHTTPD_ROOT}" ]    && android_download_library "LIBMICROHTTPD" "${LIBMICROHTTPD_ROOT}" "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
 
 android_download_ndk
 

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -83,7 +83,7 @@ android_init_dependency_root "libmicrohttpd"      # Check or initialize LIBMICRO
 # Fetch required dependencies:
 [ ! -d "${LIBZMQ_ROOT}" ]           && android_clone_library "LIBZMQ" "${LIBZMQ_ROOT}" "https://github.com/zeromq/libzmq.git" ""
 [ ! -d "${LIBCURL_ROOT}" ]          && android_clone_library "LIBCURL" "${LIBCURL_ROOT}" "https://github.com/curl/curl.git" ""
-[ ! -d "${LIBMICROHTTPD_ROOT}" ]    && android_download_library "LIBMICROHTTPD" "${LIBMICROHTTPD_ROOT}" "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
+[ ! -d "${LIBMICROHTTPD_ROOT}" ]    && android_download_library "LIBMICROHTTPD" "${LIBMICROHTTPD_ROOT}" "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
 
 case "$CI_TIME" in
     [Yy][Ee][Ss]|[Oo][Nn]|[Tt][Rr][Uu][Ee])

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -85,9 +85,9 @@ if ! ((command -v dpkg >/dev/null 2>&1 && dpkg -s libmicrohttpd-dev >/dev/null 2
 ; then
     BASE_PWD=${PWD}
     cd tmp-deps
-    wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
-    tar -xzf $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
-    cd $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz) || exit $?
+    wget http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
+    tar -xzf $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
+    cd $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz) || exit $?
     CCACHE_BASEDIR=${PWD}
     export CCACHE_BASEDIR
     if [ -e autogen.sh ]; then

--- a/builds/rpi/build.sh
+++ b/builds/rpi/build.sh
@@ -106,11 +106,11 @@ if [ ! $INCREMENTAL ]; then
     # Clone and build dependencies
     BASE_PWD=${PWD}
     cd tmp-deps
-    if [ ! -e $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz") ]; then
-        $CI_TIME wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
-        tar -xzf $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
+    if [ ! -e $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz") ]; then
+        $CI_TIME wget http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
+        tar -xzf $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
     fi
-    pushd $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz)
+    pushd $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz)
     (
         $CI_TIME ./configure "${CONFIG_OPTS[@]}"
         $CI_TIME make -j4

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -407,9 +407,9 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'libmicrohttpd' from tarball..." >&2
         cd ./tmp-deps
-        $CI_TIME wget http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
-        tar -xzf $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
-        cd $(basename "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz) || exit $?
+        $CI_TIME wget http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz
+        tar -xzf $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz")
+        cd $(basename "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz" .tar.gz) || exit $?
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR
         if [ -e autogen.sh ]; then

--- a/project.xml
+++ b/project.xml
@@ -19,7 +19,7 @@
     </use>
     <use project = "nss" optional = "1" implied = "1" />
     <use project = "libmicrohttpd"
-         tarball = "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
+         tarball = "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.44.tar.gz"
          implied = "1" optional = "1"  />
 
     <check_symbol_exists symbol = "AI_V4MAPPED" include = "netdb.h" />


### PR DESCRIPTION
See issue #2323 for traces and details.

Solution: Use any of its mirrors with the help of `ftpmirror.ftp.org`.

1st commit applied in `project.xml`.
2nd commit is the result of regenerate.
