### PR TITLE
zbeacon: Fix IPv4 multicast (and small cache dir fix to zhash/zhashx selftests)

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -334,7 +334,7 @@ zdir_flatten (zdir_t *self)
     uint index = 0;
     if (self)
         index = s_dir_flatten (self, files, index);
-    
+
     //sort flattened list for proper patches computation
     zlist_t *sorted = zlist_new ();
     for (size_t i = 0; i < self->count; i++)
@@ -343,7 +343,7 @@ zdir_flatten (zdir_t *self)
     for (size_t i = 0; i < self->count; i++)
         files[i] = (zfile_t *) zlist_pop (sorted);
     zlist_destroy (&sorted);
-    
+
     return files;
 }
 

--- a/src/zhash.c
+++ b/src/zhash.c
@@ -884,15 +884,15 @@ zhash_test (bool verbose)
     //  Test save and load
     zhash_comment (hash, "This is a test file");
     zhash_comment (hash, "Created by %s", "czmq_selftest");
-    zhash_save (hash, ".cache");
+    zhash_save (hash, "src/selftest-rw/zhash-test");
     copy = zhash_new ();
     assert (copy);
-    zhash_load (copy, ".cache");
+    zhash_load (copy, "src/selftest-rw/zhash-test");
     item = (char *) zhash_lookup (copy, "LIVEBEEF");
     assert (item);
     assert (streq (item, "dead beef"));
     zhash_destroy (&copy);
-    zsys_file_delete (".cache");
+    zsys_file_delete ("src/selftest-rw/zhash-test");
 
     //  Delete a item
     zhash_delete (hash, "LIVEBEEF");

--- a/src/zhashx.c
+++ b/src/zhashx.c
@@ -1250,15 +1250,15 @@ zhashx_test (bool verbose)
     //  Test save and load
     zhashx_comment (hash, "This is a test file");
     zhashx_comment (hash, "Created by %s", "czmq_selftest");
-    zhashx_save (hash, ".cache");
+    zhashx_save (hash, "src/selftest-rw/zhashx-test");
     copy = zhashx_new ();
     assert (copy);
-    zhashx_load (copy, ".cache");
+    zhashx_load (copy, "src/selftest-rw/zhashx-test");
     item = (char *) zhashx_lookup (copy, "LIVEBEEF");
     assert (item);
     assert (streq (item, "dead beef"));
     zhashx_destroy (&copy);
-    zsys_file_delete (".cache");
+    zsys_file_delete ("src/selftest-rw/zhashx-test");
 
     //  Delete a item
     zhashx_delete (hash, "LIVEBEEF");

--- a/src/zsys.c
+++ b/src/zsys.c
@@ -1147,8 +1147,8 @@ zsys_vprintf (const char *format, va_list argptr)
 
 //  --------------------------------------------------------------------------
 //  Create a UDP beacon socket; if the routable option is true, uses
-//  multicast (not yet implemented), else uses broadcast. This method
-//  and related ones might _eventually_ be moved to a zudp class.
+//  multicast for IPv4 (IPv6 multicast not implemented yet), else uses broadcast.
+//  This method and related ones might _eventually_ be moved to a zudp class.
 
 SOCKET
 zsys_udp_new (bool routable)


### PR DESCRIPTION
I didn't manage to get zbeacon IPv4 multicast to work on Linux (debian), and took a look at it and now I don't know how (if at all) this could've worked to begin with? In original code, `setsockopt IP_MULTICAST_IF` passed interface as an index, but looking at Linux docs it should only accept `ip_mreq`, `ip_mreqn` or `in_addr` structs, and indeed in my testing the multicast always fails on this `setsockopt` call. To further complicate things, on OSX only `in_addr` struct is accepted, and on Windows it can only be a DWORD containing interface index or IP address.

To make this work on Linux, OSX and Windows, I changed it to use interface index only on Windows and use `in_addr` struct on other platforms. At least tested this on those three platforms and now IPv4 multicast beacon worked on all of them.

Then I noticed another problem that the original code always bound the listening socket to `INADDR_ANY` on *NIX platform, which causes that any beacons in _any_ multicast group will be heard by the socket, which in turn makes using multicast meaningless compared to broadcast (beacons in different multicast groups hear each other). This was fixed by binding the listening socket on *NIX to the multicast address instead when we are using multicast, after which the beacons in one multicast group were only heard by beacons that are members in that specific group. I assume this is the way this was intended to work, please correct me if I'm wrong?

On Windows, the original code already bound to the host address instead, and for some reason that already also works correctly with multicast and only the beacon in the specific multicast group is heard. Honestly, I don't know why that works, but I guess Windows handles the IPv4 membership for the socket differently?

zbeacon selftest also had a similarly broken check for determining if IPv4 multicast was available. I actually just removed the check and relied on the zbeacon `CONFIGURE` output instead to determine if multicast is there.

### zhash/zhashx cache dir fix

Another commit makes a small fix to zhash/zhashx selftests that used `.cache` as a temporary file for testing. The problem is that if you have clangd static analysis running, it creates `.cache` directory for the analysis which annoyingly breaks the tests. I replaced this according to the convention from other tests that RW data from tests should go to `selftest-rw` directory instead.