### PR TITLE
Add definition for GNU source on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ endif ()
 IF (ENABLE_DRAFTS)
     ADD_DEFINITIONS (-DCZMQ_BUILD_DRAFT_API)
 ENDIF (ENABLE_DRAFTS)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  add_definitions(-D_GNU_SOURCE)
+endif()
 
 ########################################################################
 # platform.h


### PR DESCRIPTION

Problem:
```
/czmq/src/zactor.c: In function ‘zactor_new’:
/czmq/src/zactor.c:129:5: error: implicit declaration of function ‘pthread_setname_np’; did you mean ‘pthread_setcanceltype’? [-Wimplicit-function-declaration]
```
see https://github.com/zeromq/czmq/issues/2330

Solution: define _GNU_SOURCE for linux 
