### PR TITLE
Windows fixes for zsock_resolve and ztimerset selftest

### DIFF
--- a/src/ztimerset.c
+++ b/src/ztimerset.c
@@ -181,7 +181,7 @@ ztimerset_test (bool verbose)
     assert (!timer_invoked);
     int timeout = ztimerset_timeout (self);
     assert (timeout > 0);
-    zclock_sleep (timeout);
+    zclock_sleep (timeout + 20);
     rc = ztimerset_execute (self);
     assert (rc == 0);
     assert (timer_invoked);


### PR DESCRIPTION
Issue #2300 describes a randomly occuring crash in zpoller. I investigated this and indeed I have only seen it happen on Windows, but the reason for it could easily cause it to happen on other platforms too.

When `zsock_resolve()` tries to resolve the passed pointer type, it first checks first against `zactor` and `zsock`, which work fine because the tag is the first variable in those structs and small enough. But that's not necessarily the case with ZMQ socket object. And when a native `SOCKET` is passed to resolve function, the `zmq_getsockopt()` tries to check the tag by accessing memory that is outside the actual variable that contained the native socket number, which in turn causes (very often) an access violation on Windows.

The solution I came up with is to reorder the checks so that native socket is checked before the `zmq_getsockopt()`, which seemed to work. Any ideas if this could break some edge case?

The other commit is a small fix to `ztimerset` selftest which also failed every now and then on Windows. This is due to Windows `Sleep()` having only a typical resolution of 16 ms, and the sleep in the test was very exact. I just gave it some margin to sleep long enough.